### PR TITLE
Using the new issuer parameter in Events

### DIFF
--- a/src/ts/components/adclickoverlay.ts
+++ b/src/ts/components/adclickoverlay.ts
@@ -35,7 +35,7 @@ export class AdClickOverlay extends ClickOverlay {
 
     this.onClick.subscribe(() => {
       // Pause the ad when overlay is clicked
-      player.pause('ui-content-click');
+      player.pause('ui');
 
       // Notify the player of the clicked ad
       player.fireEvent(player.EVENT.ON_AD_CLICKED, {

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -24,9 +24,9 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
 
     let togglePlayback = () => {
       if (player.isPlaying()) {
-        player.pause('ui-overlay');
+        player.pause('ui');
       } else {
-        player.play('ui-overlay');
+        player.play('ui');
       }
     };
 

--- a/src/ts/components/hugereplaybutton.ts
+++ b/src/ts/components/hugereplaybutton.ts
@@ -21,7 +21,7 @@ export class HugeReplayButton extends Button<ButtonConfig> {
     super.configure(player, uimanager);
 
     this.onClick.subscribe(() => {
-      player.play('ui-overlay');
+      player.play('ui');
     });
   }
 

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -42,7 +42,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     let minWidth = 0;
 
     let liveClickHandler = () => {
-      player.timeShift(0);
+      player.timeShift(0, 'ui');
     };
 
     let updateLiveState = () => {

--- a/src/ts/components/playbacktogglebutton.ts
+++ b/src/ts/components/playbacktogglebutton.ts
@@ -69,9 +69,9 @@ export class PlaybackToggleButton extends ToggleButton<ToggleButtonConfig> {
       // above that updated the button state.
       this.onClick.subscribe(() => {
         if (player.isPlaying()) {
-          player.pause('ui-button');
+          player.pause('ui');
         } else {
-          player.play('ui-button');
+          player.play('ui');
         }
       });
     }

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -219,7 +219,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     let seek = (percentage: number) => {
       if (player.isLive()) {
-        player.timeShift(player.getMaxTimeShift() - (player.getMaxTimeShift() * (percentage / 100)));
+        player.timeShift(player.getMaxTimeShift() - (player.getMaxTimeShift() * (percentage / 100)), 'ui-seekbar');
       } else {
         player.seek(player.getDuration() * (percentage / 100), 'ui-seekbar');
       }

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -219,9 +219,9 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     let seek = (percentage: number) => {
       if (player.isLive()) {
-        player.timeShift(player.getMaxTimeShift() - (player.getMaxTimeShift() * (percentage / 100)), 'ui-seekbar');
+        player.timeShift(player.getMaxTimeShift() - (player.getMaxTimeShift() * (percentage / 100)), 'ui');
       } else {
-        player.seek(player.getDuration() * (percentage / 100), 'ui-seekbar');
+        player.seek(player.getDuration() * (percentage / 100), 'ui');
       }
     };
     this.onSeek.subscribe((sender) => {
@@ -235,7 +235,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
       // Pause playback while seeking
       if (isPlaying) {
-        player.pause('ui-seek');
+        player.pause('ui');
       }
     });
     this.onSeekPreview.subscribe((sender: SeekBar, args: SeekPreviewEventArgs) => {
@@ -256,7 +256,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
       // Continue playback after seek if player was playing when seek started
       if (isPlaying) {
-        player.play('ui-seek');
+        player.play('ui');
       }
 
       // Notify UI manager of finished seek

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -221,7 +221,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       if (player.isLive()) {
         player.timeShift(player.getMaxTimeShift() - (player.getMaxTimeShift() * (percentage / 100)));
       } else {
-        player.seek(player.getDuration() * (percentage / 100));
+        player.seek(player.getDuration() * (percentage / 100), 'ui-seekbar');
       }
     };
     this.onSeek.subscribe((sender) => {

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -18,7 +18,7 @@ export interface VolumeSliderConfig extends SeekBarConfig {
  */
 export class VolumeSlider extends SeekBar {
 
-  private readonly issuerName = 'ui-volumeslider';
+  private static readonly issuerName = 'ui';
 
   constructor(config: SeekBarConfig = {}) {
     super(config);
@@ -60,11 +60,11 @@ export class VolumeSlider extends SeekBar {
 
     this.onSeekPreview.subscribe((sender, args) => {
       if (args.scrubbing) {
-        player.setVolume(args.position, this.issuerName);
+        player.setVolume(args.position, VolumeSlider.issuerName);
       }
     });
     this.onSeeked.subscribe((sender, percentage) => {
-      player.setVolume(percentage, this.issuerName);
+      player.setVolume(percentage, VolumeSlider.issuerName);
     });
 
     // Update the volume slider marker when the player resized, a source is loaded and player is ready,
@@ -100,21 +100,21 @@ export class VolumeSlider extends SeekBar {
     // Only if the volume is 100, there's the possibility we are on a volume-control-restricted iOS device
     if (volume === 100) {
       // We set the volume to zero (that's the only value that does not unmute a muted player!)
-      player.setVolume(0, this.issuerName);
+      player.setVolume(0, VolumeSlider.issuerName);
       // Then we check if the value is still 100
       if (player.getVolume() === 100) {
         // If the volume stayed at 100, we're on a volume-control-restricted device
         return false;
       } else {
         // We can control volume, so we must restore the previous player state
-        player.setVolume(volume, this.issuerName);
+        player.setVolume(volume, VolumeSlider.issuerName);
         if (muted) {
-          player.mute(this.issuerName);
+          player.mute(VolumeSlider.issuerName);
         }
         if (playing) {
           // The volume restore above pauses autoplay on mobile devices (e.g. Android) so we need to resume playback
           // (We cannot check isPaused() here because it is not set when playback is prohibited by the mobile platform)
-          player.play(this.issuerName);
+          player.play(VolumeSlider.issuerName);
         }
         return true;
       }

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -18,6 +18,8 @@ export interface VolumeSliderConfig extends SeekBarConfig {
  */
 export class VolumeSlider extends SeekBar {
 
+  private readonly issuerName = 'ui-volumeslider';
+
   constructor(config: SeekBarConfig = {}) {
     super(config);
 
@@ -58,11 +60,11 @@ export class VolumeSlider extends SeekBar {
 
     this.onSeekPreview.subscribe((sender, args) => {
       if (args.scrubbing) {
-        player.setVolume(args.position);
+        player.setVolume(args.position, this.issuerName);
       }
     });
     this.onSeeked.subscribe((sender, percentage) => {
-      player.setVolume(percentage);
+      player.setVolume(percentage, this.issuerName);
     });
 
     // Update the volume slider marker when the player resized, a source is loaded and player is ready,
@@ -98,21 +100,21 @@ export class VolumeSlider extends SeekBar {
     // Only if the volume is 100, there's the possibility we are on a volume-control-restricted iOS device
     if (volume === 100) {
       // We set the volume to zero (that's the only value that does not unmute a muted player!)
-      player.setVolume(0);
+      player.setVolume(0, this.issuerName);
       // Then we check if the value is still 100
       if (player.getVolume() === 100) {
         // If the volume stayed at 100, we're on a volume-control-restricted device
         return false;
       } else {
         // We can control volume, so we must restore the previous player state
-        player.setVolume(volume);
+        player.setVolume(volume, this.issuerName);
         if (muted) {
-          player.mute();
+          player.mute(this.issuerName);
         }
         if (playing) {
           // The volume restore above pauses autoplay on mobile devices (e.g. Android) so we need to resume playback
           // (We cannot check isPaused() here because it is not set when playback is prohibited by the mobile platform)
-          player.play();
+          player.play(this.issuerName);
         }
         return true;
       }

--- a/src/ts/components/volumetogglebutton.ts
+++ b/src/ts/components/volumetogglebutton.ts
@@ -41,9 +41,9 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
 
     this.onClick.subscribe(() => {
       if (player.isMuted()) {
-        player.unmute();
+        player.unmute('ui-volumetogglebutton');
       } else {
-        player.mute();
+        player.mute('ui-volumetogglebutton');
       }
     });
 

--- a/src/ts/components/volumetogglebutton.ts
+++ b/src/ts/components/volumetogglebutton.ts
@@ -41,9 +41,9 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
 
     this.onClick.subscribe(() => {
       if (player.isMuted()) {
-        player.unmute('ui-volumetogglebutton');
+        player.unmute('ui');
       } else {
-        player.mute('ui-volumetogglebutton');
+        player.mute('ui');
       }
     });
 

--- a/src/ts/player-events.d.ts
+++ b/src/ts/player-events.d.ts
@@ -103,7 +103,15 @@ declare namespace bitmovin {
       time: number;
     }
 
-    interface SeekEvent extends PlayerEvent {
+    interface UserInteractionEvent extends PlayerEvent {
+
+      /**
+       * The issuer who lead to the triggering of this event
+       */
+      issuer?: string;
+    }
+
+    interface SeekEvent extends UserInteractionEvent {
       /**
        * The current position (in seconds)
        */
@@ -114,7 +122,7 @@ declare namespace bitmovin {
       seekTarget: number;
     }
 
-    interface VolumeChangedEvent extends PlayerEvent {
+    interface VolumeChangedEvent extends UserInteractionEvent {
       /**
        * The volume before the event has been triggered
        */

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -301,8 +301,10 @@ declare namespace bitmovin {
     load(source: PlayerAPI.SourceConfig, forceTechnology?: string, disableSeeking?: boolean): Promise<PlayerAPI>;
     /**
      * Mutes the player if an audio track is available. Has no effect if the player is already muted.
+     *
+     * @param issuer the source of the mute command
      */
-    mute(): PlayerAPI;
+    mute(issuer?: string): PlayerAPI;
     /**
      * Pauses the video if it is playing. Has no effect if the player is already paused.
      */
@@ -435,8 +437,9 @@ declare namespace bitmovin {
      * Sets the player’s volume in the range of 0 (silent) to 100 (max volume). Unmutes a muted player.
      *
      * @param volume The volume to set between 0 and 100
+     * @param issuer the source of the setVolume command
      */
-    setVolume(volume: number): PlayerAPI;
+    setVolume(volume: number, issuer?: string): PlayerAPI;
     /**
      * Enables or disables stereo mode for VR content.
      *
@@ -455,16 +458,19 @@ declare namespace bitmovin {
      * value has to be within the timeShift window as specified by {@link #getMaxTimeShift}.
      *
      * @param offset The offset to timeshift to
+     * @param issuer The issuer of the timeShift command
      */
-    timeShift(offset: number): PlayerAPI;
+    timeShift(offset: number, issuer?: string): PlayerAPI;
     /**
      * Unloads the current video source.
      */
     unload(): PlayerAPI;
     /**
      * Unmutes the player if muted.
+     *
+     * @param issuer the issuer of the unmute command
      */
-    unmute(): PlayerAPI;
+    unmute(issuer?: string): PlayerAPI;
 
     fireEvent(event: PlayerAPI.EVENT, data: {}): void;
     /**

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -345,8 +345,9 @@ declare namespace bitmovin {
      * not possible.
      *
      * @param time The time to seek to
+     * @param issuer the source of the seek command
      */
-    seek(time: number): boolean;
+    seek(time: number, issuer?: string): boolean;
     /**
      * Sets the audio track to the ID specified by trackID.
      * Available tracks can be retrieved with {@link #getAvailableAudio}.


### PR DESCRIPTION
There is an open Pull Request at the player which enables issuer parameters for a multitude of evens:
- mute
- unmute
- volumeChange
- seek
- timeshift

This PR makes use of these new parameters.