### PR TITLE
Rework volume changeability detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
-### Fixed
-- Positioning of `SeekBar` markers was broken due to style changes in 2.11.0
-
 ### Changed
 - Execute volume control availability test on dummy media element to prevent unexpected interference with muted autoplay
+
+### Fixed
+- Positioning of `SeekBar` markers was broken due to style changes in 2.11.0
 
 ## [2.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Positioning of `SeekBar` markers was broken due to style changes in 2.11.0
 
 ### Changed
-- The volume slider now does not probe the volume setting capabilities on the player but on a dummy element to avoid muted autoplay getting paused
+- Execute volume control availability test on dummy media element to prevent unexpected interference with muted autoplay
 
 ## [2.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Positioning of `SeekBar` markers was broken due to style changes in 2.11.0
 
+### Changed
+- The volume slider now does not probe the volume setting capabilities on the player but on a dummy element to avoid muted autoplay getting paused
+
 ## [2.11.0]
 
 ### Added

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -107,7 +107,6 @@ export class VolumeSlider extends SeekBar {
     dummyVideoElement.appendChild(dummyAudioSource);
     // try setting the volume to 0.9 and if it's still 1 we are on a volume control restricted device
     dummyVideoElement.volume = 0.9;
-    // alert('volume after alteration: ' + dummyVideoElement.volume);
     return dummyVideoElement.volume !== 1;
   }
 }

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -20,16 +20,6 @@ export class VolumeSlider extends SeekBar {
 
   private static readonly issuerName = 'ui';
 
-  /**
-   * Small MP3 from https://mrcoles.com/detecting-html5-audio-autoplay/
-   * @type {string}
-   */
-  public static readonly dummyAudioSource: string = 'data:audio/mpeg;base64,/+MYxAAAAANIAUAAAASEEB/jwOFM/0MM/90b/+R' +
-    'hST//w4NFwOjf///PZu////9lns5GFDv//l9GlUIEEIAAAgIg8Ir/JGq3/+MYxDsLIj5QMYcoAP0dv9HIjUcH//yYSg+CIbkGP//8w0bLVjUP///' +
-    '3Z0x5QCAv/yLjwtGKTEFNRTMuOTeqqqqqqqqqqqqq/+MYxEkNmdJkUYc4AKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq' +
-    'qqqqqqqqqqqqqqqqqqqqqqqqq';
-
-
   constructor(config: SeekBarConfig = {}) {
     super(config);
 
@@ -103,7 +93,6 @@ export class VolumeSlider extends SeekBar {
     // probe a dummy video element with a minimal audio source
     const dummyVideoElement = document.createElement('video');
     const dummyAudioSource = document.createElement('source');
-    dummyAudioSource.src = VolumeSlider.dummyAudioSource;
     dummyVideoElement.appendChild(dummyAudioSource);
     // try setting the volume to 0.9 and if it's still 1 we are on a volume control restricted device
     dummyVideoElement.volume = 0.9;

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -44,7 +44,7 @@ export class VolumeSlider extends SeekBar {
 
     let config = <VolumeSliderConfig>this.getConfig();
 
-    if (config.hideIfVolumeControlProhibited && !this.detectVolumeControlAvailability(player)) {
+    if (config.hideIfVolumeControlProhibited && !this.detectVolumeControlAvailability()) {
       this.hide();
 
       // We can just return from here, because the user will never interact with the control and any configured
@@ -93,7 +93,7 @@ export class VolumeSlider extends SeekBar {
     volumeChangeHandler();
   }
 
-  private detectVolumeControlAvailability(player: bitmovin.PlayerAPI): boolean {
+  private detectVolumeControlAvailability(): boolean {
     /*
      * "On iOS devices, the audio level is always under the user’s physical control. The volume property is not
      * settable in JavaScript. Reading the volume property always returns 1."

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -91,9 +91,9 @@ export class VolumeSlider extends SeekBar {
      */
     // as muted autoplay gets paused as soon as we unmute it, we may not touch the volume of the actual player so we
     // probe a dummy audio element
-    const dummyAudioElement = document.createElement('audio');
+    const dummyVideoElement = document.createElement('video');
     // try setting the volume to 0.7 and if it's still 1 we are on a volume control restricted device
-    dummyAudioElement.volume = 0.7;
-    return dummyAudioElement.volume !== 1;
+    dummyVideoElement.volume = 0.7;
+    return dummyVideoElement.volume !== 1;
   }
 }

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -90,12 +90,10 @@ export class VolumeSlider extends SeekBar {
      * https://developer.apple.com/library/content/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html
      */
     // as muted autoplay gets paused as soon as we unmute it, we may not touch the volume of the actual player so we
-    // probe a dummy video element with a minimal audio source
-    const dummyVideoElement = document.createElement('video');
-    const dummyAudioSource = document.createElement('source');
-    dummyVideoElement.appendChild(dummyAudioSource);
-    // try setting the volume to 0.9 and if it's still 1 we are on a volume control restricted device
-    dummyVideoElement.volume = 0.9;
-    return dummyVideoElement.volume !== 1;
+    // probe a dummy audio element
+    const dummyAudioElement = document.createElement('audio');
+    // try setting the volume to 0.7 and if it's still 1 we are on a volume control restricted device
+    dummyAudioElement.volume = 0.7;
+    return dummyAudioElement.volume !== 1;
   }
 }


### PR DESCRIPTION
The volumeslider would try setting the volume on the player to see if it actually changes to detect if we are on a device which does not support setting of volume.
When the player was in muted autoplay and unmuted autoplay was disallowed by the browser this lead to a pause on the video element. The play call afterwards sometimes did not do anything as the player might still have been in playing state (it seems the video element does not fire the pause event immediately).
To avoid this strange behaviour i changed the code to probe a dummy video element with a minimal audio source.