### PR TITLE
Feature/onplaying listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## develop
+- `PlaybackToggleButton` now also listens to ON_PLAYING in addition of ON_PLAY
+
 ## [2.10.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## develop
-- `PlaybackToggleButton` now also listens to ON_PLAYING in addition of ON_PLAY
+
+### Changed
+- `PlaybackToggleButton` now also listens to `ON_PLAYING` in addition to `ON_PLAY`
 
 ## [2.10.3]
 

--- a/src/ts/components/playbacktogglebutton.ts
+++ b/src/ts/components/playbacktogglebutton.ts
@@ -43,7 +43,10 @@ export class PlaybackToggleButton extends ToggleButton<ToggleButtonConfig> {
     // Call handler upon these events
     player.addEventHandler(player.EVENT.ON_PLAY, playbackStateHandler);
     player.addEventHandler(player.EVENT.ON_PAUSED, playbackStateHandler);
-    player.addEventHandler(player.EVENT.ON_PLAYING, playbackStateHandler);
+    if (player.EVENT.ON_PLAYING) {
+      // Since player 7.3. Not really necessary but just in case we ever miss the ON_PLAY event.
+      player.addEventHandler(player.EVENT.ON_PLAYING, playbackStateHandler);
+    }
     // when playback finishes, player turns to paused mode
     player.addEventHandler(player.EVENT.ON_PLAYBACK_FINISHED, playbackStateHandler);
     player.addEventHandler(player.EVENT.ON_CAST_STARTED, playbackStateHandler);

--- a/src/ts/components/playbacktogglebutton.ts
+++ b/src/ts/components/playbacktogglebutton.ts
@@ -43,6 +43,7 @@ export class PlaybackToggleButton extends ToggleButton<ToggleButtonConfig> {
     // Call handler upon these events
     player.addEventHandler(player.EVENT.ON_PLAY, playbackStateHandler);
     player.addEventHandler(player.EVENT.ON_PAUSED, playbackStateHandler);
+    player.addEventHandler(player.EVENT.ON_PLAYING, playbackStateHandler);
     // when playback finishes, player turns to paused mode
     player.addEventHandler(player.EVENT.ON_PLAYBACK_FINISHED, playbackStateHandler);
     player.addEventHandler(player.EVENT.ON_CAST_STARTED, playbackStateHandler);


### PR DESCRIPTION
Added an event listener to ON_PLAYING in addition to ON_PLAY to the PlaybackToggleButton.

This is needed as in some weird edge cases the player can fire `ON_PLAY` before `ON_READY` and the UI would not have notices the event in that case and the play button would not have disappeared.