### PR TITLE
Separate issuer in play/pause during seeking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This major release is adjusted to the changed API of Bitmovin Player v8.
 
 ### Changed
 - Player type definitions updated to player v8
+- `play` and `pause` calls during seeking now have the issuer `ui-seek` instead of `ui`
 
 ### Removed
 - Everything deprecated in 2.x

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -224,7 +224,8 @@ export class SeekBar extends Component<SeekBarConfig> {
     let restorePlayingState = function() {
       // Continue playback after seek if player was playing when seek started
       if (isPlaying) {
-        player.play('ui');
+        // use the same issuer here as in the pause on seek
+        player.play('ui-seek');
       }
     };
 
@@ -252,7 +253,8 @@ export class SeekBar extends Component<SeekBarConfig> {
 
         // Pause playback while seeking
         if (isPlaying) {
-          player.pause('ui');
+          // use a different issuer here, as play/pause on seek is not "really" triggerd by the user
+          player.pause('ui-seek');
         }
       }
 


### PR DESCRIPTION
Analytics could not differentiate between user initiated play/pause calls and play/pause called which were issued due to seeking while the player was playing.

Now the play/pause calls which happen during seeking have a different issuer `ui-seek`