### PR TITLE
Consistent UI prepared-state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Changed
+- Consistent UI's prepared state detection by only looking at the player's ready state
+
 ## [2.12.1]
 
 ### Fixed
@@ -313,6 +318,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 - 2017-02-03
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.12.1...develop
 [2.12.1]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.12.0...v2.12.1
 [2.12.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.10.5...v2.11.0

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -13,10 +13,6 @@ export namespace PlayerUtils {
     FINISHED,
   }
 
-  export function isSourceLoaded(player: bitmovin.PlayerAPI): boolean {
-    return player.getConfig().source !== undefined;
-  }
-
   export function isTimeShiftAvailable(player: bitmovin.PlayerAPI): boolean {
     return player.isLive() && player.getMaxTimeShift() !== 0;
   }
@@ -28,7 +24,7 @@ export namespace PlayerUtils {
       return PlayerState.PLAYING;
     } else if (player.isPaused()) {
       return PlayerState.PAUSED;
-    } else if (isSourceLoaded(player)) {
+    } else if (player.isReady()) {
       return PlayerState.PREPARED;
     } else {
       return PlayerState.IDLE;


### PR DESCRIPTION
Depending on when the UI is loaded, it's either the `ON_READY` event (in the `UIContainer`) or the `getState` function that determines the state of the UI. `getState` checked if a source is loaded, which must not necessarily be the case when `isReady` === true, e.g. when a player is setup without a source. The UI state is initialized with `getState` but when an `ON_READY` event arrives afterwards, which happens when the UI is loaded before the player setup is finished, the UI changed into the `PREPARED` state, no matter if a source is loaded or not. If the UI is loaded later, it only changed into the `PREPARED` state if a source is actually loaded. This resulted in an inconsistent behavior, depending on when the UI is loaded. Now it's the `ON_READY` event and `isReady` flag (which are equivalent) which is used to determine the UI state, resulting in a consistent behavior.

This change is mainly required for the native SDKs.