### PR TITLE
Update localStorage detection code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Rendering of single-image thumbnails
+- Local storage detection in Firefox
 
 ## [2.17.0]
 

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -8,8 +8,9 @@ export namespace StorageUtils {
 
     // hasLocalStorage is used to safely ensure we can use localStorage
     // taken from https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage
-    let storage = window['localStorage'];
+    let storage: any = { length: 0 };
     try {
+      storage = window['localStorage'];
       let x = '__storage_test__';
       storage.setItem(x, x);
       storage.removeItem(x);


### PR DESCRIPTION
Newer Firefox versions throw a DOMException when accessing the localStorage object. Before, they only threw the exception when the object was used. Detection code has been updated according to the updated code on MDN.