### PR TITLE
Add API to switch UI variants

### DIFF
--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -314,10 +314,19 @@ export class UIManager {
     return this.config;
   }
 
+  /**
+   * Returns the list of UI variants as passed into the constructor of {@link UIManager}.
+   * @returns {UIVariant[]} the list of available UI variants
+   */
   getUiVariants(): UIVariant[] {
     return this.uiVariants;
   }
 
+  /**
+   * Switches to a UI variant from the list returned by {@link getUiVariants}.
+   * @param {UIVariant} uiVariant the UI variant to switch to
+   * @param {() => void} onShow a callback that is executed just before the new UI variant is shown
+   */
   switchToUiVariant(uiVariant: UIVariant, onShow?: () => void): void {
     let uiVariantIndex = this.uiVariants.indexOf(uiVariant);
 
@@ -358,6 +367,14 @@ export class UIManager {
     }
   }
 
+  /**
+   * Triggers a UI variant switch as triggered by events when automatic switching is enabled. It allows to overwrite
+   * properties of the {@link UIConditionContext}.
+   * @param {Partial<UIConditionContext>} context an optional set of properties that overwrite properties of the
+   *   automatically determined context
+   * @param {(context: UIConditionContext) => void} onShow a callback that is executed just before the new UI variant
+   *   is shown (if a switch is happening)
+   */
   resolveUiVariant(context: Partial<UIConditionContext> = {}, onShow?: (context: UIConditionContext) => void): void {
     // Determine the current context for which the UI variant will be resolved
     const defaultContext: UIConditionContext = {
@@ -436,7 +453,8 @@ export class UIManager {
   }
 
   /**
-   * Fires just before UI variants are about to be resolved and the UI variant is possibly switched.
+   * Fires just before UI variants are about to be resolved and the UI variant is possibly switched. It is fired when
+   * the switch is triggered from an automatic switch and when calling {@link resolveUiVariant}.
    * Can be used to modify the {@link UIConditionContext} before resolving is done.
    * @returns {EventDispatcher<UIManager, UIConditionContext>}
    */

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -75,6 +75,13 @@ export interface UIConfig {
     markers?: TimelineMarker[];
   };
   recommendations?: UIRecommendationConfig[];
+  /**
+   * Specifies if the UI variants should be resolved and switched automatically upon certain player events. The default
+   * is `true`. Should be set to `false` if purely manual switching through {@link UIManager.resolveUiVariant} is
+   * desired. A hybrid approach can be used by setting this to `true` (or leaving the default) and overriding
+   * automatic switches through a {@link UIManager.onUiVariantResolve} event handler.
+   */
+  autoUiVariantResolve?: boolean;
 }
 
 /**
@@ -225,6 +232,11 @@ export class UIManager {
       throw Error('Invalid UI variant order: the default UI (without condition) must be at the end of the list');
     }
 
+    // Switch on auto UI resolving by default
+    if (config.autoUiVariantResolve === undefined) {
+      config.autoUiVariantResolve = true;
+    }
+
     let adStartedEvent: AdStartedEvent = null; // keep the event stored here during ad playback
 
     // Dynamically select a UI variant that matches the current UI condition.
@@ -281,16 +293,18 @@ export class UIManager {
     };
 
     // Listen to the following events to trigger UI variant resolution
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_READY, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_PLAY, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_PAUSED, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_AD_STARTED, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_AD_FINISHED, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_AD_SKIPPED, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_AD_ERROR, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_PLAYER_RESIZE, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_FULLSCREEN_ENTER, resolveUiVariant);
-    this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_FULLSCREEN_EXIT, resolveUiVariant);
+    if (config.autoUiVariantResolve) {
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_READY, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_PLAY, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_PAUSED, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_AD_STARTED, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_AD_FINISHED, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_AD_SKIPPED, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_AD_ERROR, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_PLAYER_RESIZE, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_FULLSCREEN_ENTER, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_FULLSCREEN_EXIT, resolveUiVariant);
+    }
 
     // Initialize the UI
     resolveUiVariant(null);

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -144,6 +144,10 @@ export class UIManager {
   private config: UIConfig;
   private managerPlayerWrapper: PlayerWrapper;
 
+  private events = {
+    onUiVariantResolve: new EventDispatcher<UIManager, UIConditionContext>(),
+  };
+
   /**
    * Creates a UI manager with a single UI variant that will be permanently shown.
    * @param player the associated player of this UI
@@ -312,6 +316,9 @@ export class UIManager {
     // Overwrite properties of the default context with passed in context properties
     const switchingContext = { ...defaultContext, ...context };
 
+    // Fire the event and allow modification of the context before it is used to resolve the UI variant
+    this.events.onUiVariantResolve.dispatch(this, switchingContext);
+
     let nextUi: InternalUIInstanceManager = null;
     let uiVariantChanged = false;
 
@@ -396,6 +403,15 @@ export class UIManager {
       this.releaseUi(uiInstanceManager);
     }
     this.managerPlayerWrapper.clearEventHandlers();
+  }
+
+  /**
+   * Fires just before UI variants are about to be resolved and the UI variant is possibly switched.
+   * Can be used to modify the {@link UIConditionContext} before resolving is done.
+   * @returns {EventDispatcher<UIManager, UIConditionContext>}
+   */
+  get onUiVariantResolve(): EventDispatcher<UIManager, UIConditionContext> {
+    return this.events.onUiVariantResolve;
   }
 }
 


