### PR TITLE
Custom UI container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add support for FCC compliant closed captions. Adds options on how captions are displayed, and a SubtitleSettingsPanel with the possibility to update the settings while playing the video.
+- Add `UIConfig#container` config property to specify a custom place in the DOM where the UI will be put into. Can be used to place it somewhere else beside the default player figure.
 
 ## [2.6.0]
 

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -74,6 +74,11 @@ export interface TimelineMarker {
 }
 
 export interface UIConfig {
+  /**
+   * Specifies the container in the DOM into which the UI will be added. Can be a CSS selector string or a
+   * HTMLElement object. By default, the player figure will be used ({@link PlayerAPI#getFigure}).
+   */
+  container?: string | HTMLElement;
   metadata?: {
     title?: string;
     description?: string;
@@ -143,7 +148,7 @@ export interface UIVariant {
 export class UIManager {
 
   private player: PlayerAPI;
-  private playerElement: DOM;
+  private uiContainerElement: DOM;
   private uiVariants: UIVariant[];
   private uiInstanceManagers: InternalUIInstanceManager[];
   private currentUi: InternalUIInstanceManager;
@@ -202,7 +207,16 @@ export class UIManager {
     this.player = player;
     this.config = config;
     this.managerPlayerWrapper = new PlayerWrapper(player);
-    this.playerElement = new DOM(player.getFigure());
+
+    if (config.container) {
+      // Unfortunately "uiContainerElement = new DOM(config.container)" will not accept the container with
+      // string|HTMLElement type directly, although it accepts both types, so we need to spit these two cases up here.
+      // TODO check in upcoming TS versions if the container can be passed in directly, or fix the constructor
+      this.uiContainerElement = config.container instanceof HTMLElement ?
+        new DOM(config.container) : new DOM(config.container);
+    } else {
+      this.uiContainerElement = new DOM(player.getFigure());
+    }
 
     // Create UI instance managers for the UI variants
     // The instance managers map to the corresponding UI variants by their array index
@@ -274,7 +288,7 @@ export class UIManager {
         isFullscreen: this.player.isFullscreen(),
         isMobile: isMobile,
         isPlaying: this.player.isPlaying(),
-        width: this.playerElement.width(),
+        width: this.uiContainerElement.width(),
         documentWidth: document.body.clientWidth,
       };
 
@@ -359,7 +373,7 @@ export class UIManager {
     /* Append the UI DOM after configuration to avoid CSS transitions at initialization
      * Example: Components are hidden during configuration and these hides may trigger CSS transitions that are
      * undesirable at this time. */
-    this.playerElement.append(dom);
+    this.uiContainerElement.append(dom);
 
     // Fire onConfigured after UI DOM elements are successfully added. When fired immediately, the DOM elements
     // might not be fully configured and e.g. do not have a size.


### PR DESCRIPTION
Add `UIConfig#container` config property to specify a custom place in the DOM where the UI will be put into. Can be used to place it somewhere else beside the default player figure.