### PR TITLE
Custom skip ad message not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Missing custom `SkipMessage` texts while playing an advertisement
+
 ## [3.0.0 alpha]
 
 This major release is adjusted to the changed API of Bitmovin Player v8.

--- a/src/ts/components/admessagelabel.ts
+++ b/src/ts/components/admessagelabel.ts
@@ -19,14 +19,15 @@ export class AdMessageLabel extends Label<LabelConfig> {
   configure(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let text = this.getConfig().text;
+    let config = this.getConfig();
+    let text = config.text;
 
     let updateMessageHandler = () => {
       this.setText(StringUtils.replaceAdMessagePlaceholders(text, null, player));
     };
 
     let adStartHandler = (event: bitmovin.PlayerAPI.AdStartedEvent) => {
-      text = event.adMessage || text;
+      text = event.adMessage || config.text;
       updateMessageHandler();
 
       player.on(player.exports.Event.TimeChanged, updateMessageHandler);

--- a/src/ts/components/adskipbutton.ts
+++ b/src/ts/components/adskipbutton.ts
@@ -45,9 +45,9 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       // Update the skip message on the button
       if (player.getCurrentTime() < adEvent.skipOffset) {
         this.setText(
-          StringUtils.replaceAdMessagePlaceholders(config.skipMessage.countdown, adEvent.skipOffset, player));
+          StringUtils.replaceAdMessagePlaceholders(skipMessage.countdown, adEvent.skipOffset, player));
       } else {
-        this.setText(config.skipMessage.skip);
+        this.setText(skipMessage.skip);
       }
     };
 

--- a/src/ts/components/adskipbutton.ts
+++ b/src/ts/components/adskipbutton.ts
@@ -53,7 +53,7 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
 
     let adStartHandler = (event: bitmovin.PlayerAPI.AdStartedEvent) => {
       adEvent = event;
-      skipMessage = adEvent.skipMessage || skipMessage;
+      skipMessage = adEvent.skipMessage || config.skipMessage;
       updateSkipMessageHandler();
 
       player.on(player.exports.Event.TimeChanged, updateSkipMessageHandler);


### PR DESCRIPTION
## Description

Custom skip-messages are not displayed while an ad is playing.

## Fix
Use text from playerEvent instead of config

## Discussion
It seems weird to me that there are multiple different texts but only one will be taken. 
Should we update the documentation that the text in the player-config has precedence over the text configured in the UI element?

## TODO

- [ ] Backport to `support/v2.x`