### PR TITLE
Set thumbnail size from CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add an option to keep the UI always visible by setting the `UIContainerConfig#hideTimeout` to -1
 
+### Changed
+- Thumbnail size is no longer determined by the physical image size and can now be arbitrarily set by CSS
+
 ## [2.5.1]
 
 No functional changes. Improves player API declarations, code linting configuration, and adds [contribution guidelines](CONTRIBUTING.md).

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -3,6 +3,7 @@ import {Label, LabelConfig} from './label';
 import {Component, ComponentConfig} from './component';
 import {UIInstanceManager, SeekPreviewArgs} from '../uimanager';
 import {StringUtils} from '../utils';
+import {ImageLoader} from '../imageloader';
 
 /**
  * Configuration interface for a {@link SeekBarLabel}.
@@ -20,6 +21,8 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
   private titleLabel: Label<LabelConfig>;
   private thumbnail: Component<ComponentConfig>;
 
+  private thumbnailImageLoader: ImageLoader;
+
   private timeFormat: string;
 
   constructor(config: SeekBarLabelConfig = {}) {
@@ -28,6 +31,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     this.timeLabel = new Label({ cssClasses: ['seekbar-label-time'] });
     this.titleLabel = new Label({ cssClasses: ['seekbar-label-title'] });
     this.thumbnail = new Component({ cssClasses: ['seekbar-thumbnail'] });
+    this.thumbnailImageLoader = new ImageLoader();
 
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-seekbar-label',
@@ -116,12 +120,33 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       });
     }
     else {
-      thumbnailElement.css({
-        'display': 'inherit',
-        'background-image': `url(${thumbnail.url})`,
-        'width': thumbnail.w + 'px',
-        'height': thumbnail.h + 'px',
-        'background-position': `-${thumbnail.x}px -${thumbnail.y}px`,
+      // We use the thumbnail image loader to make sure the thumbnail is loaded and it's size is known before be can
+      // calculate the CSS properties and set them on the element.
+      this.thumbnailImageLoader.load(thumbnail.url, (url, width, height) => {
+        let thumbnailCountX = width / thumbnail.w;
+        let thumbnailCountY = height / thumbnail.h;
+
+        let thumbnailIndexX = thumbnail.x / thumbnail.w;
+        let thumbnailIndexY = thumbnail.y / thumbnail.h;
+
+        let sizeX = 100 * thumbnailCountX;
+        let sizeY = 100 * thumbnailCountY;
+
+        let offsetX = 100 * thumbnailIndexX;
+        let offsetY = 100 * thumbnailIndexY;
+
+        let aspectRatio = 1 / thumbnail.w * thumbnail.h;
+
+        // The thumbnail size is set by setting the CSS 'width' and 'padding-bottom' properties. 'padding-bottom' is
+        // used because it is relative to the width and can be used to set the aspect ratio of the thumbnail.
+        // A default value for width is set in the stylesheet and can be overwritten from there or anywhere else.
+        thumbnailElement.css({
+          'display': 'inherit',
+          'background-image': `url(${thumbnail.url})`,
+          'padding-bottom': `${100 * aspectRatio}%`,
+          'background-size': `${sizeX}% ${sizeY}%`,
+          'background-position': `-${offsetX}% -${offsetY}%`,
+        });
       });
     }
   }

--- a/src/ts/components/tvnoisecanvas.ts
+++ b/src/ts/components/tvnoisecanvas.ts
@@ -32,7 +32,7 @@ export class TvNoiseCanvas extends Component<ComponentConfig> {
   }
 
   start(): void {
-    this.canvasElement = <HTMLCanvasElement>this.canvas.getElements()[0];
+    this.canvasElement = <HTMLCanvasElement>this.canvas.get(0);
     this.canvasContext = this.canvasElement.getContext('2d');
     this.noiseAnimationWindowPos = -this.canvasHeight;
     this.lastFrameUpdate = 0;

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -97,9 +97,33 @@ export class DOM {
   /**
    * Gets the HTML elements that this DOM instance currently holds.
    * @returns {HTMLElement[]} the raw HTML elements
+   * @deprecated use {@link #get()} instead
    */
   getElements(): HTMLElement[] {
-    return this.elements;
+    return this.get();
+  }
+
+  /**
+   * Gets the HTML elements that this DOM instance currently holds.
+   * @returns {HTMLElement[]} the raw HTML elements
+   */
+  get(): HTMLElement[];
+  /**
+   * Gets an HTML element from the list elements that this DOM instance currently holds.
+   * @param index The zero-based index into the element list. Can be negative to return an element from the end,
+   *    e.g. -1 returns the last element.
+   */
+  get(index: number): HTMLElement;
+  get(index?: number): HTMLElement | HTMLElement[] {
+    if (index === undefined) {
+      return this.elements;
+    } else if (!this.elements || index >= this.elements.length || index < -this.elements.length) {
+      return undefined;
+    } else if (index < 0) {
+      return this.elements[this.elements.length - index];
+    } else {
+      return this.elements[index];
+    }
   }
 
   /**

--- a/src/ts/imageloader.ts
+++ b/src/ts/imageloader.ts
@@ -1,0 +1,80 @@
+import {DOM} from './dom';
+
+export interface ImageLoadedCallback {
+  (url: string, width: number, height: number): void;
+}
+
+interface ImageLoaderState {
+  url: string,
+  image: DOM;
+  loadedCallback: ImageLoadedCallback;
+  loaded: boolean;
+  width: number;
+  height: number;
+}
+
+/**
+ * Tracks the loading state of images.
+ */
+export class ImageLoader {
+
+  private state: { [url: string]: ImageLoaderState; } = {};
+
+  /**
+   * Loads an image and call the callback once the image is loaded. If the image is already loaded, the callback
+   * is called immediately, else it is called once loading has finished. Calling this method multiple times for the
+   * same image while it is loading calls only let callback passed into the last call.
+   * @param url The url to the image to load
+   * @param loadedCallback The callback that is called when the image is loaded
+   */
+  load(url: string, loadedCallback: ImageLoadedCallback): void {
+    if (!this.state[url]) {
+      // When the image was never attempted to be loaded before, we create a state and store it in the state map
+      // for later use when the same image is requested to be loaded again.
+      let state: ImageLoaderState = {
+        url: url,
+        image: new DOM('img', {}),
+        loadedCallback: loadedCallback,
+        loaded: false,
+        width: 0,
+        height: 0,
+      };
+      this.state[url] = state;
+
+      // We need to add the image element to the DOM to get the size of the loaded image
+      new DOM('body').append(state.image);
+
+      // Listen to the load event, update the state and call the callback once the image is loaded
+      state.image.on('load', (e) => {
+        state.loaded = true;
+        state.width = state.image.width();
+        state.height = state.image.height();
+
+        // We can safely remove the image from the DOM once the image is loaded and the size extracted
+        state.image.remove();
+
+        this.callLoadedCallback(state);
+      });
+
+      // Set the image URL to start the loading
+      state.image.attr('src', state.url);
+    } else {
+      // We have a state for the requested image, so it is either already loaded or currently loading
+      let state = this.state[url];
+
+      // We overwrite the callback to make sure that only the callback of the latest call gets executed.
+      // Earlier callbacks become invalid once a new load call arrives, and they are not called as long as the image
+      // is not loaded.
+      state.loadedCallback = loadedCallback;
+
+      // When the image is already loaded, we directly execute the callback instead of waiting for the load event
+      if(state.loaded) {
+        this.callLoadedCallback(state);
+      }
+    }
+  }
+
+  private callLoadedCallback(state: ImageLoaderState): void {
+    state.loadedCallback(state.url, state.width, state.height);
+  }
+}

