### PR TITLE
Turn off live edge indicator during pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Update `SeekBar` playback position of live streams with DVR window while playback is paused
 
+### Changed
+- Switch off live edge indicator in `PlaybackTimeLabel` when a live stream is paused
+
 ### Fixed
 - Stop `SeekBar` smooth playback position updates on `ON_PLAYBACK_FINISHED`
 

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -73,7 +73,9 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       // An exception is made for live streams without a timeshift window, because here we "stop" playback instead
       // of pausing it (from a UI perspective), so we keep the live edge indicator on because a play would always
       // resume at the live edge.
-      if (player.getTimeShift() === 0 && (!player.isPaused() || player.getMaxTimeShift() === 0)) {
+      const isTimeshifted = player.getTimeShift() < 0;
+      const isTimeshiftAvailable = player.getMaxTimeShift() < 0;
+      if (!isTimeshifted && (!player.isPaused() || !isTimeshiftAvailable)) {
         this.getDomElement().addClass(liveEdgeCssClass);
       } else {
         this.getDomElement().removeClass(liveEdgeCssClass);

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -68,7 +68,9 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     };
 
     let updateLiveTimeshiftState = () => {
-      if (player.getTimeShift() === 0) {
+      // The player is only at the live edge iff the stream is not shifted and it is actually playing or playback has
+      // never been started (meaning it isn't paused). A player that is paused is always behind the live edge.
+      if (player.getTimeShift() === 0 && !player.isPaused()) {
         this.getDomElement().addClass(liveEdgeCssClass);
       } else {
         this.getDomElement().removeClass(liveEdgeCssClass);
@@ -104,6 +106,8 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
 
     player.addEventHandler(player.EVENT.ON_TIME_SHIFT, updateLiveTimeshiftState);
     player.addEventHandler(player.EVENT.ON_TIME_SHIFTED, updateLiveTimeshiftState);
+    player.addEventHandler(player.EVENT.ON_PLAY, updateLiveTimeshiftState);
+    player.addEventHandler(player.EVENT.ON_PAUSED, updateLiveTimeshiftState);
 
     let init = () => {
       // Reset min-width when a new source is ready (especially for switching VOD/Live modes where the label content

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -70,7 +70,10 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     let updateLiveTimeshiftState = () => {
       // The player is only at the live edge iff the stream is not shifted and it is actually playing or playback has
       // never been started (meaning it isn't paused). A player that is paused is always behind the live edge.
-      if (player.getTimeShift() === 0 && !player.isPaused()) {
+      // An exception is made for live streams without a timeshift window, because here we "stop" playback instead
+      // of pausing it (from a UI perspective), so we keep the live edge indicator on because a play would always
+      // resume at the live edge.
+      if (player.getTimeShift() === 0 && (!player.isPaused() || player.getMaxTimeShift() === 0)) {
         this.getDomElement().addClass(liveEdgeCssClass);
       } else {
         this.getDomElement().removeClass(liveEdgeCssClass);

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -68,6 +68,10 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     };
 
     let updateLiveTimeshiftState = () => {
+      if (!live) {
+        return;
+      }
+
       // The player is only at the live edge iff the stream is not shifted and it is actually playing or playback has
       // never been started (meaning it isn't paused). A player that is paused is always behind the live edge.
       // An exception is made for live streams without a timeshift window, because here we "stop" playback instead


### PR DESCRIPTION
As pointed out in https://github.com/bitmovin/bitmovin-player-ui/pull/76#pullrequestreview-84722035, the live edge indicator continued to indicate the player being at the live edge (red dot) while playback was paused and the playhead shifted behind the live edge.

This PR switches off the live indicator when a live stream is paused and the playhead is away from the live edge.