### PR TITLE
CEA-608: Rewritten text layouting, CSS simplification & code improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Changed
+- Rewritten CEA-608 text layouting
+- Greatly simplified CEA-608 CSS style (`.{prefix}-ui-subtitle-overlay.{prefix}-cea608`)
+- Calculate CEA-608 font size only with active CEA-608 cues
+
+### Fixed
+- Overlapping CEA-608 texts with large player aspect ratios
+
 ## [2.10.1]
 
 ### Changed
@@ -256,6 +266,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 - 2017-02-03
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.1...develop
 [2.10.1]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.8.3...v2.9.0

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -410,6 +410,17 @@
       // Remove cues after some time
       setInterval(function() { cues.forEach(function(cue) { cueExit(cue); }); }, 60000);
     },
+    'Animate player size/height (needs player 7.5)': function() {
+      var playerFigure = player.getFigure();
+      var initialHeight = playerFigure.offsetHeight;
+      var minHeight = 300;
+      var maxHeight = 1400;
+
+      $(playerFigure)
+      .animate({height: minHeight}, 1000)
+      .animate({height: maxHeight}, 1000)
+      .animate({height: initialHeight}, 1000);
+    },
   };
   $.each(actions, function(title, handler) {
     $('#actions').append($('<button type="button" class="btn btn-primary btn-sm">' + title + '</button>').click(function() {printResult(handler(), title);})).append(' ');

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -403,8 +403,8 @@
       for (var row = 0; row < 15; row++) {
         var text = 'Test' + (row + 1);
         cues.push(cueEnter(text, row, 0));
-        cues.push(cueEnter(text, row, 15 - text.length / 2));
-        cues.push(cueEnter(text, row, 31 - text.length));
+        cues.push(cueEnter(text, row, 15 - text.length / 2 + 1));
+        cues.push(cueEnter(text, row, 31 - text.length + 1));
       }
 
       // Remove cues after some time

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -400,8 +400,8 @@
 
       // Create list of cues and display them
       var cues = [];
-      var text = 'Test';
       for (var row = 0; row < 15; row++) {
+        var text = 'Test' + (row + 1);
         cues.push(cueEnter(text, row, 0));
         cues.push(cueEnter(text, row, 15 - text.length / 2));
         cues.push(cueEnter(text, row, 31 - text.length));

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -380,7 +380,36 @@
       return player.scheduleAd(
         'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/2nd_test_ad_unit&ciu_szs=300x100&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&url=[referrer_url]&description_url=[description_url]&correlator=[random]',
         'ima', {timeOffset: player.getCurrentTime() + 5});
-    }
+    },
+    'CEA-608 subtitle test pattern (60 secs)': function() {
+      const cueEnter = function(text, row, column) {
+        var cue = {
+          text: text,
+          position: {
+            row: row,
+            column: column,
+          },
+        };
+        player.fireEvent(player.EVENT.ON_CUE_ENTER, cue);
+        return cue;
+      };
+
+      const cueExit = function(cue) {
+        player.fireEvent(player.EVENT.ON_CUE_EXIT, cue);
+      };
+
+      // Create list of cues and display them
+      var cues = [];
+      var text = 'Test';
+      for (var row = 0; row < 15; row++) {
+        cues.push(cueEnter(text, row, 0));
+        cues.push(cueEnter(text, row, 15 - text.length / 2));
+        cues.push(cueEnter(text, row, 31 - text.length));
+      }
+
+      // Remove cues after some time
+      setInterval(function() { cues.forEach(function(cue) { cueExit(cue); }); }, 60000);
+    },
   };
   $.each(actions, function(title, handler) {
     $('#actions').append($('<button type="button" class="btn btn-primary btn-sm">' + title + '</button>').click(function() {printResult(handler(), title);})).append(' ');

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -1,6 +1,8 @@
 .#{$prefix}-ui-subtitle-overlay {
   &.#{$prefix}-cea608 {
 
+    top: 2em;
+
     .#{$prefix}-ui-subtitle-label {
       font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace;
       line-height: 1em;

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -1,30 +1,20 @@
 .#{$prefix}-ui-subtitle-overlay {
   &.#{$prefix}-cea608 {
-    align-items: flex-end;
-    bottom: unset;
-    display: flex;
-    height: 86%;
-    justify-content: center;
-    left: unset;
-    margin: auto 10%;
-    pointer-events: none;
-    right: unset;
-    top: 50%;
-    transform: translate(0%, -50%);
-    transition: height $animation-duration-short ease-out;
-    width: 80%;
 
     .#{$prefix}-ui-subtitle-label {
       font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace;
-      letter-spacing: .11em;
+      line-height: 1em;
       position: absolute;
       text-transform: uppercase;
     }
 
     &.#{$prefix}-controlbar-visible {
-      bottom: unset;
-      height: 70%;
-      transition: height $animation-duration-short ease-in;
+      // Disable the make-space-for-controlbar mechanism
+      // We don't want CEA-608 subtitles to make space for the controlbar because they're
+      // positioned absolutely in relation to the video picture and thus cannot just move
+      // somewhere else.
+      bottom: 2em;
+      transition: none;
     }
   }
 }

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -6,7 +6,6 @@
 
   @include hidden;
 