### PR DESCRIPTION
Implements #101 and provides multiple ways to switch between UI variants via the public `UIManager` API:

```ts
interface UIConfig {
  /** 
   * A configuration flag that allows to turn off automatic UI variant switching to allow purely 
   * externally triggered switching through `resolveUiVariant` and/or directly through 
   * `switchToUiVariant` (default `true`)
   */
  autoUiVariantResolve?: boolean;
}

class UIManager {
  /**
   * An event that is triggered just before the next UI variant is resoved and the UI variant 
   * is switched. It is fired when the switch is triggered from an automatic switch and when 
   * calling `resolveUiVariant` and can be used to modify the `UIConditionContext` before 
   * the UI variant is resoved.
   */
  onUiVariantResolve: EventDispatcher<UIManager, UIConditionContext>;

  /*
   * Returns the list of UI variants as passed into the constructor of `UIManager`.
   */
  getUiVariants(): UIVariant[];
  /*
   * Switches to a passed in UI variant taken from the list returned by `getUiVariants()`.
   */
  switchToUiVariant(uiVariant: UIVariant): void;
  /*
   * Triggers a UI variant switch according to the current `UIConditionContext` and allows 
   * to overwrite internal context properties.
   */
  resolveUiVariant(context: Partial<UIConditionContext> = {}): void;
}
```

## Examples

All the following examples can be combined in all kinds of combinations. Im many cases it will make sense to disable automatic switching and handle the switching purely through the API with `switchToUiVariant`, but there might be cases where automatic switching is wanted but certain modifications in the behavior are desired. In the latter case it makes sense to combine `resolveUiVariant` and/or `switchToUiVariant` with `onUiVariantResolve`.

```ts
const uiConfig: UIConfig = {};

const uiManager = new UIManager(player, [{
  // Add a UI variant for ads
  ui: buildAdsUi(),
  condition: (context: UIConditionContext) => {
    return context.isAd;
  },
}, {
  // Add a UI variant for the main content
  ui: buildDefaultUi(),
}], uiConfig);
```

### Example 1: Modify automatic switches

```ts
uiManager.onUiVariantResolve.subscribe((sender, context) => {
  // Avoid switching to the ads UI depending on our custom `preventAdsUi` flag
  if (context.isAd && preventAdsUi === true) {
    context.isAd = false;
  }
});
```

### Example 2: Trigger a switch
```ts
// Switch to the ads UI independently from the content and player events
// This will reset as soon as any monitored player event is fired (e.g. `ON_PAUSED`)
uiManager.resolveUiVariant({ isAd: true });
```

### Example 3: Disable automatic switching and trigger a switch by player events
```ts
// Disable automatic switching
uiConfig = {
  autoUiVariantResolve: false,
};

// Show ads UI when ad starts
player.addEventHandler(player.EVENT.ON_AD_STARTED, () => {
  uiManager.resolveUiVariant({ isAd: true });
});

// Switch back to default UI when ad is finished
player.addEventHandler(player.EVENT.ON_AD_FINISHED, () => {
  uiManager.resolveUiVariant({ isAd: true });
});
```

### Example 4: Switch directly to desired variant

```ts
const myUiVariants = uiManager.getUiVariants();
// We know the index because we have defined the UI variant list and passed it into the UIManager
const myAdsUiVariant = myUiVariants[0];

// Show ads UI when ad starts
player.addEventHandler(player.EVENT.ON_AD_STARTED, () => {
  uiManager.switchToUiVariant(myAdsUiVariant);
});
```