### PR TITLE
Implement new quality selection API for player 7.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Changed
+
+- Use new quality change API in `AudioQualitySelectBox` and `VideoQualitySelectBox` for player >= 7.3.1 (selection is now synced with player-API `set[Audio|Video]Quality` calls)
+
 ### Fixed
 - Fix `animate-slide-in-from-bottom` SCSS mixin (fixes missing `VolumeSlider` slide-in animation of `VolumeControlButton` in the legacy skin)
 - Fire `ON_READY` event if UI is loaded after player is ready to initialize all components correctly

--- a/src/ts/components/audioqualityselectbox.ts
+++ b/src/ts/components/audioqualityselectbox.ts
@@ -17,7 +17,7 @@ export class AudioQualitySelectBox extends SelectBox {
     let selectCurrentAudioQuality = () => {
       if (player.getAudioQuality) {
         // Since player 7.3.1
-        this.selectItem(player.getAudioQuality().id)
+        this.selectItem(player.getAudioQuality().id);
       } else {
         // Backwards compatibility for players <= 7.3.0
         // TODO remove in next major release

--- a/src/ts/components/audioqualityselectbox.ts
+++ b/src/ts/components/audioqualityselectbox.ts
@@ -15,8 +15,15 @@ export class AudioQualitySelectBox extends SelectBox {
     super.configure(player, uimanager);
 
     let selectCurrentAudioQuality = () => {
-      let data = player.getDownloadedAudioData();
-      this.selectItem(data.isAuto ? 'auto' : data.id);
+      if (player.getAudioQuality) {
+        // Since player 7.3.1
+        this.selectItem(player.getAudioQuality().id)
+      } else {
+        // Backwards compatibility for players <= 7.3.0
+        // TODO remove in next major release
+        let data = player.getDownloadedAudioData();
+        this.selectItem(data.isAuto ? 'auto' : data.id);
+      }
     };
 
     let updateAudioQualities = () => {
@@ -47,6 +54,13 @@ export class AudioQualitySelectBox extends SelectBox {
     // Update qualities when a new source is loaded
     player.addEventHandler(player.EVENT.ON_READY, updateAudioQualities);
     // Update quality selection when quality is changed (from outside)
-    player.addEventHandler(player.EVENT.ON_AUDIO_DOWNLOAD_QUALITY_CHANGE, selectCurrentAudioQuality);
+    if (player.EVENT.ON_AUDIO_QUALITY_CHANGED) {
+      // Since player 7.3.1
+      player.addEventHandler(player.EVENT.ON_AUDIO_QUALITY_CHANGED, selectCurrentAudioQuality);
+    } else {
+      // Backwards compatibility for players <= 7.3.0
+      // TODO remove in next major release
+      player.addEventHandler(player.EVENT.ON_AUDIO_DOWNLOAD_QUALITY_CHANGE, selectCurrentAudioQuality);
+    }
   }
 }

--- a/src/ts/components/videoqualityselectbox.ts
+++ b/src/ts/components/videoqualityselectbox.ts
@@ -1,7 +1,6 @@
 import {SelectBox} from './selectbox';
 import {ListSelectorConfig} from './listselector';
 import {UIInstanceManager} from '../uimanager';
-import VideoDownloadQualityChangeEvent = bitmovin.PlayerAPI.VideoDownloadQualityChangeEvent;
 
 /**
  * A select box providing a selection between 'auto' and the available video qualities.
@@ -20,7 +19,7 @@ export class VideoQualitySelectBox extends SelectBox {
     let selectCurrentVideoQuality = () => {
       if (player.getVideoQuality) {
         // Since player 7.3.1
-        this.selectItem(player.getVideoQuality().id)
+        this.selectItem(player.getVideoQuality().id);
       } else {
         // Backwards compatibility for players <= 7.3.0
         // TODO remove in next major release

--- a/src/ts/player-events.d.ts
+++ b/src/ts/player-events.d.ts
@@ -24,6 +24,7 @@ declare namespace bitmovin {
       ON_AUDIO_CHANGED: EVENT;
       ON_AUDIO_ADDED: EVENT;
       ON_AUDIO_REMOVED: EVENT;
+      ON_AUDIO_QUALITY_CHANGED: EVENT;
       ON_AUDIO_DOWNLOAD_QUALITY_CHANGE: EVENT;
       ON_AUDIO_DOWNLOAD_QUALITY_CHANGED: EVENT;
       ON_AUDIO_PLAYBACK_QUALITY_CHANGED: EVENT;
@@ -71,6 +72,7 @@ declare namespace bitmovin {
       ON_TIME_SHIFTED: EVENT;
       ON_UNMUTED: EVENT;
       ON_VIDEO_ADAPTATION: EVENT;
+      ON_VIDEO_QUALITY_CHANGED: EVENT;
       ON_VIDEO_DOWNLOAD_QUALITY_CHANGE: EVENT;
       ON_VIDEO_DOWNLOAD_QUALITY_CHANGED: EVENT;
       ON_VIDEO_PLAYBACK_QUALITY_CHANGED: EVENT;
@@ -177,7 +179,7 @@ declare namespace bitmovin {
       targetSubtitle: Subtitle;
     }
 
-    interface MediaDownloadQualityChangeEvent<Q extends Quality> extends PlayerEvent {
+    interface MediaQualityChangeEvent<Q extends Quality> extends PlayerEvent {
       /**
        * Previous quality or null if no quality was set before.
        */
@@ -196,16 +198,22 @@ declare namespace bitmovin {
       targetQualityId: string;
     }
 
-    interface VideoDownloadQualityChangeEvent extends MediaDownloadQualityChangeEvent<VideoQuality> {
+    interface VideoQualityChangeEvent extends MediaQualityChangeEvent<VideoQuality> {
     }
 
-    interface AudioDownloadQualityChangeEvent extends MediaDownloadQualityChangeEvent<AudioQuality> {
+    interface AudioQualityChangeEvent extends MediaQualityChangeEvent<AudioQuality> {
     }
 
-    interface VideoDownloadQualityChangedEvent extends MediaDownloadQualityChangeEvent<VideoQuality> {
+    interface VideoDownloadQualityChangeEvent extends MediaQualityChangeEvent<VideoQuality> {
     }
 
-    interface AudioDownloadQualityChangedEvent extends MediaDownloadQualityChangeEvent<AudioQuality> {
+    interface AudioDownloadQualityChangeEvent extends MediaQualityChangeEvent<AudioQuality> {
+    }
+
+    interface VideoDownloadQualityChangedEvent extends MediaQualityChangeEvent<VideoQuality> {
+    }
+
+    interface AudioDownloadQualityChangedEvent extends MediaQualityChangeEvent<AudioQuality> {
     }
 
     interface MediaPlaybackQualityChangeEvent<Q extends Quality> extends PlayerEvent {

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -364,6 +364,10 @@ declare namespace bitmovin {
      */
     setAudioQuality(audioQualityID: string): PlayerAPI;
     /**
+     * Gets the currently set audio quality.
+     */
+    getAudioQuality(): PlayerAPI.AudioQuality;
+    /**
      * Sets authentication data which is sent along with the licensing call. Can be used to add more
      * information for a 3rd party licensing backend. The data be any type or object as needed by the
      * 3rd party licensing backend.
@@ -431,6 +435,10 @@ declare namespace bitmovin {
      * @param videoQualityID ID defined in the MPD or 'auto'
      */
     setVideoQuality(videoQualityID: string): PlayerAPI;
+    /**
+     * Gets the currently set video quality.
+     */
+    getVideoQuality(): PlayerAPI.VideoQuality;
     /**
      * Sets the player’s volume in the range of 0 (silent) to 100 (max volume). Unmutes a muted player.
      *


### PR DESCRIPTION
UI `AudioQualitySelectBox` and `VideoQualitySelectBox` selected items are now correctly kept in sync with API calls to `setAudioQuality`/`setVideoQuality`.