-  top: 2em;
   bottom: 2em;
   font-size: 1.2em;
   left: 3em;

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -6,6 +6,7 @@
 
   @include hidden;
 
+  top: 2em;
   bottom: 2em;
   font-size: 1.2em;
   left: 3em;
@@ -28,6 +29,7 @@
     }
   }
 
+  // Move the subtitle up above the controlbar when it appears to avoid them overlapping
   &.#{$prefix}-controlbar-visible {
     bottom: 5em;
     transition: bottom $animation-duration-short ease-in;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -117,11 +117,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         text: dummyText,
       });
       dummyLabel.getDomElement().css({
-        'color': 'rgba(0, 0, 0, 0)',
         'font-size': '30px',
         'line-height': '30px',
-        'top': '0',
-        'left': '0',
       });
       this.addComponent(dummyLabel);
       this.updateComponents();

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -25,8 +25,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CEA608_WIDTH = 0.8;
   // The actual font width is 1 + 0.11 letter-spacing
   private static readonly CEA608_FONT_SPACING = 1.11;
-  // 6.25 = 100/16 because there's 15 possible lines
-  private static readonly CEA608_LINE_COEF = 6.25;
+  // The offset in percent for one row (which is also the height of a row)
+  private static readonly CEA608_ROW_OFFSET = 6.25;
   // To avoid having the font too big and overlap, while still have the proper width,
   // the font must be sized down, the width is then compensated by letter-spacing
   private static readonly CEA608_LINE_TO_FONT_SIZE = 0.9;
@@ -172,7 +172,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       for (let label of labels) {
         label.getDomElement().css({
           'left': `${event.position.column / ratio}em`,
-          'top': `${event.position.row * SubtitleOverlay.CEA608_LINE_COEF}%`,
+          'top': `${event.position.row * SubtitleOverlay.CEA608_ROW_OFFSET}%`,
           'font-size': `${SubtitleOverlay.CEA608_LINE_TO_FONT_SIZE * this.cea608lineHeight}px`,
         });
       }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -125,7 +125,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         // accurate measurement even though the returned size is an integer value
         'font-size': '200px',
         'line-height': '200px',
-        'display': 'hidden',
+        'visibility': 'hidden',
       });
       this.addComponent(dummyLabel);
       this.updateComponents();

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -4,7 +4,6 @@ import SubtitleCueEvent = bitmovin.PlayerAPI.SubtitleCueEvent;
 import {Label, LabelConfig} from './label';
 import {ComponentConfig, Component} from './component';
 import {ControlBar} from './controlbar';