--- a/src/ts/imageloader.ts
+++ b/src/ts/imageloader.ts
@@ -5,7 +5,7 @@ export interface ImageLoadedCallback {
 }
 
 interface ImageLoaderState {
-  url: string,
+  url: string;
   image: DOM;
   loadedCallback: ImageLoadedCallback;
   loaded: boolean;
@@ -68,7 +68,7 @@ export class ImageLoader {
       state.loadedCallback = loadedCallback;
 
       // When the image is already loaded, we directly execute the callback instead of waiting for the load event
-      if(state.loaded) {
+      if (state.loaded) {
         this.callLoadedCallback(state);
       }
     }

--- a/src/ts/imageloader.ts
+++ b/src/ts/imageloader.ts
@@ -41,17 +41,11 @@ export class ImageLoader {
       };
       this.state[url] = state;
 
-      // We need to add the image element to the DOM to get the size of the loaded image
-      new DOM('body').append(state.image);
-
       // Listen to the load event, update the state and call the callback once the image is loaded
       state.image.on('load', (e) => {
         state.loaded = true;
-        state.width = state.image.width();
-        state.height = state.image.height();
-
-        // We can safely remove the image from the DOM once the image is loaded and the size extracted
-        state.image.remove();
+        state.width = (<HTMLImageElement>state.image.get(0)).width;
+        state.height = (<HTMLImageElement>state.image.get(0)).height;
 
         this.callLoadedCallback(state);
       });


### PR DESCRIPTION
The thumbnail size was set programmatically in pixels and was directly taken from the sprites file, so it could only be changed by adjusting the sprites file. 

Now the thumbnail size can be a relative or absolute size. It's not programmatically set any more so it can be set in CSS too.