### PR TITLE
Use ON_PLAYBACK_SPEED_CHANGED event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [development]
 
 ### Added
-- Subscribe to the `ON_PLAYBACK_SPEED_CHANGED` event to display the correct speed in the selector
+- Subscribe to the `ON_PLAYBACK_SPEED_CHANGED` event to display the correct speed in the `PlaybackSpeedSelectBox`
 
 ## [2.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Added
+- Subscribe to the `ON_PLAYBACK_SPEED_CHANGED` event to display the correct speed in the selector
+
 ## [2.13.0]
 
 ### Changed

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -32,7 +32,7 @@ export class PlaybackSpeedSelectBox extends SelectBox {
     player.addEventHandler(player.EVENT.ON_READY, setDefaultValue);
 
     if (player.EVENT.ON_PLAYBACK_SPEED_CHANGED) {
-      // Since player 7.7.0
+      // Since player 7.8.0
       player.addEventHandler(player.EVENT.ON_PLAYBACK_SPEED_CHANGED, setDefaultValue);
     }
   }

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -21,32 +21,27 @@ export class PlaybackSpeedSelectBox extends SelectBox {
       this.selectItem(value);
     });
 
-    let setDefaultValue = (): void => {
-      let playbackSpeed = String(player.getPlaybackSpeed());
-      if (!this.selectItem(playbackSpeed)) {
-        playbackSpeed = '1';
-        this.selectItem(playbackSpeed);
-      }
+    const setDefaultValue = (): void => {
+      const playbackSpeed = String(player.getPlaybackSpeed());
+      this.setSpeed(playbackSpeed);
     };
 
-    setDefaultValue();
-
-    // when the player hits onReady again, adjust the playback speed selection with fallback to default 1
+    // when the player hits onReady again, adjust the playback speed selection
     player.addEventHandler(player.EVENT.ON_READY, setDefaultValue);
 
     if (player.EVENT.ON_PLAYBACK_SPEED_CHANGED) {
       // Since player 7.7.0
-      player.addEventHandler(player.EVENT.ON_PLAYBACK_SPEED_CHANGED, () => {
-        const speed = String(player.getPlaybackSpeed());
+      player.addEventHandler(player.EVENT.ON_PLAYBACK_SPEED_CHANGED, setDefaultValue);
+    }
+  }
 
-        if (!this.selectItem(speed)) {
-          // a playback speed was set which is not in the list, add it to the list to show it to the user
-          this.clearItems();
-          this.addItem(speed, `${speed}x`);
-          this.addDefaultItems();
-          this.selectItem(speed);
-        }
-      });
+  setSpeed(speed: string): void {
+    if (!this.selectItem(speed)) {
+      // a playback speed was set which is not in the list, add it to the list to show it to the user
+      this.clearItems();
+      this.addItem(speed, `${speed}x`);
+      this.addDefaultItems();
+      this.selectItem(speed);
     }
   }
 

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -24,7 +24,7 @@ export class PlaybackSpeedSelectBox extends SelectBox {
     });
 
     const setDefaultValue = (): void => {
-      const playbackSpeed = String(player.getPlaybackSpeed());
+      const playbackSpeed = player.getPlaybackSpeed();
       this.setSpeed(playbackSpeed);
     };
 
@@ -37,16 +37,16 @@ export class PlaybackSpeedSelectBox extends SelectBox {
     }
   }
 