-import {DOM} from '../dom';
 
 /**
  * Overlays the player to display subtitles.

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -25,8 +25,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CEA608_WIDTH = 0.8;
   // The actual font width is 1 + 0.11 letter-spacing
   private static readonly CEA608_FONT_SPACING = 1.11;
-  // 6.66 = 100/15 the number of possible lines
-  private static readonly CEA608_LINE_COEF = 6.66;
+  // 6.25 = 100/16 because there's 15 possible lines
+  private static readonly CEA608_LINE_COEF = 6.25;
   // To avoid having the font too big and overlap, while still have the proper width,
   // the font must be sized down, the width is then compensated by letter-spacing
   private static readonly CEA608_LINE_TO_FONT_SIZE = 0.9;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -19,14 +19,16 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   private static readonly CLASS_CONTROLBAR_VISIBLE = 'controlbar-visible';
   private static readonly CLASS_CEA_608 = 'cea608';
-  // The number of columns in a cea608 line
+  // The number of rows in a cea608 grid
+  private static readonly CEA608_NUM_ROWS = 15;
+  // The number of columns in a cea608 grid
   private static readonly CEA608_NUM_COLUMNS = 32;
   // 80% is the width of the space where CEA608 captions are displayed
   private static readonly CEA608_WIDTH = 0.8;
   // The actual font width is 1 + 0.11 letter-spacing
   private static readonly CEA608_FONT_SPACING = 1.11;
   // The offset in percent for one row (which is also the height of a row)
-  private static readonly CEA608_ROW_OFFSET = 6.25;
+  private static readonly CEA608_ROW_OFFSET = 100 / (SubtitleOverlay.CEA608_NUM_ROWS + 1);
   // To avoid having the font too big and overlap, while still have the proper width,
   // the font must be sized down, the width is then compensated by letter-spacing
   private static readonly CEA608_LINE_TO_FONT_SIZE = 0.9;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -105,6 +105,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   configureCea608Captions(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {
     // The calculated font size
     let fontSize = 0;
+    // The required letter spacing spread the text characters evenly across the grid
+    let fontLetterSpacing = 0;
     // Flag telling if the CEA-608 mode is enabled
     let enabled = false;
 
@@ -122,6 +124,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       const dummyLabelCharWidth = dummyLabel.getDomElement().width();
       const dummyLabelCharHeight = dummyLabel.getDomElement().height();
+      const fontSizeRatio = dummyLabelCharWidth / dummyLabelCharHeight;
 
       this.removeComponent(dummyLabel);
       this.updateComponents();
@@ -139,12 +142,17 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         // When the available space is wider than the text grid, the font size is simply
         // determined by the height of the available space.
         fontSize = this.getDomElement().height() / SubtitleOverlay.CEA608_NUM_ROWS;
+
+        // Calculate the additional letter spacing required to evenly spread the text across the grid's width
+        const gridSlotWidth = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS;
+        const fontCharWidth = fontSize * fontSizeRatio;
+        fontLetterSpacing = gridSlotWidth - fontCharWidth;
       } else {
         // When the available space is not wide enough, texts would vertically overlap if we take
         // the height as a base for the font size, so we need to limit the height. We do that
         // by determining the font size by the width of the available space.
-        const fontSizeRatio = dummyLabelCharHeight / dummyLabelCharWidth;
-        fontSize = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS * fontSizeRatio;
+        fontSize = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS / fontSizeRatio;
+        fontLetterSpacing = 0;
       }
 
       if (enabled) {
@@ -153,6 +161,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
           if (label instanceof SubtitleLabel) {
             label.getDomElement().css({
               'font-size': `${fontSize}px`,
+              'letter-spacing': `${fontLetterSpacing}px`,
             });
           }
         }
@@ -179,6 +188,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
           'left': `${event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET}%`,
           'top': `${event.position.row * SubtitleOverlay.CEA608_ROW_OFFSET}%`,
           'font-size': `${fontSize}px`,
+          'letter-spacing': `${fontLetterSpacing}px`,
         });
       }
     });

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -137,11 +137,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       this.cea608lineHeight = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS * ratio;
 
       if (this.isCEA608) {
+        // Update font-size of all active subtitle labels
         for (let label of this.getComponents()) {
           if (label instanceof SubtitleLabel) {
-            // Only element with left property are cea-608
-            let domElement = label.getDomElement();
-            domElement.css({
+            label.getDomElement().css({
               'font-size': `${this.cea608lineHeight}px`,
             });
           }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -23,8 +23,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CEA608_NUM_ROWS = 15;
   // The number of columns in a cea608 grid
   private static readonly CEA608_NUM_COLUMNS = 32;
-  // 80% is the width of the space where CEA608 captions are displayed
-  private static readonly CEA608_WIDTH = 0.8;
   // The actual font width is 1 + 0.11 letter-spacing
   private static readonly CEA608_FONT_SPACING = 1.11;
   // The offset in percent for one row (which is also the height of a row)
@@ -141,7 +139,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
 
       ratio = height / width;
-      this.cea608lineHeight = (new DOM(player.getFigure()).width()) * (SubtitleOverlay.CEA608_WIDTH / SubtitleOverlay.CEA608_NUM_COLUMNS) * ratio * SubtitleOverlay.CEA608_FONT_SPACING;
+      this.cea608lineHeight = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS * ratio * SubtitleOverlay.CEA608_FONT_SPACING;
 
       if (this.isCEA608) {
         for (let label of this.getComponents()) {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -43,6 +43,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     this.subtitleManager = subtitleManager;
 
     player.addEventHandler(player.EVENT.ON_CUE_ENTER, (event: SubtitleCueEvent) => {
+      // Sanitize invalid positioning data
+      // Sometimes the positions are undefined, we assume them to be zero
+      event.position.row = event.position.row || 0;
+      event.position.column = event.position.column || 0;
+
       let labelToAdd = subtitleManager.cueEnter(event);
 
       if (this.previewSubtitleActive) {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -197,6 +197,15 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
       enabled = false;
     };
+
+    player.addEventHandler(player.EVENT.ON_CUE_EXIT, () => {
+      if (!this.subtitleManager.hasCues) {
+        // Disable CEA-608 mode when all subtitles are gone (to allow correct formatting and
+        // display of other types of subtitles, e.g. the formatting preview subtitle)
+        reset();
+      }
+    });
+
     player.addEventHandler(player.EVENT.ON_SOURCE_UNLOADED, reset);
     player.addEventHandler(player.EVENT.ON_SUBTITLE_CHANGED, reset);
   }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -23,13 +23,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CEA608_NUM_ROWS = 15;
   // The number of columns in a cea608 grid
   private static readonly CEA608_NUM_COLUMNS = 32;
-  // The actual font width is 1 + 0.11 letter-spacing
-  private static readonly CEA608_FONT_SPACING = 1.11;
   // The offset in percent for one row (which is also the height of a row)
   private static readonly CEA608_ROW_OFFSET = 100 / (SubtitleOverlay.CEA608_NUM_ROWS + 1);
-  // To avoid having the font too big and overlap, while still have the proper width,
-  // the font must be sized down, the width is then compensated by letter-spacing
-  private static readonly CEA608_LINE_TO_FONT_SIZE = 0.9;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
@@ -139,7 +134,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
 
       ratio = height / width;
-      this.cea608lineHeight = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS * ratio * SubtitleOverlay.CEA608_FONT_SPACING;
+      this.cea608lineHeight = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS * ratio;
 
       if (this.isCEA608) {
         for (let label of this.getComponents()) {
@@ -147,7 +142,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
             // Only element with left property are cea-608
             let domElement = label.getDomElement();
             domElement.css({
-              'font-size': `${SubtitleOverlay.CEA608_LINE_TO_FONT_SIZE * this.cea608lineHeight}px`,
+              'font-size': `${this.cea608lineHeight}px`,
             });
           }
         }
@@ -173,7 +168,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         label.getDomElement().css({
           'left': `${event.position.column / ratio}em`,
           'top': `${event.position.row * SubtitleOverlay.CEA608_ROW_OFFSET}%`,
-          'font-size': `${SubtitleOverlay.CEA608_LINE_TO_FONT_SIZE * this.cea608lineHeight}px`,
+          'font-size': `${this.cea608lineHeight}px`,
         });
       }
     });

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -109,22 +109,18 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     let enabled = false;
 
     const updateCEA608FontSize = () => {
-      const dummyText = 'dummyStringToMeasureFontSizeRatio';
-      const dummyLabel = new SubtitleLabel({
-        // One letter label used to calculate the height width ratio of the font
-        // Works because we are using a monospace font for cea 608
-        // Using a longer string increases precision due to width being an integer
-        text: dummyText,
-      });
+      const dummyLabel = new SubtitleLabel({ text: 'X' });
       dummyLabel.getDomElement().css({
-        'font-size': '30px',
-        'line-height': '30px',
+        // By using a large font size we do not need to use multiple letters and can get still an
+        // accurate measurement even though the returned size is an integer value
+        'font-size': '200px',
+        'line-height': '200px',
       });
       this.addComponent(dummyLabel);
       this.updateComponents();
       this.show();
 
-      const dummyLabelCharWidth = dummyLabel.getDomElement().width() / dummyText.length;
+      const dummyLabelCharWidth = dummyLabel.getDomElement().width();
       const dummyLabelCharHeight = dummyLabel.getDomElement().height();
 
       this.removeComponent(dummyLabel);

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -157,15 +157,13 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         fontLetterSpacing = 0;
       }
 
-      if (enabled) {
-        // Update font-size of all active subtitle labels
-        for (let label of this.getComponents()) {
-          if (label instanceof SubtitleLabel) {
-            label.getDomElement().css({
-              'font-size': `${fontSize}px`,
-              'letter-spacing': `${fontLetterSpacing}px`,
-            });
-          }
+      // Update font-size of all active subtitle labels
+      for (let label of this.getComponents()) {
+        if (label instanceof SubtitleLabel) {
+          label.getDomElement().css({
+            'font-size': `${fontSize}px`,
+            'letter-spacing': `${fontLetterSpacing}px`,
+          });
         }
       }
     };

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -43,10 +43,12 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     this.subtitleManager = subtitleManager;
 
     player.addEventHandler(player.EVENT.ON_CUE_ENTER, (event: SubtitleCueEvent) => {
-      // Sanitize invalid positioning data
-      // Sometimes the positions are undefined, we assume them to be zero
-      event.position.row = event.position.row || 0;
-      event.position.column = event.position.column || 0;
+      // Sanitize cue data (must be done before the cue ID is generated in subtitleManager.cueEnter)
+      if (event.position) {
+        // Sometimes the positions are undefined, we assume them to be zero
+        event.position.row = event.position.row || 0;
+        event.position.column = event.position.column || 0;
+      }
 
       let labelToAdd = subtitleManager.cueEnter(event);
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -135,8 +135,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
 
       // The size ratio of the letter grid
-      const fontGridSizeRatio = (dummyLabelCharHeight * SubtitleOverlay.CEA608_NUM_ROWS) /
-        (dummyLabelCharWidth * SubtitleOverlay.CEA608_NUM_COLUMNS);
+      const fontGridSizeRatio = (dummyLabelCharWidth * SubtitleOverlay.CEA608_NUM_COLUMNS) /
+        (dummyLabelCharHeight * SubtitleOverlay.CEA608_NUM_ROWS);
       // The size ratio of the available space for the grid
       const subtitleOverlaySizeRatio = this.getDomElement().width() / this.getDomElement().height();
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -236,14 +236,20 @@ class ActiveSubtitleManager {
    * Calculates a unique ID for a subtitle cue, which is needed to associate an ON_CUE_ENTER with its ON_CUE_EXIT
    * event so we can remove the correct subtitle in ON_CUE_EXIT when multiple subtitles are active at the same time.
    * The start time plus the text should make a unique identifier, and in the only case where a collision
-   * can happen, two similar texts will be displayed at a similar time.
+   * can happen, two similar texts will be displayed at a similar time and a similar position (or without position).
    * The start time should always be known, because it is required to schedule the ON_CUE_ENTER event. The end time
    * must not necessarily be known and therefore cannot be used for the ID.
    * @param event
    * @return {string}
    */
   private static calculateId(event: SubtitleCueEvent): string {
-    return event.start + event.text;
+    let id = event.start + '-' + event.text;
+
+    if (event.position) {
+      id += '-' + event.position.row + '-' + event.position.column;
+    }
+
+    return id;
   }
 
   /**

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -125,6 +125,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         // accurate measurement even though the returned size is an integer value
         'font-size': '200px',
         'line-height': '200px',
+        'display': 'hidden',
       });
       this.addComponent(dummyLabel);
       this.updateComponents();

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -22,7 +22,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   // The number of columns in a cea608 grid
   private static readonly CEA608_NUM_COLUMNS = 32;
   // The offset in percent for one row (which is also the height of a row)
-  private static readonly CEA608_ROW_OFFSET = 100 / (SubtitleOverlay.CEA608_NUM_ROWS + 1);
+  private static readonly CEA608_ROW_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_ROWS;
+  // The offset in percent for one column (which is also the width of a column)
+  private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
@@ -165,7 +167,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
       for (let label of labels) {
         label.getDomElement().css({
-          'left': `${event.position.column / fontSizeRatio}em`,
+          'left': `${event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET}%`,
           'top': `${event.position.row * SubtitleOverlay.CEA608_ROW_OFFSET}%`,
           'font-size': `${fontSize}px`,
         });


### PR DESCRIPTION
The basic issue was that under certain aspect ratios texts were overlapping. See issue #61 for a description and before/after comparison.

This PR
 * Rewrites the layouting code
 * Greatly simplifies the CSS
 * Removes all hardcoded values except the ones that are really "hardcoded", which is only the 32x15 grid size
 * Improves code readability by adding comments and renaming variables
 * Calculates and applies the font size only when CEA cues are active