### PR TITLE
Hide hovered select boxes when the whole UI hides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Apply the IE/Firefox workaround for a hovered dropdown panel of a  `SelectBox` on the `onControlsHide` event too
+
 ## [2.16.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Fixed
-- Apply the IE/Firefox workaround for a hovered dropdown panel of a  `SelectBox` on the `onControlsHide` event too
+- Apply the IE/Firefox workaround for a hovered dropdown panel of a `SelectBox` when the UI hides
 
 ## [2.16.0]
 

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -53,6 +53,8 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
         this.hideHoveredSelectBoxes();
       });
 
+      uimanager.onControlsHide.subscribe(this.hideHoveredSelectBoxes);
+
       this.onShow.subscribe(() => {
         // Activate timeout when shown
         this.hideTimeout.start();
@@ -97,7 +99,7 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
    * when the settings panel fades out while an item of a select box is still hovered, the select box will not fade out
    * while the settings panel does. This would leave a floating select box, which is just weird
    */
-  private hideHoveredSelectBoxes() {
+  private hideHoveredSelectBoxes = () => {
     this.getItems().forEach((item: SettingsPanelItem) => {
       if (item.isActive() && (item as any).setting instanceof SelectBox) {
         const selectBox = (item as any).setting as SelectBox;
@@ -114,7 +116,7 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
         }
       }
     });
-  }
+  };
 
   release(): void {
     super.release();

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -47,13 +47,13 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
 
     let config = <SettingsPanelConfig>this.getConfig(); // TODO fix generics type inference
 
+    uimanager.onControlsHide.subscribe(() => this.hideHoveredSelectBoxes());
+
     if (config.hideDelay > -1) {
       this.hideTimeout = new Timeout(config.hideDelay, () => {
         this.hide();
         this.hideHoveredSelectBoxes();
       });
-
-      uimanager.onControlsHide.subscribe(this.hideHoveredSelectBoxes);
 
       this.onShow.subscribe(() => {
         // Activate timeout when shown
@@ -99,7 +99,7 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
    * when the settings panel fades out while an item of a select box is still hovered, the select box will not fade out
    * while the settings panel does. This would leave a floating select box, which is just weird
    */
-  private hideHoveredSelectBoxes = () => {
+  private hideHoveredSelectBoxes(): void {
     this.getItems().forEach((item: SettingsPanelItem) => {
       if (item.isActive() && (item as any).setting instanceof SelectBox) {
         const selectBox = (item as any).setting as SelectBox;
@@ -116,7 +116,7 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
         }
       }
     });
-  };
+  }
 
   release(): void {
     super.release();


### PR DESCRIPTION
The fix for hiding hovered select boxes: https://github.com/bitmovin/bitmovin-player-ui/pull/116 did not cover the case, that the whole UI is hiding.

We now listen to the `uimanager.onControlsHide` to apply the same functionality on the global hiding of the UI