### PR TITLE
Update playback position during paused live streams with DVR window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Added
+- Update `SeekBar` playback position of live streams with DVR window while playback is paused
+
 ### Fixed
 - Stop `SeekBar` smooth playback position updates on `ON_PLAYBACK_FINISHED`
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -198,6 +198,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     // update playback position of Cast playback
     player.addEventHandler(player.EVENT.ON_CAST_TIME_UPDATED, playbackPositionHandler);
 
+    this.configureLivePausedTimeshiftUpdater(player, uimanager, playbackPositionHandler);
 
     // Seek handling
     player.addEventHandler(player.EVENT.ON_SEEK, () => {
@@ -315,6 +316,26 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.configureSmoothPlaybackPositionUpdater(player, uimanager);
     }
     this.configureMarkers(player, uimanager);
+  }
+
+  /**
+   * Update seekbar while a live stream with DVR window is paused.
+   * The playback position stays still and the position indicator visually moves towards the back.
+   */
+  private configureLivePausedTimeshiftUpdater(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager,
+                                              playbackPositionHandler: () => void): void {
+    // Regularly update the playback position while the timeout is active
+    const pausedTimeshiftUpdater = new Timeout(1000, playbackPositionHandler, true);
+
+    // Start updater when a live stream with timeshift window is paused
+    player.addEventHandler(player.EVENT.ON_PAUSED, () => {
+      if (player.isLive() && player.getMaxTimeShift() < 0) {
+        pausedTimeshiftUpdater.start();
+      }
+    });
+
+    // Stop updater when playback continues (no matter if the updater was started before)
+    player.addEventHandler(player.EVENT.ON_PLAY, () => pausedTimeshiftUpdater.clear());
   }
 
   private configureSmoothPlaybackPositionUpdater(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {


### PR DESCRIPTION
When pausing a live stream with a DVR window, the playback position stays still and thus moves away from the live edge. The visual playback position indicator on the seekbar should therefore move towards the back.

Because this case was not handled, the playback position during a paused live stream with timeshift window only updated "accidentally" for a few seconds while the buffer was filled, but the buffer is usually < 1 minute while the timeshift window can be much longer (e.g. multiple hours).

This PR adds a timer that is activated once a live stream with timeshift window is paused, and deactivated once playback continues. It updates the playback position once per second.