### PR TITLE
Feature/remove subtitles on unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix updating container components with `Container#updateComponents` (fixes empty subtitles in IE11)
 - Fix handling of duplicate subtitle cues (same text at same time) in `SubtitleOverlay` (fixes another sticky subtitle issue)
 - Fix clearing of recommendations in `RecommendationOverlay` (fixes duplicate recommendations issue)
+- Reset selected value in `ListSelector` when the items are cleared
+- Updating selected value in `PlaybackSpeedSelectBox` when player is ready
 
 ## [2.7.1]
 

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -119,8 +119,13 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    * Removes all items from this selector.
    */
   clearItems() {
-    let items = this.items; // local copy for iteration after clear
-    this.items = []; // clear items
+    // local copy for iteration after clear
+    let items = this.items;
+    // clear items
+    this.items = [];
+
+    // clear the selection as the selected item is also removed
+    this.selectedItem = null;
 
     // fire events
     for (let item of items) {

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -26,5 +26,15 @@ export class PlaybackSpeedSelectBox extends SelectBox {
     this.onItemSelected.subscribe((sender: PlaybackSpeedSelectBox, value: string) => {
       player.setPlaybackSpeed(parseFloat(value));
     });
+
+    // when the player hits onReady again, adjust the playback speed selection with fallback to default 1
+    player.addEventHandler(player.EVENT.ON_READY, (): void => {
+      let playbackSpeed = String(player.getPlaybackSpeed());
+      if (!this.selectItem(playbackSpeed)) {
+        playbackSpeed = '1';
+        this.selectItem(playbackSpeed);
+      }
+      this.updateDomItems(playbackSpeed);
+    });
   }
 }

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -20,21 +20,23 @@ export class PlaybackSpeedSelectBox extends SelectBox {
     this.addItem('1.5', '1.5x');
     this.addItem('2', '2x');
 
-    this.selectItem('1');
-
 
     this.onItemSelected.subscribe((sender: PlaybackSpeedSelectBox, value: string) => {
       player.setPlaybackSpeed(parseFloat(value));
-      this.selectedItem = value;
+      this.selectItem(value);
     });
 
-    // when the player hits onReady again, adjust the playback speed selection with fallback to default 1
-    player.addEventHandler(player.EVENT.ON_READY, (): void => {
+    let setDefaultValue = (): void => {
       let playbackSpeed = String(player.getPlaybackSpeed());
       if (!this.selectItem(playbackSpeed)) {
         playbackSpeed = '1';
         this.selectItem(playbackSpeed);
       }
-    });
+    };
+
+    setDefaultValue();
+
+    // when the player hits onReady again, adjust the playback speed selection with fallback to default 1
+    player.addEventHandler(player.EVENT.ON_READY, setDefaultValue);
   }
 }

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -25,6 +25,7 @@ export class PlaybackSpeedSelectBox extends SelectBox {
 
     this.onItemSelected.subscribe((sender: PlaybackSpeedSelectBox, value: string) => {
       player.setPlaybackSpeed(parseFloat(value));
+      this.selectedItem = value;
     });
 
     // when the player hits onReady again, adjust the playback speed selection with fallback to default 1
@@ -34,7 +35,6 @@ export class PlaybackSpeedSelectBox extends SelectBox {
         playbackSpeed = '1';
         this.selectItem(playbackSpeed);
       }
-      this.updateDomItems(playbackSpeed);
     });
   }
 }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -124,6 +124,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
     player.addEventHandler(player.EVENT.ON_SEEK, subtitleClearHandler);
     player.addEventHandler(player.EVENT.ON_TIME_SHIFT, subtitleClearHandler);
     player.addEventHandler(player.EVENT.ON_PLAYBACK_FINISHED, subtitleClearHandler);
+    player.addEventHandler(player.EVENT.ON_SOURCE_UNLOADED, subtitleClearHandler);
 
     uimanager.onComponentShow.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {


### PR DESCRIPTION
Fixed an issue where the select controls would not correctly reset when the player was reloaded without being destroyed.