### PR TITLE
Fix audio track selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support CEA-608 subtitle positioning
 
+### Fixed
+- Select correct audio track after updating the items in `AudioTrackSelectBox`
+
 ## [2.8.3]
 
 ### Changed

--- a/src/ts/components/audiotrackselectbox.ts
+++ b/src/ts/components/audiotrackselectbox.ts
@@ -14,7 +14,7 @@ export class AudioTrackSelectBox extends SelectBox {
   configure(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let audioTrackHandler = () => {
+    let selectCurrentAudioTrack = () => {
       let currentAudioTrack = player.getAudio();
 
       // HLS streams don't always provide this, so we have to check
@@ -36,7 +36,7 @@ export class AudioTrackSelectBox extends SelectBox {
       // Select the correct audio track after the tracks have been added
       // This is also important in case we missed the `ON_AUDIO_CHANGED` event, e.g. when `playback.audioLanguage`
       // is configured but the event is fired before the UI is created.
-      audioTrackHandler();
+      selectCurrentAudioTrack();
     };
 
     this.onItemSelected.subscribe((sender: AudioTrackSelectBox, value: string) => {
@@ -44,7 +44,7 @@ export class AudioTrackSelectBox extends SelectBox {
     });
 
     // Update selection when selected track has changed
-    player.addEventHandler(player.EVENT.ON_AUDIO_CHANGED, audioTrackHandler);
+    player.addEventHandler(player.EVENT.ON_AUDIO_CHANGED, selectCurrentAudioTrack);
     // Update tracks when source goes away
     player.addEventHandler(player.EVENT.ON_SOURCE_UNLOADED, updateAudioTracks);
     // Update tracks when a new source is loaded


### PR DESCRIPTION
Select the correct audio track after updating the items in `AudioTrackSelectBox`. Before, when the select box was updated, no item was selected, but it looked like the first one was selected since browers automatically show it as the active item.

Now we query the player for the active track and set it correctly.