### PR TITLE
Use on/off instead of addEventHandler/removeEventHandler when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [development]
 
 ### Added
-- Support for `on`/`off` replacing `addEventHandler`/`removeEventHandler` in player Version 8
+- Prefer `on`/`off` over `addEventHandler`/`removeEventHandler` with player version 7.8+ to avoid deprecation log messages
 
 ## [2.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Added
+- Support for `on`/`off` replacing `addEventHandler`/`removeEventHandler` in player Version 8
+
 ## [2.13.0]
 
 ### Changed

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -58,7 +58,7 @@ declare namespace bitmovin {
      * @param eventType The type of event to subscribe to.
      * @param callback The event callback handler that will be called when the event fires.
      *
-     * @deprecated since 7.7, use {@link PlayerAPI#on} instead
+     * @deprecated since 7.7, use {@link PlayerAPI.on} instead
      */
     addEventHandler(eventType: PlayerAPI.EVENT, callback: PlayerAPI.PlayerEventCallback): PlayerAPI;
     /**
@@ -338,7 +338,7 @@ declare namespace bitmovin {
      * @param eventType The event to remove the handler from
      * @param callback The callback handler to remove
      *
-     * @deprecated since 7.7, use {@link PlayerAPI#off} instead
+     * @deprecated since 7.7, use {@link PlayerAPI.off} instead
      */
     // TODO remove string type option (this is a temporary hack for PlayerWrapper#clearEventHandlers)
     removeEventHandler(eventType: PlayerAPI.EVENT | string, callback: PlayerAPI.PlayerEventCallback): PlayerAPI;

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -57,8 +57,19 @@ declare namespace bitmovin {
      *
      * @param eventType The type of event to subscribe to.
      * @param callback The event callback handler that will be called when the event fires.
+     *
+     * @deprecated since 7.7, use {@link PlayerAPI#on} instead
      */
     addEventHandler(eventType: PlayerAPI.EVENT, callback: PlayerAPI.PlayerEventCallback): PlayerAPI;
+    /**
+     * Subscribes an event handler to a player event.
+     *
+     * @param eventType The type of event to subscribe to.
+     * @param callback The event callback handler that will be called when the event fires.
+     *
+     * @since v7.7
+     */
+    on(eventType: PlayerAPI.EVENT, callback: PlayerAPI.PlayerEventCallback): PlayerAPI;
     /**
      * Sends custom metadata to Bitmovin's Cast receiver app.
      *
@@ -326,9 +337,20 @@ declare namespace bitmovin {
      *
      * @param eventType The event to remove the handler from
      * @param callback The callback handler to remove
+     *
+     * @deprecated since 7.7, use {@link PlayerAPI#off} instead
      */
     // TODO remove string type option (this is a temporary hack for PlayerWrapper#clearEventHandlers)
     removeEventHandler(eventType: PlayerAPI.EVENT | string, callback: PlayerAPI.PlayerEventCallback): PlayerAPI;
+    /**
+     * Removes a handler for a player event.
+     *
+     * @param eventType The event to remove the handler from
+     * @param callback The callback handler to remove
+     *
+     * @since v7.7
+     */
+    off(eventType: PlayerAPI.EVENT | string, callback: PlayerAPI.PlayerEventCallback): PlayerAPI;
     /**
      * Removes the existing subtitle/caption track with the track ID specified by trackID. If the track is
      * currently active, it will be deactivated and then removed. If no track with the given ID exists,

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -54,11 +54,10 @@ declare namespace bitmovin {
   interface PlayerAPI {
     /**
      * Subscribes an event handler to a player event.
+     * This will be replaced by {@link PlayerAPI.on} in version 8
      *
      * @param eventType The type of event to subscribe to.
      * @param callback The event callback handler that will be called when the event fires.
-     *
-     * @deprecated since 7.7, use {@link PlayerAPI.on} instead
      */
     addEventHandler(eventType: PlayerAPI.EVENT, callback: PlayerAPI.PlayerEventCallback): PlayerAPI;
     /**
@@ -334,11 +333,10 @@ declare namespace bitmovin {
     play(issuer?: string): PlayerAPI;
     /**
      * Removes a handler for a player event.
+     * This will be replaced by {@link PlayerAPI.off} in version 8
      *
      * @param eventType The event to remove the handler from
      * @param callback The callback handler to remove
-     *
-     * @deprecated since 7.7, use {@link PlayerAPI.off} instead
      */
     // TODO remove string type option (this is a temporary hack for PlayerWrapper#clearEventHandlers)
     removeEventHandler(eventType: PlayerAPI.EVENT | string, callback: PlayerAPI.PlayerEventCallback): PlayerAPI;

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -1118,7 +1118,13 @@ class PlayerWrapper {
 
     // Explicitly add a wrapper method for 'addEventHandler' that adds added event handlers to the event list
     wrapper.addEventHandler = (eventType: EVENT, callback: PlayerEventCallback) => {
-      player.addEventHandler(eventType, callback);
+      // in player V8 addEventHandler was replaced by on
+      if (player.on) {
+        (player as any).on(eventType, callback);
+      } else {
+        // keep backward compatibility for versions <7.7
+        player.addEventHandler(eventType, callback);
+      }
 
       if (!this.eventHandlers[eventType]) {
         this.eventHandlers[eventType] = [];
@@ -1131,7 +1137,12 @@ class PlayerWrapper {
 
     // Explicitly add a wrapper method for 'removeEventHandler' that removes removed event handlers from the event list
     wrapper.removeEventHandler = (eventType: EVENT, callback: PlayerEventCallback) => {
-      player.removeEventHandler(eventType, callback);
+      if (player.off) {
+        player.off(eventType, callback);
+      } else {
+        // keep backward compatibility for versions <7.7
+        player.removeEventHandler(eventType, callback);
+      }
 
       if (this.eventHandlers[eventType]) {
         ArrayUtils.remove(this.eventHandlers[eventType], callback);

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -1120,7 +1120,7 @@ class PlayerWrapper {
     wrapper.addEventHandler = (eventType: EVENT, callback: PlayerEventCallback) => {
       // in player V8 addEventHandler was replaced by on
       if (player.on) {
-        (player as any).on(eventType, callback);
+        player.on(eventType, callback);
       } else {
         // keep backward compatibility for versions <7.7
         player.addEventHandler(eventType, callback);


### PR DESCRIPTION
Since Player Version 7.7 add/removeEventHandler are deprecated. This PR introduces the adaptation to the new on + off methods while keeping a fallback to the old functionality to stay compatible with older versions