### PR TITLE
Adds the option to alway show the controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Add an option to keep the UI always visible by setting the UIContainerConfig#hideTimeout to -1
+- Add an option to keep the UI always visible by setting the `UIContainerConfig#hideTimeout` to -1
 
 ## [2.5.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Add an option to keep the UI always on by setting the hideTimeout to -1
+
 ## [2.5.1]
 
 No functional changes. Improves player API declarations, code linting configuration, and adds [contribution guidelines](CONTRIBUTING.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Add an option to keep the UI always on by setting the hideTimeout to -1
+- Add an option to keep the UI always visible by setting the UIContainerConfig#hideTimeout to -1
 
 ## [2.5.1]
 

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -12,6 +12,7 @@ import {CancelEventArgs} from '../eventdispatcher';
 export interface UIContainerConfig extends ContainerConfig {
   /**
    * The delay in milliseconds after which the control bar will be hidden when there is no user interaction.
+   * Set to -1 for the UI to be always shown.
    * Default: 5 seconds (5000)
    */
   hideDelay?: number;
@@ -52,6 +53,11 @@ export class UIContainer extends Container<UIContainerConfig> {
   private configureUIShowHide(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {
     let container = this.getDomElement();
     let config = <UIContainerConfig>this.getConfig();
+
+    if (config.hideDelay === -1) {
+      uimanager.onConfigured.subscribe(() => uimanager.onControlsShow.dispatch(this));
+      return;
+    }
 
     let isUiShown = false;
     let isSeeking = false;


### PR DESCRIPTION
So it pretty much bypass all the logic in `configureUIShowHide` and just fires a `onControlsShow` event as soon as the ui is configured (otherwise component are not subscribed).