### PR TITLE
Single image thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Fixed
-- Rendering of single-image thumbnails when position and size properties are missing.
+- Rendering of single-image thumbnails
 
 ## [2.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Create CSS properties for sprite and single images differently
+
 ## [2.17.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Fixed
-- Create CSS properties for sprite and single images differently
+- Rendering of single-image thumbnails when position and size properties are missing.
 
 ## [2.17.0]
 

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -139,7 +139,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
         if (['x', 'y', 'w', 'h'].every((key) => thumbnail.hasOwnProperty(key))) {
           thumbnailElement.css(this.thumbnailCssSprite(thumbnail, width, height));
         } else {
-          thumbnailElement.css(this.thumbnailCssSingeImage(thumbnail, width, height));
+          thumbnailElement.css(this.thumbnailCssSingleImage(thumbnail, width, height));
         }
       });
     }
@@ -172,7 +172,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     };
   }
 
-  private thumbnailCssSingeImage(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): any {
+  private thumbnailCssSingleImage(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): any {
     let aspectRatio = 1 / width * height;
 
     return {

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -4,6 +4,7 @@ import {Component, ComponentConfig} from './component';
 import {UIInstanceManager, SeekPreviewArgs} from '../uimanager';
 import {StringUtils} from '../stringutils';
 import {ImageLoader} from '../imageloader';
+import {CssProperties} from '../dom';
 
 /**
  * Configuration interface for a {@link SeekBarLabel}.
@@ -145,7 +146,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     }
   }
 
-  private thumbnailCssSprite(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): any {
+  private thumbnailCssSprite(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): CssProperties {
     let thumbnailCountX = width / thumbnail.w;
     let thumbnailCountY = height / thumbnail.h;
 
@@ -172,7 +173,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     };
   }
 
-  private thumbnailCssSingleImage(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): any {
+  private thumbnailCssSingleImage(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): CssProperties {
     let aspectRatio = 1 / width * height;
 
     return {

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -138,7 +138,9 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       // We use the thumbnail image loader to make sure the thumbnail is loaded and it's size is known before be can
       // calculate the CSS properties and set them on the element.
       this.thumbnailImageLoader.load(thumbnail.url, (url, width, height) => {
-        if (['x', 'y', 'w', 'h'].every((key) => thumbnail.hasOwnProperty(key))) {
+        // can be checked like that because x/y/w/h are either all present or none
+        // https://www.w3.org/TR/media-frags/#naming-space
+        if (thumbnail.x !== undefined) {
           thumbnailElement.css(this.thumbnailCssSprite(thumbnail, width, height));
         } else {
           thumbnailElement.css(this.thumbnailCssSingleImage(thumbnail, width, height));

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -146,10 +146,10 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
   }
 
   private thumbnailCssSprite(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): any {
-    let thumbnailCountX = width / (thumbnail.w || 1);
-    let thumbnailCountY = height / (thumbnail.h || 1);
+    let thumbnailCountX = width / thumbnail.w;
+    let thumbnailCountY = height / thumbnail.h;
 
-    let thumbnailIndexX = (thumbnail.x || 0) / thumbnail.w;
+    let thumbnailIndexX = thumbnail.x / thumbnail.w;
     let thumbnailIndexY = thumbnail.y / thumbnail.h;
 
     let sizeX = 100 * thumbnailCountX;

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -136,31 +136,50 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       // We use the thumbnail image loader to make sure the thumbnail is loaded and it's size is known before be can
       // calculate the CSS properties and set them on the element.
       this.thumbnailImageLoader.load(thumbnail.url, (url, width, height) => {
-        let thumbnailCountX = width / thumbnail.w;
-        let thumbnailCountY = height / thumbnail.h;
-
-        let thumbnailIndexX = thumbnail.x / thumbnail.w;
-        let thumbnailIndexY = thumbnail.y / thumbnail.h;
-
-        let sizeX = 100 * thumbnailCountX;
-        let sizeY = 100 * thumbnailCountY;
-
-        let offsetX = 100 * thumbnailIndexX;
-        let offsetY = 100 * thumbnailIndexY;
-
-        let aspectRatio = 1 / thumbnail.w * thumbnail.h;
-
-        // The thumbnail size is set by setting the CSS 'width' and 'padding-bottom' properties. 'padding-bottom' is
-        // used because it is relative to the width and can be used to set the aspect ratio of the thumbnail.
-        // A default value for width is set in the stylesheet and can be overwritten from there or anywhere else.
-        thumbnailElement.css({
-          'display': 'inherit',
-          'background-image': `url(${thumbnail.url})`,
-          'padding-bottom': `${100 * aspectRatio}%`,
-          'background-size': `${sizeX}% ${sizeY}%`,
-          'background-position': `-${offsetX}% -${offsetY}%`,
-        });
+        if (['x', 'y', 'w', 'h'].every((key) => thumbnail.hasOwnProperty(key))) {
+          thumbnailElement.css(this.thumbnailCssSprite(thumbnail, width, height));
+        } else {
+          thumbnailElement.css(this.thumbnailCssSingeImage(thumbnail, width, height));
+        }
       });
     }
+  }
+
+  private thumbnailCssSprite(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): any {
+    let thumbnailCountX = width / (thumbnail.w || 1);
+    let thumbnailCountY = height / (thumbnail.h || 1);
+
+    let thumbnailIndexX = (thumbnail.x || 0) / thumbnail.w;
+    let thumbnailIndexY = thumbnail.y / thumbnail.h;
+
+    let sizeX = 100 * thumbnailCountX;
+    let sizeY = 100 * thumbnailCountY;
+
+    let offsetX = 100 * thumbnailIndexX;
+    let offsetY = 100 * thumbnailIndexY;
+
+    let aspectRatio = 1 / thumbnail.w * thumbnail.h;
+
+    // The thumbnail size is set by setting the CSS 'width' and 'padding-bottom' properties. 'padding-bottom' is
+    // used because it is relative to the width and can be used to set the aspect ratio of the thumbnail.
+    // A default value for width is set in the stylesheet and can be overwritten from there or anywhere else.
+    return {
+      'display': 'inherit',
+      'background-image': `url(${thumbnail.url})`,
+      'padding-bottom': `${100 * aspectRatio}%`,
+      'background-size': `${sizeX}% ${sizeY}%`,
+      'background-position': `-${offsetX}% -${offsetY}%`,
+    };
+  }
+
+  private thumbnailCssSingeImage(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): any {
+    let aspectRatio = 1 / width * height;
+
+    return {
+      'display': 'inherit',
+      'background-image': `url(${thumbnail.url})`,
+      'padding-bottom': `${100 * aspectRatio}%`,
+      'background-size': `100% 100%`,
+    };
   }
 }

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -5,6 +5,7 @@ import {UIInstanceManager, SeekPreviewArgs} from '../uimanager';
 import {StringUtils} from '../stringutils';
 import {ImageLoader} from '../imageloader';
 import {CssProperties} from '../dom';
+import Thumbnail = bitmovin.PlayerAPI.Thumbnail;
 
 /**
  * Configuration interface for a {@link SeekBarLabel}.
@@ -122,7 +123,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
    * Sets or removes a thumbnail on the label.
    * @param thumbnail the thumbnail to display on the label or null to remove a displayed thumbnail
    */
-  setThumbnail(thumbnail: bitmovin.PlayerAPI.Thumbnail = null) {
+  setThumbnail(thumbnail: Thumbnail = null) {
     let thumbnailElement = this.thumbnail.getDomElement();
 
     if (thumbnail == null) {
@@ -146,7 +147,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     }
   }
 
-  private thumbnailCssSprite(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): CssProperties {
+  private thumbnailCssSprite(thumbnail: Thumbnail, width: number, height: number): CssProperties {
     let thumbnailCountX = width / thumbnail.w;
     let thumbnailCountY = height / thumbnail.h;
 
@@ -173,7 +174,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     };
   }
 
-  private thumbnailCssSingleImage(thumbnail: bitmovin.PlayerAPI.Thumbnail, width: number, height: number): CssProperties {
+  private thumbnailCssSingleImage(thumbnail: Thumbnail, width: number, height: number): CssProperties {
     let aspectRatio = 1 / width * height;
 
     return {

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -180,6 +180,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       'background-image': `url(${thumbnail.url})`,
       'padding-bottom': `${100 * aspectRatio}%`,
       'background-size': `100% 100%`,
+      'background-position': `0 0`,
     };
   }
 }

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -3,6 +3,10 @@ export interface Offset {
   top: number;
 }
 
+export interface CssProperties {
+  [propertyName: string]: string;
+}
+
 /**
  * Simple DOM manipulation and DOM element event handling modeled after jQuery (as replacement for jQuery).
  *
@@ -506,8 +510,8 @@ export class DOM {
    * Sets a collection of CSS properties and their values on all elements.
    * @param propertyValueCollection an object containing pairs of property names and their values
    */
-  css(propertyValueCollection: {[propertyName: string]: string}): DOM;
-  css(propertyNameOrCollection: string | {[propertyName: string]: string}, value?: string): string | null | DOM {
+  css(propertyValueCollection: CssProperties): DOM;
+  css(propertyNameOrCollection: string | CssProperties, value?: string): string | null | DOM {
     if (typeof propertyNameOrCollection === 'string') {
       let propertyName = propertyNameOrCollection;
 


### PR DESCRIPTION
We did always expect x/y/w/h values for a thumbnail. With single images those properties don't have to be present.

An example file looks like this:
```
WEBVTT

00:00:00.0 --> 00:00:06.142
http://example.com/images/1.jpg

00:00:06.142 --> 00:00:12.285
http://example.com/images/2.jpg
```

This PR creates the CSS properties accordingly for the single image.