### PR TITLE
Also hide the buffer overlay when pausing

### DIFF
--- a/src/ts/components/bufferingoverlay.ts
+++ b/src/ts/components/bufferingoverlay.ts
@@ -61,6 +61,7 @@ export class BufferingOverlay extends Container<BufferingOverlayConfig> {
     player.on(player.exports.Event.StallEnded, hideOverlay);
     player.on(player.exports.Event.Play, showOverlay);
     player.on(player.exports.Event.Playing, hideOverlay);
+    player.on(player.exports.Event.Paused, hideOverlay);
     player.on(player.exports.Event.Seek, showOverlay);
     player.on(player.exports.Event.Seeked, hideOverlay);
     player.on(player.exports.Event.TimeShift, showOverlay);


### PR DESCRIPTION
We show the buffer overlay between play and playing, but don't hide it when we pause. That means that the sequence `Play` -> `Paused` will lead to buffer overlay staying on the screen for the paused duration, which is not correct.