### PR TITLE
Prevent controls from hiding in certain player states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Icon for audio tracks
 - Demo section within the UI variants in the playground
 - Demo with separate `SettingsPanel`s for subtitles and audio tracks
+- `UIContainerConfig.hidePlayerStateExceptions` option to configure player states in which the controls will not be hidden
 
 ### Changed
 - SmallScreenUI: Move `RecommendationOverlay` behind `TitleBar` to avoid hidden `FullscreenToggleButton` in replay screen and prevent smartphone users from exiting fullscreen
+- SmallScreenUI: Do not hide controls in replay screen
 
 ## [2.17.1]
 

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -68,6 +68,10 @@ export class UIContainer extends Container<UIContainerConfig> {
     let isFirstTouch = true;
     let playerState: PlayerUtils.PlayerState;
 
+    const hidingPrevented = (): boolean => {
+      return config.hidePlayerStateExceptions && config.hidePlayerStateExceptions.indexOf(playerState) > -1;
+    };
+
     let showUi = () => {
       if (!isUiShown) {
         // Let subscribers know that they should reveal themselves
@@ -75,7 +79,7 @@ export class UIContainer extends Container<UIContainerConfig> {
         isUiShown = true;
       }
       // Don't trigger timeout while seeking (it will be triggered once the seek is finished) or casting
-      if (!isSeeking && !player.isCasting()) {
+      if (!isSeeking && !player.isCasting() && !hidingPrevented()) {
         this.uiHideTimeout.start();
       }
     };
@@ -128,7 +132,7 @@ export class UIContainer extends Container<UIContainerConfig> {
     container.on('mouseleave', () => {
       // When a seek is going on, the seek scrub pointer may exit the UI area while still seeking, and we do not hide
       // the UI in such cases
-      if (!isSeeking) {
+      if (!isSeeking && !hidingPrevented()) {
         this.uiHideTimeout.start();
       }
     });

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -4,7 +4,7 @@ import {DOM} from '../dom';
 import {Timeout} from '../timeout';
 import {PlayerUtils} from '../playerutils';
 import PlayerResizeEvent = bitmovin.PlayerAPI.PlayerResizeEvent;
-import {CancelEventArgs} from '../eventdispatcher';
+import { CancelEventArgs, EventDispatcher } from '../eventdispatcher';
 
 /**
  * Configuration interface for a {@link UIContainer}.
@@ -33,6 +33,7 @@ export class UIContainer extends Container<UIContainerConfig> {
   private static readonly CONTROLS_HIDDEN = 'controls-hidden';
 
   private uiHideTimeout: Timeout;
+  private playerStateChange: EventDispatcher<UIContainer, PlayerUtils.PlayerState>;
 
   constructor(config: UIContainerConfig) {
     super(config);
@@ -41,6 +42,8 @@ export class UIContainer extends Container<UIContainerConfig> {
       cssClass: 'ui-uicontainer',
       hideDelay: 5000,
     }, this.config);
+
+    this.playerStateChange = new EventDispatcher<UIContainer, PlayerUtils.PlayerState>();
   }
 
   configure(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {
@@ -165,6 +168,7 @@ export class UIContainer extends Container<UIContainerConfig> {
     const updateState = (state: PlayerUtils.PlayerState) => {
       removeStates();
       container.addClass(stateClassNames[state]);
+      this.playerStateChange.dispatch(this, state);
     };
 
     player.addEventHandler(player.EVENT.ON_READY, () => {

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -151,8 +151,12 @@ export class UIContainer extends Container<UIContainerConfig> {
     this.playerStateChange.subscribe((_, state) => {
       playerState = state;
       if (hidingPrevented()) {
+        // Entering a player state that prevents hiding and forces the controls to be shown
         this.uiHideTimeout.clear();
         showUi();
+      } else {
+        // Entering a player state that allows hiding
+        this.uiHideTimeout.start();
       }
     });
   }

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -66,6 +66,7 @@ export class UIContainer extends Container<UIContainerConfig> {
     let isUiShown = false;
     let isSeeking = false;
     let isFirstTouch = true;
+    let playerState: PlayerUtils.PlayerState;
 
     let showUi = () => {
       if (!isUiShown) {
@@ -142,6 +143,9 @@ export class UIContainer extends Container<UIContainerConfig> {
     });
     player.addEventHandler(player.EVENT.ON_CAST_STARTED, () => {
       showUi(); // Show UI when a Cast session has started (UI will then stay permanently on during the session)
+    });
+    this.playerStateChange.subscribe((_, state) => {
+      playerState = state;
     });
   }
 

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -161,28 +161,29 @@ export class UIContainer extends Container<UIContainerConfig> {
       container.removeClass(stateClassNames[PlayerUtils.PlayerState.PAUSED]);
       container.removeClass(stateClassNames[PlayerUtils.PlayerState.FINISHED]);
     };
-    player.addEventHandler(player.EVENT.ON_READY, () => {
+
+    const updateState = (state: PlayerUtils.PlayerState) => {
       removeStates();
-      container.addClass(stateClassNames[PlayerUtils.PlayerState.PREPARED]);
+      container.addClass(stateClassNames[state]);
+    };
+
+    player.addEventHandler(player.EVENT.ON_READY, () => {
+      updateState(PlayerUtils.PlayerState.PREPARED);
     });
     player.addEventHandler(player.EVENT.ON_PLAY, () => {
-      removeStates();
-      container.addClass(stateClassNames[PlayerUtils.PlayerState.PLAYING]);
+      updateState(PlayerUtils.PlayerState.PLAYING);
     });
     player.addEventHandler(player.EVENT.ON_PAUSED, () => {
-      removeStates();
-      container.addClass(stateClassNames[PlayerUtils.PlayerState.PAUSED]);
+      updateState(PlayerUtils.PlayerState.PAUSED);
     });
     player.addEventHandler(player.EVENT.ON_PLAYBACK_FINISHED, () => {
-      removeStates();
-      container.addClass(stateClassNames[PlayerUtils.PlayerState.FINISHED]);
+      updateState(PlayerUtils.PlayerState.FINISHED);
     });
     player.addEventHandler(player.EVENT.ON_SOURCE_UNLOADED, () => {
-      removeStates();
-      container.addClass(stateClassNames[PlayerUtils.PlayerState.IDLE]);
+      updateState(PlayerUtils.PlayerState.IDLE);
     });
     // Init in current player state
-    container.addClass(stateClassNames[PlayerUtils.getState(player)]);
+    updateState(PlayerUtils.getState(player));
 
     // Fullscreen marker class
     player.addEventHandler(player.EVENT.ON_FULLSCREEN_ENTER, () => {

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -16,6 +16,7 @@ export interface UIContainerConfig extends ContainerConfig {
    * Default: 5 seconds (5000)
    */
   hideDelay?: number;
+  hidePlayerStateExceptions?: PlayerUtils.PlayerState[];
 }
 
 /**

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -150,6 +150,10 @@ export class UIContainer extends Container<UIContainerConfig> {
     });
     this.playerStateChange.subscribe((_, state) => {
       playerState = state;
+      if (hidingPrevented()) {
+        this.uiHideTimeout.clear();
+        showUi();
+      }
     });
   }
 

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -50,6 +50,7 @@ import {Spacer} from './components/spacer';
 import {UIUtils} from './uiutils';
 import {ArrayUtils} from './arrayutils';
 import {BrowserUtils} from './browserutils';
+import { PlayerUtils } from './playerutils';
 
 export interface UIRecommendationConfig {
   title: string;
@@ -772,6 +773,7 @@ export namespace UIManager.Factory {
         new ErrorMessageOverlay(),
       ],
       cssClasses: ['ui-skin-modern', 'ui-skin-smallscreen'],
+      hidePlayerStateExceptions: [PlayerUtils.PlayerState.FINISHED],
     });
   }
 


### PR DESCRIPTION
Until now it was only possible to configure if the UI controls will be hidden after a certain amount of inactivity time (`UIContainerConfig.hideDelay`) or if they are always shown.

This PR adds `UIContainerConfig.hidePlayerStateExceptions` that allows to specify a list of player states in which the UI controls will always be shown, e.g.

https://github.com/bitmovin/bitmovin-player-ui/blob/b2e1f004086d12c6137bd8c0d3edfb56109d118a/src/ts/uimanager.ts#L776

In the small screen UI we prevent the UI controls from hiding in the replay screen to avoid a required double tap on smartphones to first display the controls and then start playback. By always showing the controls, replay can be started with one tap and buttons like the fullscreen button are always easily available.