### PR TITLE
Makes the menu closign more intuitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Detect live streams and time shift availability when configuring dependent components (`PlaybackTimeLabel`, `PlaybackToggleButton`, `SeekBar`) to adjust their mode independently from the player state changes
 
 ### Fixed
+- Fix option panel closing when an option list is open
 - Fix crash of Gulp `serve` task on HTML file changes
 - Fix `SeekBar` in legacy skin did not hide on `hide()`
 - Fix missing audio track selection box in Safari with player 7.1.2 and 7.1.3

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -55,8 +55,12 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
         // Activate timeout when shown
         this.hideTimeout.start();
       });
-      this.getDomElement().on('mousemove', () => {
-        // Reset timeout on interaction
+      this.getDomElement().on('mouseenter', () => {
+        // On mouse enter clear the timeout
+        this.hideTimeout.clear();
+      });
+      this.getDomElement().on('mouseleave', () => {
+        // On mouse leave activate the timeout
         this.hideTimeout.reset();
       });
       this.onHide.subscribe(() => {


### PR DESCRIPTION
Uses mouseleave event to not close the panel when option list are open.
The main difference is that if an option list is open, it won't close even if the mouse leaves the menu area.
It will however still close the panel if after opening it the user doesn't move the mouse into the panel.