### PR TITLE
Allow multiline CEA-608 captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Changed
+- Remove `nowrap` from CEA-608 style to correctly render multiline cues
+
 ## [2.10.3]
 
 ### Fixed
@@ -271,6 +276,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 - 2017-02-03
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.3...develop
 [2.10.3]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.2...v2.10.3
 [2.10.2]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.1...v2.10.2
 [2.10.1]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.0...v2.10.1

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -8,7 +8,6 @@
       line-height: 1em;
       position: absolute;
       text-transform: uppercase;
-      white-space: nowrap;
     }
 
     &.#{$prefix}-controlbar-visible {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -141,26 +141,29 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         this.hide();
       }
 
+      const subtitleOverlayWidth = this.getDomElement().width();
+      const subtitleOverlayHeight = this.getDomElement().height();
+
       // The size ratio of the letter grid
       const fontGridSizeRatio = (dummyLabelCharWidth * SubtitleOverlay.CEA608_NUM_COLUMNS) /
         (dummyLabelCharHeight * SubtitleOverlay.CEA608_NUM_ROWS);
       // The size ratio of the available space for the grid
-      const subtitleOverlaySizeRatio = this.getDomElement().width() / this.getDomElement().height();
+      const subtitleOverlaySizeRatio = subtitleOverlayWidth / subtitleOverlayHeight;
 
       if (subtitleOverlaySizeRatio > fontGridSizeRatio) {
         // When the available space is wider than the text grid, the font size is simply
         // determined by the height of the available space.
-        fontSize = this.getDomElement().height() / SubtitleOverlay.CEA608_NUM_ROWS;
+        fontSize = subtitleOverlayHeight / SubtitleOverlay.CEA608_NUM_ROWS;
 
         // Calculate the additional letter spacing required to evenly spread the text across the grid's width
-        const gridSlotWidth = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS;
+        const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
         const fontCharWidth = fontSize * fontSizeRatio;
         fontLetterSpacing = gridSlotWidth - fontCharWidth;
       } else {
         // When the available space is not wide enough, texts would vertically overlap if we take
         // the height as a base for the font size, so we need to limit the height. We do that
         // by determining the font size by the width of the available space.
-        fontSize = this.getDomElement().width() / SubtitleOverlay.CEA608_NUM_COLUMNS / fontSizeRatio;
+        fontSize = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS / fontSizeRatio;
         fontLetterSpacing = 0;
       }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -141,7 +141,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         this.hide();
       }
 
-      const subtitleOverlayWidth = this.getDomElement().width();
+      // We subtract 1px here to avoid line breaks at the right border of the subtitle overlay that can happen
+      // when texts contain whitespaces. It's probably some kind of pixel rounding issue in the browser's
+      // layouting, but the actual reason could not be determined. Aiming for a target width - 1px solves the issue.
+      const subtitleOverlayWidth = this.getDomElement().width() - 1;
       const subtitleOverlayHeight = this.getDomElement().height();
 
       // The size ratio of the letter grid


### PR DESCRIPTION
#66 added a `white-space: nowrap` CSS rule to avoid unwanted line breaks when a caption would touch the right border of the subtitle area. This probably happened due to floating values used for sizes and positioning and when captions contained a whitespace they became a little bit wider than expected, leading to line breaks. The CSS rule avoided that.

Unfortunately, Safari does not output CEA-608 caption lines separately, but as a single string without line breaks. This is probably because Safari converts the captions to WebVTT, which is inherently designed for multiline captions because it is built on the concept of layout boxes with a position and width that leads to a specific height. At least that is my interpretation of the data from Safari's `VTTCue` combined with how Safari's native player renders captions (when you open a m3u8 playlist directly in Safari) and the [WebVTT draft](https://www.w3.org/TR/webvtt1/).

This means that `nowrap` cannot be used, so this PR removes the `nowrap` and adds another workaround that avoid the unwanted line breaks while still allowing desired line breaks.

Ideally the UI would only support WebVTT and not know about CEA-608 and it's 32x15 grid at all, but that will have to wait until the captions handling in the player is redesigned.