-  setSpeed(speed: string): void {
-    if (!this.selectItem(speed)) {
+  setSpeed(speed: number): void {
+    if (!this.selectItem(String(speed))) {
       // a playback speed was set which is not in the list, add it to the list to show it to the user
       this.clearItems();
-      this.addDefaultItems([Number(speed)]);
-      this.selectItem(speed);
+      this.addDefaultItems([speed]);
+      this.selectItem(String(speed));
     }
   }
 
-  addDefaultItems(customItems: number[] = []) {
+  addDefaultItems(customItems: number[] = []): void {
     const sortedSpeeds = this.defaultPlaybackSpeeds.concat(customItems).sort();
 
     sortedSpeeds.forEach(element => {
@@ -58,7 +58,7 @@ export class PlaybackSpeedSelectBox extends SelectBox {
     });
   }
 
-  clearItems() {
+  clearItems(): void {
     this.items = [];
     this.selectedItem = null;
   }

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -6,9 +6,11 @@ import {UIInstanceManager} from '../uimanager';
  * A select box providing a selection of different playback speeds.
  */
 export class PlaybackSpeedSelectBox extends SelectBox {
+  protected defaultPlaybackSpeeds: number[];
 
   constructor(config: ListSelectorConfig = {}) {
     super(config);
+    this.defaultPlaybackSpeeds = [0.25, 0.5, 1, 1.5, 2];
   }
 
   configure(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {
@@ -39,18 +41,21 @@ export class PlaybackSpeedSelectBox extends SelectBox {
     if (!this.selectItem(speed)) {
       // a playback speed was set which is not in the list, add it to the list to show it to the user
       this.clearItems();
-      this.addItem(speed, `${speed}x`);
-      this.addDefaultItems();
+      this.addDefaultItems([Number(speed)]);
       this.selectItem(speed);
     }
   }
 
-  addDefaultItems() {
-    this.addItem('0.25', '0.25x');
-    this.addItem('0.5', '0.5x');
-    this.addItem('1', 'Normal');
-    this.addItem('1.5', '1.5x');
-    this.addItem('2', '2x');
+  addDefaultItems(customItems: number[] = []) {
+    const sortedSpeeds = this.defaultPlaybackSpeeds.concat(customItems).sort();
+
+    sortedSpeeds.forEach(element => {
+      if (element !== 1) {
+        this.addItem(String(element), `${element}x`);
+      } else {
+        this.addItem(String(element), 'Normal');
+      }
+    });
   }
 
   clearItems() {

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -14,12 +14,7 @@ export class PlaybackSpeedSelectBox extends SelectBox {
   configure(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    this.addItem('0.25', '0.25x');
-    this.addItem('0.5', '0.5x');
-    this.addItem('1', 'Normal');
-    this.addItem('1.5', '1.5x');
-    this.addItem('2', '2x');
-
+    this.addDefaultItems();
 
     this.onItemSelected.subscribe((sender: PlaybackSpeedSelectBox, value: string) => {
       player.setPlaybackSpeed(parseFloat(value));
@@ -38,5 +33,33 @@ export class PlaybackSpeedSelectBox extends SelectBox {
 
     // when the player hits onReady again, adjust the playback speed selection with fallback to default 1
     player.addEventHandler(player.EVENT.ON_READY, setDefaultValue);
+
+    if (player.EVENT.ON_PLAYBACK_SPEED_CHANGED) {
+      // Since player 7.7.0
+      player.addEventHandler(player.EVENT.ON_PLAYBACK_SPEED_CHANGED, () => {
+        const speed = String(player.getPlaybackSpeed());
+
+        if (!this.selectItem(speed)) {
+          // a playback speed was set which is not in the list, add it to the list to show it to the user
+          this.clearItems();
+          this.addItem(speed, `${speed}x`);
+          this.addDefaultItems();
+          this.selectItem(speed);
+        }
+      });
+    }
+  }
+
+  addDefaultItems() {
+    this.addItem('0.25', '0.25x');
+    this.addItem('0.5', '0.5x');
+    this.addItem('1', 'Normal');
+    this.addItem('1.5', '1.5x');
+    this.addItem('2', '2x');
+  }
+
+  clearItems() {
+    this.items = [];
+    this.selectedItem = null;
   }
 }

--- a/src/ts/player-events.d.ts
+++ b/src/ts/player-events.d.ts
@@ -90,6 +90,7 @@ declare namespace bitmovin {
       ON_DESTROY: EVENT;
       ON_AD_BREAK_STARTED: EVENT;
       ON_AD_BREAK_FINISHED: EVENT;
+      ON_PLAYBACK_SPEED_CHANGED: EVENT;
     }
 
     interface PlayerEvent {
@@ -507,6 +508,11 @@ declare namespace bitmovin {
         row: number;
         column: number;
       };
+    }
+
+    interface PlaybackSpeedChangeEvent extends PlayerEvent {
+      from: number;
+      to: number;
     }
 
     interface PlayerEventCallback {


### PR DESCRIPTION
There was no event in the player to notify about playback speed changes. This event will be introduced in v7.7. The UI now listens to the event (if the player version supports it) and changes the selector accordingly.