### PR TITLE
fix blocked autoplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ License change from LGPLv3 to MIT.
 - Prefer `on`/`off` over `addEventHandler`/`removeEventHandler` with player version 7.8+ to avoid deprecation log messages
 - `data-bmpui-volume-level-tens` attribute on `VolumeToggleButton` for more granular styling of the volume icon
 - `onClass`/`offClass` configuration properties in `ToggleButtonConfig` to allow customizing the state marker CSS class names
-- handling for blocked autoplay in the `hugeplaybacktogglebutton`
 
 ### Changed
 - Removed `bmpui-low` marker class from `VolumeToggleButton` (replaced by `data-bmpui-volume-level-tens` attribute)
@@ -25,6 +24,7 @@ License change from LGPLv3 to MIT.
 ### Fixed
 - Initialize `ToggleButton` state at UI configuration
 - `SettingsPanel` attempted to check `isActive` on non-`SettingsPanelItem` components (e.g. `CloseButton`)
+- User interaction passthrough from `HugePlaybackToggleButton` to player when autoplay is blocked
 
 ## [2.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ License change from LGPLv3 to MIT.
 - Prefer `on`/`off` over `addEventHandler`/`removeEventHandler` with player version 7.8+ to avoid deprecation log messages
 - `data-bmpui-volume-level-tens` attribute on `VolumeToggleButton` for more granular styling of the volume icon
 - `onClass`/`offClass` configuration properties in `ToggleButtonConfig` to allow customizing the state marker CSS class names
+- handling for blocked autoplay in the `hugeplaybacktogglebutton`
 
 ### Changed
 - Removed `bmpui-low` marker class from `VolumeToggleButton` (replaced by `data-bmpui-volume-level-tens` attribute)

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -103,9 +103,9 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
       firstPlay = false;
     });
 
-    player.addEventHandler(player.EVENT.ON_WARNING, (ev: WarningEvent) => {
+    player.addEventHandler(player.EVENT.ON_WARNING, (event: WarningEvent) => {
       // 5008 == Playback could not be started
-      if (ev.code === 5008) {
+      if (event.code === 5008) {
         // if playback could not be started, reset the first play flag as we need the user interaction to start
         firstPlay = true;
       }

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -3,6 +3,7 @@ import {PlaybackToggleButton} from './playbacktogglebutton';
 import {DOM} from '../dom';
 import {UIInstanceManager} from '../uimanager';
 import PlayerEvent = bitmovin.PlayerAPI.PlayerEvent;
+import WarningEvent = bitmovin.PlayerAPI.WarningEvent;
 
 /**
  * A button that overlays the video and toggles between playback and pause.
@@ -100,6 +101,14 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
     player.addEventHandler(player.EVENT.ON_PLAY, () => {
       // Playback has really started, we can disable the flag to switch to normal toggle button handling
       firstPlay = false;
+    });
+
+    player.addEventHandler(player.EVENT.ON_WARNING, (ev: WarningEvent) => {
+      // 5008 == Playback could not be started
+      if (ev.code === 5008) {
+        // if playback could not be started, reset the first play flag as we need the user interaction to start
+        firstPlay = true;
+      }
     });
 
     // Hide button while initializing a Cast session

--- a/src/ts/player-events.d.ts
+++ b/src/ts/player-events.d.ts
@@ -163,6 +163,17 @@ declare namespace bitmovin {
       message: string;
     }
 
+    interface WarningEvent extends PlayerEvent {
+      /**
+       * The error code used to identify the occurred error
+       */
+      code: number;
+      /**
+       * The error message to explain the reason for the error
+       */
+      message: string;
+    }
+
     interface AudioChangedEvent extends PlaybackEvent {
       /**
        * Previous audio track


### PR DESCRIPTION
When a play call was tried but blocked due to disabled autoplay on some devices the `play` event would be fired, but the player would never transition into playing. This breaks the hugeplaybacktogglebutton as it only waits for the first `play` event to start the the waiting for a potential double click for potential fullscreen handling. This handling destroys the user interaction needed for the play call to succeed.

As a fix we now reset this first play flag on an `onWarning` event to use the first click as a user interaction to call play.

