### PR TITLE
Player resized event not working

### DIFF
--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -311,7 +311,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     // Refresh the playback position when the player resized or the UI is configured. The playback position marker
     // is positioned absolutely and must therefore be updated when the size of the seekbar changes.
-    player.on(player.exports.Event.PlayerResize, () => {
+    player.on(player.exports.Event.PlayerResized, () => {
       this.refreshPlaybackPosition();
     });
     // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
@@ -451,7 +451,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     // Remove markers when unloaded
     player.on(player.exports.Event.SourceUnloaded, clearMarkers);
     // Update markers when the size of the seekbar changes
-    player.on(player.exports.Event.PlayerResize, () => this.updateMarkers());
+    player.on(player.exports.Event.PlayerResized, () => this.updateMarkers());
     // Update markers when a marker is added or removed
     uimanager.getConfig().events.onUpdated.subscribe(setupMarkers);
     uimanager.onRelease.subscribe(() => uimanager.getConfig().events.onUpdated.unsubscribe(setupMarkers));

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -189,7 +189,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
     };
 
-    player.on(player.exports.Event.PlayerResize, () => {
+    player.on(player.exports.Event.PlayerResized, () => {
       if (enabled) {
         updateCEA608FontSize();
       } else {

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -270,7 +270,7 @@ export class UIContainer extends Container<UIContainerConfig> {
         container.addClass(this.prefixCss('layout-max-width-1200'));
       }
     };
-    player.on(player.exports.Event.PlayerResize, (e: PlayerResizeEvent) => {
+    player.on(player.exports.Event.PlayerResized, (e: PlayerResizeEvent) => {
       // Convert strings (with "px" suffix) to ints
       let width = Math.round(Number(e.width.substring(0, e.width.length - 2)));
       let height = Math.round(Number(e.height.substring(0, e.height.length - 2)));

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -66,7 +66,7 @@ export class VolumeSlider extends SeekBar {
 
     // Update the volume slider marker when the player resized, a source is loaded and player is ready,
     // or the UI is configured. Check the seekbar for a detailed description.
-    player.on(player.exports.Event.PlayerResize, () => {
+    player.on(player.exports.Event.PlayerResized, () => {
       this.refreshPlaybackPosition();
     });
     player.on(player.exports.Event.Ready, () => {

--- a/src/ts/player-events.d.ts
+++ b/src/ts/player-events.d.ts
@@ -51,7 +51,7 @@ declare namespace bitmovin {
       Playing,
       PlaybackFinished,
       PlaybackSpeedChanged,
-      PlayerResize,
+      PlayerResized,
       Ready,
       Seek,
       Seeked,

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -378,7 +378,7 @@ export class UIManager {
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.Event.AdFinished, resolveUiVariant);
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.Event.AdSkipped, resolveUiVariant);
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.Event.AdError, resolveUiVariant);
-      this.managerPlayerWrapper.getPlayer().on(this.player.exports.Event.PlayerResize, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().on(this.player.exports.Event.PlayerResized, resolveUiVariant);
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.Event.ViewModeChanged, resolveUiVariant);
     }
 


### PR DESCRIPTION
## Description

Found out that it was not possible to listen on the `PlayerResized` event.

## Fix

Update wording of Enum value for the event to match name in the player