### PR TITLE
Hide hovered select boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Consolidated configuration management of `UIConfig` from components into `UIManager`
 - Configuration from the player source now takes precedence over the configuration passed into the `UIManager`
 
+### Fixed
+- IE & Firefox could leave active/hovered select boxes floating after the parent container was hidden.
+
 ## [2.15.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Configuration from the player source now takes precedence over the configuration passed into the `UIManager`
 
 ### Fixed
-- IE & Firefox could leave active/hovered select boxes floating after the parent container was hidden.
+- IE & Firefox could leave the dropdown panel of an active/hovered `SelectBox` floating after the parent container was hidden.
 
 ## [2.15.0]
 

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -50,6 +50,7 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
     if (config.hideDelay > -1) {
       this.hideTimeout = new Timeout(config.hideDelay, () => {
         this.hide();
+        this.hideHoveredSelectBoxes();
       });
 
       this.onShow.subscribe(() => {
@@ -89,6 +90,31 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
     for (let component of this.getItems()) {
       component.onActiveChanged.subscribe(settingsStateChangedHandler);
     }
+  }
+
+  /**
+   * Hack for IE + Firefox
+   * when the settings panel fades out while an item of a select box is still hovered, the select box will not fade out
+   * while the settings panel does. This would leave a floating select box, which is just weird
+   */
+  private hideHoveredSelectBoxes() {
+    this.getItems().forEach((item: SettingsPanelItem) => {
+      if (item.isActive()) {
+        if ((item as any).setting instanceof SelectBox) {
+          const selBox: HTMLElement = (item as any).setting.getDomElement().get()[0];
+          const oldDisplay = selBox.style.display;
+          // updating the display to none marks the select-box as inactive, so it will be hidden with the rest
+          // we just have to make sure to reset this as soon as possible
+          selBox.style.display = 'none';
+          if (window.requestAnimationFrame) {
+            requestAnimationFrame(() => { selBox.style.display = oldDisplay; });
+          } else {
+            // IE9 has no requestAnimationFrame, just use setTimeout(0)
+            setTimeout(() => { selBox.style.display = oldDisplay; }, 0);
+          }
+        }
+      }
+    });
   }
 
   release(): void {

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -99,19 +99,18 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
    */
   private hideHoveredSelectBoxes() {
     this.getItems().forEach((item: SettingsPanelItem) => {
-      if (item.isActive()) {
-        if ((item as any).setting instanceof SelectBox) {
-          const selBox: HTMLElement = (item as any).setting.getDomElement().get()[0];
-          const oldDisplay = selBox.style.display;
-          // updating the display to none marks the select-box as inactive, so it will be hidden with the rest
-          // we just have to make sure to reset this as soon as possible
-          selBox.style.display = 'none';
-          if (window.requestAnimationFrame) {
-            requestAnimationFrame(() => { selBox.style.display = oldDisplay; });
-          } else {
-            // IE9 has no requestAnimationFrame, just use setTimeout(0)
-            setTimeout(() => { selBox.style.display = oldDisplay; }, 0);
-          }
+      if (item.isActive() && (item as any).setting instanceof SelectBox) {
+        const selectBox = (item as any).setting as SelectBox;
+        const oldDisplay = selectBox.getDomElement().css('display');
+        // updating the display to none marks the select-box as inactive, so it will be hidden with the rest
+        // we just have to make sure to reset this as soon as possible
+        selectBox.getDomElement().css('display', 'none');
+        if (window.requestAnimationFrame) {
+          requestAnimationFrame(() => { selectBox.getDomElement().css('display', oldDisplay); });
+        } else {
+          // IE9 has no requestAnimationFrame, set the value directly. It has no optimization about ignoring DOM-changes
+          // between animationFrames
+          selectBox.getDomElement().css('display', oldDisplay);
         }
       }
     });


### PR DESCRIPTION
## Problem
When a select box was hovered, but the mouse pointer went outside the screen (without clicking to release the hover selection), select boxes of the `SettingsPanel` would not get hidden with the rest of the panel, but rather floated around without a visible parent. In IE11 the items itself would then even hide when they were hovered again which made things even worse.

## Fix
When hiding the `SettingsPanel` set the visibility to `none` for a very short time to remove the elements active/hovered state