### PR TITLE
Feature/load listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Remove `nowrap` from CEA-608 style to correctly render multiline cues
 - `PlaybackToggleButton` now also listens to `ON_PLAYING` in addition to `ON_PLAY`
+- `PlaybackToggleButton` now also listens to `ON_SOURCE_LOADED` and `ON_SOURCE_UNLOADED` to properly react to a new source which might not be playing
 
 ## [2.10.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## develop
+
+### Changed
+- `PlaybackToggleButton` now also listens to `ON_SOURCE_LOADED` and `ON_SOURCE_UNLOADED` to properly update the playback state when the source changes
 
 ## [2.10.4]
 
 ### Changed
 - Remove `nowrap` from CEA-608 style to correctly render multiline cues
 - `PlaybackToggleButton` now also listens to `ON_PLAYING` in addition to `ON_PLAY`
-- `PlaybackToggleButton` now also listens to `ON_SOURCE_LOADED` and `ON_SOURCE_UNLOADED` to properly react to a new source which might not be playing
 
 ## [2.10.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
 ## develop
 
 ### Changed

--- a/src/ts/components/playbacktogglebutton.ts
+++ b/src/ts/components/playbacktogglebutton.ts
@@ -47,6 +47,9 @@ export class PlaybackToggleButton extends ToggleButton<ToggleButtonConfig> {
       // Since player 7.3. Not really necessary but just in case we ever miss the ON_PLAY event.
       player.addEventHandler(player.EVENT.ON_PLAYING, playbackStateHandler);
     }
+    // after unloading + loading a new source, the player might be in a different playing state (from playing into stopped)
+    player.addEventHandler(player.EVENT.ON_SOURCE_LOADED, playbackStateHandler);
+    player.addEventHandler(player.EVENT.ON_SOURCE_UNLOADED, playbackStateHandler);
     // when playback finishes, player turns to paused mode
     player.addEventHandler(player.EVENT.ON_PLAYBACK_FINISHED, playbackStateHandler);
     player.addEventHandler(player.EVENT.ON_CAST_STARTED, playbackStateHandler);


### PR DESCRIPTION
When we had a playing player and loaded a source which did not have autoplay, the UI did not react appropriately and did not display the play button (as there are no play/pause/playing events).
Added listeners for ON_SOURCE_LOADED and ON_SOURCE_UNLOADED