### PR TITLE
Fix flickering bar indicators of SeekBar & VolumeSlider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Fixed
+- Flickering heights of `SeekBar` and `VolumeSlider` bar indicators
+
 ## [2.12.0]
 
 ### Changed

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -763,6 +763,16 @@ export class SeekBar extends Component<SeekBarConfig> {
    */
   private setPosition(element: DOM, percent: number) {
     let scale = percent / 100;
+
+    // When the scale is exactly 1, browsers seem to render the elements differently and the height gets slightly off,
+    // leading to mismatching heights when e.g. the buffer level bar has a width of 1 and the playback position bar has
+    // a width < 1. A jittering buffer level around 1 leads to an even worse flickering effect.
+    // Various changes in CSS styling and DOM hierarchy did not solve the issue so the workaround is to avoid a scale
+    // of exactly 1.
+    if (scale === 1.0) {
+      scale = 0.999999;
+    }
+
     let style = this.config.vertical ?
       // -ms-transform required for IE9
       { 'transform': 'scaleY(' + scale + ')', '-ms-transform': 'scaleY(' + scale + ')' } :

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -312,6 +312,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     playbackPositionHandler(); // Set the playback position
     this.setBufferPosition(0);
     this.setSeekPosition(0);
+    this.setPosition(this.seekBarBackdrop, 100); // Apply scaling transform to have all bars rendered similarly
     if (this.config.smoothPlaybackPositionUpdateIntervalMs !== SeekBar.SMOOTH_PLAYBACK_POSITION_UPDATE_DISABLED) {
       this.configureSmoothPlaybackPositionUpdater(player, uimanager);
     }

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -764,13 +764,14 @@ export class SeekBar extends Component<SeekBarConfig> {
   private setPosition(element: DOM, percent: number) {
     let scale = percent / 100;
 
-    // When the scale is exactly 1, browsers seem to render the elements differently and the height gets slightly off,
-    // leading to mismatching heights when e.g. the buffer level bar has a width of 1 and the playback position bar has
-    // a width < 1. A jittering buffer level around 1 leads to an even worse flickering effect.
+    // When the scale is exactly 1 or very near 1 (and the browser internally rounds it to 1), browsers seem to render
+    // the elements differently and the height gets slightly off, leading to mismatching heights when e.g. the buffer
+    // level bar has a width of 1 and the playback position bar has a width < 1. A jittering buffer level around 1
+    // leads to an even worse flickering effect.
     // Various changes in CSS styling and DOM hierarchy did not solve the issue so the workaround is to avoid a scale
     // of exactly 1.
-    if (scale === 1.0) {
-      scale = 0.999999;
+    if (scale >= 0.99999 && scale <= 1.00001) {
+      scale = 0.99999;
     }
 
     let style = this.config.vertical ?

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -122,6 +122,10 @@ export class SeekBar extends Component<SeekBarConfig> {
   configure(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager, configureSeek: boolean = true): void {
     super.configure(player, uimanager);
 
+    // Apply scaling transform to the backdrop bar to have all bars rendered similarly
+    // (the call must be up here to be executed for the volume slider as well)
+    this.setPosition(this.seekBarBackdrop, 100);
+
     if (!configureSeek) {
       // The configureSeek flag can be used by subclasses to disable configuration as seek bar. E.g. the volume
       // slider is reusing this component but adds its own functionality, and does not need the seek functionality.
@@ -312,7 +316,6 @@ export class SeekBar extends Component<SeekBarConfig> {
     playbackPositionHandler(); // Set the playback position
     this.setBufferPosition(0);
     this.setSeekPosition(0);
-    this.setPosition(this.seekBarBackdrop, 100); // Apply scaling transform to have all bars rendered similarly
     if (this.config.smoothPlaybackPositionUpdateIntervalMs !== SeekBar.SMOOTH_PLAYBACK_POSITION_UPDATE_DISABLED) {
       this.configureSmoothPlaybackPositionUpdater(player, uimanager);
     }


### PR DESCRIPTION
The bar indicators of `SeekBar` and `VolumeSlider` use the `transform: scaleX(value)` CSS rule to scale their width horizontally (or `scaleY` vertically). When the value is exactly `1`, browers seem to render the elements differently and their height is slightly different. Two overlaying bars where one has a scale of `1` and the other `!=1` do not match in height/width, leading to an unpleasant rendered result as visible here:

![image](https://user-images.githubusercontent.com/1189235/36096140-4da4d17a-0ff5-11e8-8fb3-d22ed1c07732.png)

When one bar jitters around a value of `1`, as it frequently can happen with the buffer indicator bar, this leads to an even worse flickering effect.

I have tried lots of different ways of applying CSS rules and building the DOM tree to avoid this rendering issue but could not find a way to avoid it. I also wasn't able to find any related issues of other people on the internet. Strangely, YouTube uses the same styling/scaling approach and I could not reproduce the issue there. So this seems to be related to a specific pattern of styling or structure within our UI.

To work around the issue, this PR adds code to simply never apply a scale of `1` but use a very near value instead that is visually indistinguishable from `1`.