### PR TITLE
Track initiated play for player v8

### DIFF
--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -24,7 +24,7 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
     super.configure(player, uimanager, false);
 
     let togglePlayback = () => {
-      if (player.isPlaying()) {
+      if (player.isPlaying() || this.isPlayInitiated) {
         player.pause('ui');
       } else {
         player.play('ui');


### PR DESCRIPTION
In player v8 the API method `isPlaying` would only return `true` once the media element has started playback. In previous versions it would already return `true` once the play was initiated (i.e. `player.play` was called). 

For player v8 we need to track the state of a play being initiated separately so the play buttons can react to that. I am using the `onPlay` event for that matter.