### PR TITLE
Add flag to hide PlaybackSpeedSelectBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Display `AirPlayToggleButton` on `modernSmallScreenUI` for MacOS devices
 - Display `PictureInPictureToggleButton` on `modernSmallScreenUI` for MacOS devices
+- New option `UIConfig.playbackSpeedSelectionEnabled` to show/hide `PlaybackSpeedSelectBox` within the `SettingsPanel`
 
 ### Fixed
 - Apply the IE/Firefox workaround for a hovered dropdown panel of a `SelectBox` when the UI hides
+
+### Changed
+- `PlaybackSpeedSelectBox` is no longer visible within the `SettingsPanel` by default
 
 ## [2.16.0]
 

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -7,6 +7,7 @@ import {VideoQualitySelectBox} from './videoqualityselectbox';
 import {AudioQualitySelectBox} from './audioqualityselectbox';
 import {Timeout} from '../timeout';
 import {Event, EventDispatcher, NoArgs} from '../eventdispatcher';
+import {PlaybackSpeedSelectBox} from './playbackspeedselectbox';
 
 /**
  * Configuration interface for a {@link SettingsPanel}.
@@ -208,8 +209,12 @@ export class SettingsPanelItem extends Container<ContainerConfig> {
           minItemsToDisplay = 3;
         }
 
-        // Hide the setting if no meaningful choice is available
         if (this.setting.itemCount() < minItemsToDisplay) {
+          // Hide the setting if no meaningful choice is available
+          this.hide();
+        } else if (this.setting instanceof PlaybackSpeedSelectBox
+          && !uimanager.getConfig().playbackSpeedSelectionEnabled) {
+          // Hide the PlaybackSpeedSelectBox if disabled in config
           this.hide();
         } else {
           this.show();

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -108,6 +108,11 @@ export interface UIConfig {
    * automatic switches through a {@link UIManager.onUiVariantResolve} event handler.
    */
   autoUiVariantResolve?: boolean;
+  /**
+   * Specifies if the `PlaybackSpeedSelectBox` should be displayed within the `SettingsPanel`
+   * Default: false
+   */
+  playbackSpeedSelectionEnabled?: boolean;
 }
 
 export interface InternalUIConfig extends UIConfig {


### PR DESCRIPTION
The `PlaybackSpeedSelectBox` only gets hidden not removed from the DOM.