### PR TITLE
Adjust to player getFigure removal

### DIFF
--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -278,7 +278,7 @@ export class UIContainer extends Container<UIContainerConfig> {
       updateLayoutSizeClasses(width, height);
     });
     // Init layout state
-    updateLayoutSizeClasses(new DOM(player.getFigure()).width(), new DOM(player.getFigure()).height());
+    updateLayoutSizeClasses(new DOM(player.getContainer()).width(), new DOM(player.getContainer()).height());
   }
 
   release(): void {

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -179,7 +179,7 @@ declare namespace bitmovin {
      */
     getDuration(): number;
     /**
-     * Returns the figure element that the player is embedded in, if the player is set up, or null otherwise.
+     * Returns the html element that the player is embedded in, which has been provided in the player constructor.
      */
     getContainer(): HTMLElement;
     /**

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -181,7 +181,7 @@ declare namespace bitmovin {
     /**
      * Returns the figure element that the player is embedded in, if the player is set up, or null otherwise.
      */
-    getFigure(): HTMLElement;
+    getContainer(): HTMLElement;
     /**
      * Returns the manifest file.
      */

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -282,7 +282,7 @@ export class UIManager {
       this.uiContainerElement = config.container instanceof HTMLElement ?
         new DOM(config.container) : new DOM(config.container);
     } else {
-      this.uiContainerElement = new DOM(player.getFigure());
+      this.uiContainerElement = new DOM(player.getContainer());
     }
 
     // Create UI instance managers for the UI variants


### PR DESCRIPTION
`player.getFigure` has been removed with V8 along with the actual figure
`player.getContainer` now returns the element which embeds the player, use that one