### PR TITLE
Fix SeekBar marker style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Positioning of `SeekBar` markers was broken due to style changes in 2.11.0
+
 ## [2.11.0]
 
 ### Added
@@ -299,6 +304,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 - 2017-02-03
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.11.0...develop
 [2.11.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.5...v2.11.0
 [2.10.5]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.4...v2.10.5
 [2.10.4]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.3...v2.10.4

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -12,6 +12,7 @@
   width: 100%;
 
   $bar-inset: auto;
+  $bar-height: .2em;
 
   .#{$prefix}-seekbar {
     height: 100%;
@@ -21,7 +22,7 @@
       // sass-lint:disable no-vendor-prefixes
       -ms-transform-origin: 0 0; // required for IE9
       bottom: 0;
-      height: .2em;
+      height: $bar-height;
       left: 0;
       position: absolute;
       right: auto;
@@ -77,7 +78,8 @@
 
       $marker-width: 2px;
 
-      margin: ($bar-inset / 1.3) 0;
+      height: $bar-height * 2;
+      margin: $bar-inset 0;
 
       > .#{$prefix}-seekbar-marker {
         @extend %bar;
@@ -85,6 +87,7 @@
         border-right: $marker-width solid $color-primary;
         // don't consider the border for width, else it does not overlap at edges
         box-sizing: content-box;
+        height: 100%;
         // offset position marker to center it on its actual position
         margin-left: -$marker-width / 2;
         width: 0;


### PR DESCRIPTION
Due to style changes in #79, `SeekBar` markers were not rendered correctly any longer. This PR fixes the marker style to get them rendered correctly again.