### PR TITLE
Fix init components on ready v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix `animate-slide-in-from-bottom` SCSS mixin (fixes missing `VolumeSlider` slide-in animation of `VolumeControlButton` in the legacy skin)
+- Fire `ON_READY` event if UI is loaded after player is ready to initialize all components correctly
 
 ## [2.8.1]
 

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -368,7 +368,7 @@ export class UIManager {
 
     // Some components initialize their state on ON_READY. When the UI is loaded after the player is already ready,
     // they will never receive the event so we fire it from here in such cases.
-    if (!player.isReady()) {
+    if (player.isReady()) {
       player.fireEventInUI(player.EVENT.ON_READY, {});
     }
 

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -358,11 +358,19 @@ export class UIManager {
 
   private addUi(ui: InternalUIInstanceManager): void {
     let dom = ui.getUI().getDomElement();
+    let player = ui.getWrappedPlayer();
+
     ui.configureControls();
     /* Append the UI DOM after configuration to avoid CSS transitions at initialization
      * Example: Components are hidden during configuration and these hides may trigger CSS transitions that are
      * undesirable at this time. */
     this.uiContainerElement.append(dom);
+
+    // Some components initialize their state on ON_READY. When the UI is loaded after the player is already ready,
+    // they will never receive the event so we fire it from here in such cases.
+    if (!player.isReady()) {
+      player.fireEventInUI(player.EVENT.ON_READY, {});
+    }
 
     // Fire onConfigured after UI DOM elements are successfully added. When fired immediately, the DOM elements
     // might not be fully configured and e.g. do not have a size.


### PR DESCRIPTION
Fires a `ON_READY` event into the UI when the UI is loaded after the player is ready and will thus not receive an `ON_READY` from the player. This is done because some components wait for `ON_READY` to initialize their state.