### PR TITLE
Add filter & translator functions to ListSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `UIManager` API to dynamically manage `SeekBar` markers: `getTimelineMarkers`, `addTimelineMarker`, `removeTimelineMarker` ([#103](https://github.com/bitmovin/bitmovin-player-ui/issues/103))
 - Interval marking with added property `TimelineMarker.duration` ([#103](https://github.com/bitmovin/bitmovin-player-ui/issues/103))
 - Custom CSS classes on markers in `SeekBar` and `SeekBarLabel` through `TimelineMarker.cssClasses` ([#103](https://github.com/bitmovin/bitmovin-player-ui/issues/103))
+- `ListSelectorConfig.filter` to filter items of auto-populated `SelectBox` implementations, e.g. `SubtitleSelectBox`
+- `ListSelectorConfig.translator` to translate item labels of auto-populated `SelectBox` implementations, e.g. `SubtitleSelectBox`
 
 ### Changed
 - Animate `HugePlaybackToggleButton` only on state changes (not when UI is initially loaded)

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -13,9 +13,8 @@ export interface ListItem {
 /**
  * Filter function that can be used to filter out list items added through {@link ListSelector.addItem}.
  *
- * Using this does not make a lot of sense when items are added from outside because the added items can be
- * controlled anyway, but it does make sense to be used in conjunction with subclasses that populate
- * themselves automatically via the player API, e.g. {@link SubtitleSelectBox}.
+ * This is intended to be used in conjunction with subclasses that populate themselves automatically
+ * via the player API, e.g. {@link SubtitleSelectBox}.
  */
 export interface ListItemFilter {
   /**
@@ -29,9 +28,8 @@ export interface ListItemFilter {
 /**
  * Translator function to translate labels of list items added through {@link ListSelector.addItem}.
  *
- * Using this does not make a lot of sense when items are added from outside because the added items can be
- * controlled anyway, but it does make sense to be used in conjunction with subclasses that populate
- * themselves automatically via the player API, e.g. {@link SubtitleSelectBox}.
+ * This is intended to be used in conjunction with subclasses that populate themselves automatically
+ * via the player API, e.g. {@link SubtitleSelectBox}.
  */
 export interface ListItemLabelTranslator {
   /**

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -27,6 +27,22 @@ export interface ListItemFilter {
 }
 
 /**
+ * Translator function to translate labels of list items added through {@link ListSelector.addItem}.
+ *
+ * Using this does not make a lot of sense when items are added from outside because the added items can be
+ * controlled anyway, but it does make sense to be used in conjunction with subclasses that populate
+ * themselves automatically via the player API, e.g. {@link SubtitleSelectBox}.
+ */
+export interface ListItemLabelTranslator {
+  /**
+   * Takes a list item, optionally changes the label, and returns the new label.
+   * @param {ListItem} listItem the item to translate
+   * @returns {string} the translated or original label
+   */
+  (listItem: ListItem): string;
+}
+
+/**
  * Configuration interface for a {@link ListSelector}.
  */
 export interface ListSelectorConfig extends ComponentConfig {

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -81,8 +81,15 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    * @param label the (human-readable) label of the item to add
    */
   addItem(key: string, label: string) {
+    const listItem = { key: key, label: label };
+
+    // Apply filter function
+    if (this.config.filter && !this.config.filter(listItem)) {
+      return;
+    }
+
     this.removeItem(key); // Try to remove key first to get overwrite behavior and avoid duplicate keys
-    this.items.push({ key: key, label: label });
+    this.items.push(listItem);
     this.onItemAddedEvent(key);
   }
 

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -105,6 +105,11 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
       return;
     }
 
+    // Apply translator function
+    if (this.config.translator) {
+      listItem.label = this.config.translator(listItem);
+    }
+
     this.removeItem(key); // Try to remove key first to get overwrite behavior and avoid duplicate keys
     this.items.push(listItem);
     this.onItemAddedEvent(key);

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -11,6 +11,22 @@ export interface ListItem {
 }
 
 /**
+ * Filter function that can be used to filter out list items added through {@link ListSelector.addItem}.
+ *
+ * Using this does not make a lot of sense when items are added from outside because the added items can be
+ * controlled anyway, but it does make sense to be used in conjunction with subclasses that populate
+ * themselves automatically via the player API, e.g. {@link SubtitleSelectBox}.
+ */
+export interface ListItemFilter {
+  /**
+   * Takes a list item and decides whether it should pass or be discarded.
+   * @param {ListItem} listItem the item to apply the filter to
+   * @returns {boolean} true to let the item pass through the filter, false to discard the item
+   */
+  (listItem: ListItem): boolean;
+}
+
+/**
  * Configuration interface for a {@link ListSelector}.
  */
 export interface ListSelectorConfig extends ComponentConfig {

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -31,6 +31,7 @@ export interface ListItemFilter {
  */
 export interface ListSelectorConfig extends ComponentConfig {
   items?: ListItem[];
+  filter?: ListItemFilter;
 }
 
 export abstract class ListSelector<Config extends ListSelectorConfig> extends Component<ListSelectorConfig> {

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -48,6 +48,7 @@ export interface ListItemLabelTranslator {
 export interface ListSelectorConfig extends ComponentConfig {
   items?: ListItem[];
   filter?: ListItemFilter;
+  translator?: ListItemLabelTranslator;
 }
 
 export abstract class ListSelector<Config extends ListSelectorConfig> extends Component<ListSelectorConfig> {


### PR DESCRIPTION
Adds `ListSelectorConfig.filter` and `ListSelectorConfig.translator` to allow filtering items and translating labels of items added through `ListSelector.addItem`. 

While this does not seem to make a lot of sense in situations where the programmer has control over what is added via `addItem`, it is very useful for subclasses that automatically populate themselves (`SubtitleSelectBox`, `AudioTrackSelectBox`, ...), where no control over the added items was possible until now:

```ts
new SubtitleSelectBox({
  // Filter out all French subtitles (sorry my French friends, we still like you!)
  filter: (listItem) => listItem.key !== 'fr' && !listItem.label.includes('Fran'),

  // Translate the Spanish label but no other
  translator: (listItem) => {
    if (listItem.key === 'es') {
      return 'Aiaiai!';
    }
    return listItem.label;
  },
})
```