### PR TITLE
Fix concurrent event listener array modification in EventDispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Flickering heights of `SeekBar` and `VolumeSlider` bar indicators
+- "Concurrent" modification of event handlers in `EventDispatcher` when a handler is unsubscribed by a handler
 
 ## [2.12.0]
 

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -124,7 +124,7 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
     // listeners are shifted within the array).
     // This means that listener x+1 will still be called if unsubscribed from within the handler of listener x, as well
     // as listener y+1 will not be called when subscribed from within the handler of listener y.
-    // Array.slice(0) is the fasted array copy method according to: https://stackoverflow.com/a/21514254/370252
+    // Array.slice(0) is the fastest array copy method according to: https://stackoverflow.com/a/21514254/370252
     const listeners = this.listeners.slice(0);
     for (let listener of listeners) {
       listener.fire(sender, args);

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -91,6 +91,7 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
    */
   unsubscribe(listener: EventListener<Sender, Args>): boolean {
     // Iterate through listeners, compare with parameter, and remove if found
+    // NOTE: In case we ever remove all matching listeners instead of just the first, we need to reverse-iterate here
     for (let i = 0; i < this.listeners.length; i++) {
       let subscribedListener = this.listeners[i];
       if (subscribedListener.listener === listener) {

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -118,7 +118,14 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
     let listenersToRemove = [];
 
     // Call every listener
-    for (let listener of this.listeners) {
+    // We iterate over a copy of the array of listeners to avoid the case where events are not fired on listeners when
+    // listeners are unsubscribed from within the event handlers during a dispatch (because the indices change and
+    // listeners are shifted within the array).
+    // This means that listener x+1 will still be called if unsubscribed from within the handler of listener x, as well
+    // as listener y+1 will not be called when subscribed from within the handler of listener y.
+    // Array.slice(0) is the fasted array copy method according to: https://stackoverflow.com/a/21514254/370252
+    const listeners = this.listeners.slice(0);
+    for (let listener of listeners) {
       listener.fire(sender, args);
 
       if (listener.isOnce()) {


### PR DESCRIPTION
In `EventDispatcher`, when an event listener with array index `y <= x` is unsubscribed from within the event handler with index `x`, then the event handler `x+1` is not called because it shifts back to index `x`. To fix this, the `dispatch` method now iterates over a copy of the list of event listeners to avoid the "concurrent" modification of the iterated list. `Array.slice(0)` is used to create a copy of the array which, according to benchmarks, is the most effective way to copy an array.