### PR TITLE
Improve CEA-608 rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - `PlaybackToggleButton` now also listens to `ON_SOURCE_LOADED` and `ON_SOURCE_UNLOADED` to properly update the playback state when the source changes
 - Update package dependencies
+- Apply CEA-608 style to subtitles before they are added to the DOM to avoid "style flickering"
 
 ### Fixed
 - Unnecessary line breaks in CEA-608 texts

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -4,6 +4,7 @@ import SubtitleCueEvent = bitmovin.PlayerAPI.SubtitleCueEvent;
 import {Label, LabelConfig} from './label';
 import {ComponentConfig, Component} from './component';
 import {ControlBar} from './controlbar';
+import { EventDispatcher } from '../eventdispatcher';
 
 /**
  * Overlays the player to display subtitles.
@@ -13,6 +14,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private subtitleManager: ActiveSubtitleManager;
   private previewSubtitleActive: boolean;
   private previewSubtitle: SubtitleLabel;
+
+  private preprocessLabelEventCallback = new EventDispatcher<SubtitleCueEvent, SubtitleLabel>();
 
   private static readonly CLASS_CONTROLBAR_VISIBLE = 'controlbar-visible';
   private static readonly CLASS_CEA_608 = 'cea608';
@@ -51,6 +54,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
 
       let labelToAdd = subtitleManager.cueEnter(event);
+
+      this.preprocessLabelEventCallback.dispatch(event, labelToAdd);
 
       if (this.previewSubtitleActive) {
         this.removeComponent(this.previewSubtitle);
@@ -189,14 +194,12 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
     });
 
-    player.addEventHandler(player.EVENT.ON_CUE_ENTER, (event: SubtitleCueEvent) => {
+    this.preprocessLabelEventCallback.subscribe((event: SubtitleCueEvent, label: SubtitleLabel) => {
       const isCEA608 = event.position != null;
       if (!isCEA608) {
         // Skip all non-CEA608 cues
         return;
       }
-
-      const labels = this.subtitleManager.getCues(event);
 
       if (!enabled) {
         enabled = true;
@@ -211,14 +214,13 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
           fontSizeCalculationRequired = false;
         }
       }
-      for (let label of labels) {
-        label.getDomElement().css({
-          'left': `${event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET}%`,
-          'top': `${event.position.row * SubtitleOverlay.CEA608_ROW_OFFSET}%`,
-          'font-size': `${fontSize}px`,
-          'letter-spacing': `${fontLetterSpacing}px`,
-        });
-      }
+
+      label.getDomElement().css({
+        'left': `${event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET}%`,
+        'top': `${event.position.row * SubtitleOverlay.CEA608_ROW_OFFSET}%`,
+        'font-size': `${fontSize}px`,
+        'letter-spacing': `${fontLetterSpacing}px`,
+      });
     });
 
     const reset = () => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -148,8 +148,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       // We subtract 1px here to avoid line breaks at the right border of the subtitle overlay that can happen
       // when texts contain whitespaces. It's probably some kind of pixel rounding issue in the browser's
-      // layouting, but the actual reason could not be determined. Aiming for a target width - 1px solves the issue.
-      const subtitleOverlayWidth = this.getDomElement().width() - 1;
+      // layouting, but the actual reason could not be determined. Aiming for a target width - 1px would work in
+      // most browsers, but Safari has a "quantized" font size rendering with huge steps in between so we need
+      // to subtract some more pixels to avoid line breaks there as well.
+      const subtitleOverlayWidth = this.getDomElement().width() - 10;
       const subtitleOverlayHeight = this.getDomElement().height();
 
       // The size ratio of the letter grid


### PR DESCRIPTION
This PR fixes unnecessary line breaks in Safari (which renders font sizes differently to other browsers) and applies the CEA-608 styling before the texts are added to the DOM, avoiding "style flickering".