### PR TITLE
Fix Container#updateComponents by only processing changes (fixes subtitles in IE11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix clearing of container components with `Container#removeComponents` (fixes sticky/duplicate subtitle issue)
+- Fix updating container components with `Container#updateComponents` (fixes empty subtitles in IE11)
 
 ## [2.7.1]
 


### PR DESCRIPTION
Only add new components and remove removed components, leaving remaining components alone. This avoids that their innerHTML is lost to garbage collection in IE11, which let to empty subtitle labels.