### PR TITLE
Animate HugePlaybackToggleButton only on state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Changed
+- Animate `HugePlaybackToggleButton` only on state changes (not when UI is initially loaded)
+
 ## [2.15.0]
 
 ### Added
@@ -346,6 +351,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 - 2017-02-03
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.15.0...develop
 [2.15.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.14.0...v2.15.0
 [2.14.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.13.0...v2.14.0
 [2.13.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.12.1...v2.13.0

--- a/src/scss/skin-legacy/components/_hugeplaybacktogglebutton.scss
+++ b/src/scss/skin-legacy/components/_hugeplaybacktogglebutton.scss
@@ -58,4 +58,14 @@
       visibility: visible;
     }
   }
+
+  &.#{$prefix}-no-transition-animations {
+    &.#{$prefix}-on,
+    &.#{$prefix}-off {
+      .#{$prefix}-image {
+        animation: none;
+        transition: none;
+      }
+    }
+  }
 }

--- a/src/scss/skin-modern/components/_hugeplaybacktogglebutton.scss
+++ b/src/scss/skin-modern/components/_hugeplaybacktogglebutton.scss
@@ -71,4 +71,14 @@
       visibility: visible;
     }
   }
+
+  &.#{$prefix}-no-transition-animations {
+    &.#{$prefix}-on,
+    &.#{$prefix}-off {
+      .#{$prefix}-image {
+        animation: none;
+        transition: none;
+      }
+    }
+  }
 }

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -139,4 +139,19 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
 
     return buttonElement;
   }
+
+  /**
+   * Enables or disables the play state transition animations of the play button image. Can be used to suppress
+   * animations.
+   * @param {boolean} enabled true to enable the animations (default), false to disable them
+   */
+  protected setTransitionAnimationsEnabled(enabled: boolean): void {
+    const noTransitionAnimationsClass = this.prefixCss('no-transition-animations');
+
+    if (enabled) {
+      this.getDomElement().removeClass(noTransitionAnimationsClass);
+    } else if (!this.getDomElement().hasClass(noTransitionAnimationsClass)) {
+      this.getDomElement().addClass(noTransitionAnimationsClass);
+    }
+  }
 }

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -124,6 +124,14 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
     player.addEventHandler(player.EVENT.ON_CAST_START, castInitializationHandler);
     player.addEventHandler(player.EVENT.ON_CAST_STARTED, castInitializationHandler);
     player.addEventHandler(player.EVENT.ON_CAST_STOPPED, castInitializationHandler);
+
+    // Hide the play button animation when the UI is loaded (it should only be animated on state changes)
+    this.setTransitionAnimationsEnabled(false);
+
+    // Enable the transition animations when the play state changes for the first time
+    this.onToggle.subscribeOnce(() => {
+      this.setTransitionAnimationsEnabled(true);
+    });
   }
 
   protected toDomElement(): DOM {


### PR DESCRIPTION
Implements #107

This does not work in all cases because it depends on when the UI is initialized and which events from the player it receives. It works in some cases though, so it's an improvement for some users.