### PR TITLE
Recommendation overlay not shown

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -188,7 +188,7 @@
       }
     ]
   };
-  var adsEnabled = true;
+  var adsEnabled = false;
 
   var config = {
     key: 'YOUR KEY HERE',

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -169,36 +169,26 @@
   };
 
   var advertisingConfig = {
-    forceSinglePlayer: false,
-    //clickThroughEnabled: false,
-    client: 'vast',
-    admessage: 'staring contest (ಠ_ಠ) ... hold on for {remainingTime} seconds',
-    skipmessage: {
-      countdown: '┏(-_-)┛┗(-_-﻿ )┓┗(-_-)┛┏(-_-)┓ ({remainingTime})',
-      skip: 'SKIP'
-    },
-    schedule: {
-      'ad-skippable': {
-        offset: 'pre',
-        tag: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]'
+    adBreaks: [
+      {
+        tag: {
+          // skippable
+          url: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]',
+          type: 'vast',
+        },
+        position: 'pre',
       },
-      'ad-nonskippable': {
-        offset: '15',
-        tag: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/2nd_test_ad_unit&ciu_szs=300x100&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&url=[referrer_url]&description_url=[description_url]&correlator=[random]'
-      },
-      'ad-skippable-ima': {
-        client: 'ima',
-        offset: '30',
-        tag: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]'
-      },
-      'ad-nonskippable-ima': {
-        client: 'ima',
-        offset: '45',
-        tag: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/2nd_test_ad_unit&ciu_szs=300x100&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&url=[referrer_url]&description_url=[description_url]&correlator=[random]'
+      {
+        tag: {
+          // nonskippable
+          url: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/2nd_test_ad_unit&ciu_szs=300x100&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&url=[referrer_url]&description_url=[description_url]&correlator=[random]',
+          type: 'vast',
+        },
+        position: '10',
       }
-    }
+    ]
   };
-  var adsEnabled = false;
+  var adsEnabled = true;
 
   var config = {
     key: 'YOUR KEY HERE',

--- a/src/ts/components/recommendationoverlay.ts
+++ b/src/ts/components/recommendationoverlay.ts
@@ -67,7 +67,8 @@ export class RecommendationOverlay extends Container<ContainerConfig> {
     player.on(player.exports.Event.PlaybackFinished, () => {
       // Dismiss ON_PLAYBACK_FINISHED events at the end of ads
       // TODO remove this workaround once issue #1278 is solved
-      if (player.isAd()) {
+      if (player.ads.isLinearAdActive()) {
+        console.log('was ad');
         return;
       }
 

--- a/src/ts/components/recommendationoverlay.ts
+++ b/src/ts/components/recommendationoverlay.ts
@@ -65,12 +65,6 @@ export class RecommendationOverlay extends Container<ContainerConfig> {
     });
     // Display recommendations when playback has finished
     player.on(player.exports.Event.PlaybackFinished, () => {
-      // Dismiss ON_PLAYBACK_FINISHED events at the end of ads
-      // TODO remove this workaround once issue #1278 is solved
-      if (player.ads.isLinearAdActive()) {
-        return;
-      }
-
       this.show();
     });
     // Hide recommendations when playback starts, e.g. a restart

--- a/src/ts/components/recommendationoverlay.ts
+++ b/src/ts/components/recommendationoverlay.ts
@@ -68,7 +68,6 @@ export class RecommendationOverlay extends Container<ContainerConfig> {
       // Dismiss ON_PLAYBACK_FINISHED events at the end of ads
       // TODO remove this workaround once issue #1278 is solved
       if (player.ads.isLinearAdActive()) {
-        console.log('was ad');
         return;
       }
 

--- a/src/ts/player.d.ts
+++ b/src/ts/player.d.ts
@@ -107,6 +107,11 @@ declare namespace bitmovin {
     readonly subtitles: PlayerAPI.PlayerSubtitlesAPI;
 
     /**
+     * The Ads API.
+     */
+    readonly ads: PlayerAPI.PlayerAdvertisingAPI;
+
+    /**
      * Exports from the player core as a convenience fallback for non-modular code.
      * It is recommended to use ES6 imports instead.
      *
@@ -1299,6 +1304,49 @@ declare namespace bitmovin {
       list(): SubtitleTrack[];
       enable(subtitleID: string, exclusive?: boolean): void;
       disable(subtitleID: string): void;
+    }
+
+    interface PlayerAdvertisingAPI {
+      /**
+       * Schedules resulting ad break(s) of an ad config for playback.
+       *
+       * @param adConfig The ad configuration used to schedule one or more ad breaks.
+       * @since v8.0
+       * @return Promise that resolves with the ad breaks that were scheduled as a result of the given ad config.
+       */
+      schedule(adConfig: AdConfig): Promise<AdBreak[]>;
+      /**
+       * Skips the current ad. Has no effect if the ad is not skippable or if no ad is active.
+       * @since v8.0
+       */
+      skip(): void;
+      /**
+       * Returns all scheduled ad breaks.
+       *
+       * @since v8.0
+       * @return Array containing all the scheduled ad breaks.
+       */
+      list(): AdBreak[];
+      /**
+       * Returns the currently active ad break.
+       *
+       * @since v8.0
+       * @return AdBreak
+       */
+      getActiveAdBreak(): AdBreak;
+      /**
+       * Discards all scheduled ad breaks with the given ID. Also stops the current ad break if it has the same ID.
+       *
+       * @param adBreakId The ID which shall be removed from the scheduled ad breaks.
+       * @since v8.0
+       */
+      discardAdBreak(adBreakId: string): void;
+      /**
+       * Returns true if a linear ad is currently active (playing or paused). Returns false otherwise.
+       *
+       * @since v8.0
+       */
+      isLinearAdActive(): boolean;
     }
   }
 }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -341,7 +341,7 @@ export class UIManager {
           // of the ad playback by checking isAd() in ON_READY, because ON_READY always arrives when the source
           // changes.
           case player.exports.Event.Ready:
-            if (adStartedEvent && !player.isAd()) {
+            if (adStartedEvent && !player.ads.isLinearAdActive()) {
               adStartedEvent = null;
             }
         }


### PR DESCRIPTION
## Description

I recognized that the recommendation-overlay was not shown when playback finished.

## Fix

* update the UI to use the new AdsAPI
* update ad samples

## Discussion

@Reevn two open questions:
* Is it possible to set `skipMessage` and `adMessage`?
* The `skipAfter` is currently not working with the IMA module?