### PR TITLE
Fix Container#removeComponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Develop]
+
+### Fixed
+- Fix clearing of container components with `Container#removeComponents` (fixes sticky/duplicate subtitle issue)
+
 ## [2.7.1]
 
 ### Changed
@@ -187,6 +192,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 - 2017-02-03
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.7.1...develop
 [2.7.1]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.5.1...v2.6.0

--- a/src/ts/components/container.ts
+++ b/src/ts/components/container.ts
@@ -76,7 +76,7 @@ export class Container<Config extends ContainerConfig> extends Component<Contain
    * Removes all child components from the container.
    */
   removeComponents(): void {
-    for (let component of this.getComponents()) {
+    for (let component of this.getComponents().slice()) {
       this.removeComponent(component);
     }
   }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -373,7 +373,7 @@ class ActiveSubtitleManager {
    * Calculates a unique ID for a subtitle cue, which is needed to associate an ON_CUE_ENTER with its ON_CUE_EXIT
    * event so we can remove the correct subtitle in ON_CUE_EXIT when multiple subtitles are active at the same time.
    * The start time plus the text should make a unique identifier, and in the only case where a collision
-   * can happen, two similar texts will displayed at a similar time so it does not matter which one we delete.
+   * can happen, two similar texts will be displayed at a similar time so it does not matter which one we delete.
    * The start time should always be known, because it is required to schedule the ON_CUE_ENTER event. The end time
    * must not necessarily be known and therefore cannot be used for the ID.
    * @param event


### PR DESCRIPTION
`Container#removeComponents` did not reliably remove all components if the container contained multiple components. The list of components was iterated and modified at the same time, leading to skipped components that were not removed. 

This issue became noticeable on the subtitle overlay when multiple subtitle cues were displayed at the same time but not all got cleared on a seek.

The fix is to iterate a copy of the components list while modifying the original list.