### PR TITLE
Fix seekbar in Android 4.4 WebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ License change from LGPLv3 to MIT.
 - Initialize `ToggleButton` state at UI configuration
 - `SettingsPanel` attempted to check `isActive` on non-`SettingsPanelItem` components (e.g. `CloseButton`)
 - User interaction passthrough from `HugePlaybackToggleButton` to player when autoplay is blocked
+- `SeekBar` bar levels and scrubber positioning in Android 4.4 WebView
 
 ## [2.13.0]
 

--- a/src/scss/skin-legacy/components/_seekbar.scss
+++ b/src/scss/skin-legacy/components/_seekbar.scss
@@ -26,6 +26,7 @@
     %bar {
       // sass-lint:disable no-vendor-prefixes
       -ms-transform-origin: 0 0; // required for IE9
+      -webkit-transform-origin: 0 0; // required for Android 4.4 WebView
       bottom: 0;
       left: 0;
       position: absolute;

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -21,6 +21,7 @@
     %bar {
       // sass-lint:disable no-vendor-prefixes
       -ms-transform-origin: 0 0; // required for IE9
+      -webkit-transform-origin: 0 0; // required for Android 4.4 WebView
       bottom: 0;
       height: $bar-height;
       left: 0;

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -731,8 +731,17 @@ export class SeekBar extends Component<SeekBarConfig> {
     }
     let style = this.config.vertical ?
       // -ms-transform required for IE9
-      { 'transform': 'translateY(' + px + 'px)', '-ms-transform': 'translateY(' + px + 'px)' } :
-      { 'transform': 'translateX(' + px + 'px)', '-ms-transform': 'translateX(' + px + 'px)' };
+      // -webkit-transform required for Android 4.4 WebView
+      {
+        'transform': 'translateY(' + px + 'px)',
+        '-ms-transform': 'translateY(' + px + 'px)',
+        '-webkit-transform': 'translateY(' + px + 'px)',
+      } :
+      {
+        'transform': 'translateX(' + px + 'px)',
+        '-ms-transform': 'translateX(' + px + 'px)',
+        '-webkit-transform': 'translateX(' + px + 'px)',
+      };
     this.seekBarPlaybackPositionMarker.css(style);
   }
 
@@ -780,8 +789,17 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     let style = this.config.vertical ?
       // -ms-transform required for IE9
-      { 'transform': 'scaleY(' + scale + ')', '-ms-transform': 'scaleY(' + scale + ')' } :
-      { 'transform': 'scaleX(' + scale + ')', '-ms-transform': 'scaleX(' + scale + ')' };
+      // -webkit-transform required for Android 4.4 WebView
+      {
+        'transform': 'scaleY(' + scale + ')',
+        '-ms-transform': 'scaleY(' + scale + ')',
+        '-webkit-transform': 'scaleY(' + scale + ')',
+      } :
+      {
+        'transform': 'scaleX(' + scale + ')',
+        '-ms-transform': 'scaleX(' + scale + ')',
+        '-webkit-transform': 'scaleY(' + scale + ')',
+      };
     element.css(style);
   }
 


### PR DESCRIPTION
Missing `-webkit` prefixes on `transform` properties led to a dysfunctional `SeekBar` in Android 4.4's `WebView` (which is based on an old `WebKit` engine).