### PR TITLE
Fix an issue that many components are not updating the content after an ui variant switch

### DIFF
--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -497,7 +497,7 @@ export class UIManager {
      * undesirable at this time. */
     this.uiContainerElement.append(dom);
 
-    // Some components initialize their state on ON_READY. When the UI is loaded after the player is already ready,
+    // Some components initialize their state on Ready. When the UI is loaded after the player is already ready,
     // they will never receive the event so we fire it from here in such cases.
     if (player) {
       player.fireEventInUI(player.exports.Event.Ready, {});

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -489,12 +489,19 @@ export class UIManager {
 
   private addUi(ui: InternalUIInstanceManager): void {
     let dom = ui.getUI().getDomElement();
+    let player = ui.getWrappedPlayer();
 
     ui.configureControls();
     /* Append the UI DOM after configuration to avoid CSS transitions at initialization
      * Example: Components are hidden during configuration and these hides may trigger CSS transitions that are
      * undesirable at this time. */
     this.uiContainerElement.append(dom);
+
+    // Some components initialize their state on ON_READY. When the UI is loaded after the player is already ready,
+    // they will never receive the event so we fire it from here in such cases.
+    if (player) {
+      player.fireEventInUI(player.exports.Event.Ready, {});
+    }
 
     // Fire onConfigured after UI DOM elements are successfully added. When fired immediately, the DOM elements
     // might not be fully configured and e.g. do not have a size.


### PR DESCRIPTION
## Description

Intentionally I was investigating a issue that the video-quality select box value was not updating correctly but I was not able to reproduce it in UI v3 with player v8. 

I found another issue that after an UI variant switch some components were not able to update their state again.

## Fix

Partly revert of [fd817f](https://github.com/bitmovin/bitmovin-player-ui/commit/fd817fc9eb495237e103aba9c68ad8da462cc7aa)