### PR TITLE
Image attribute for cueEnterEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Added
+- The image attribute from a `SubtitleCueEvent` event will now be used to generate a html tag if the html attributes is empty
+
 ## [3.0.0 alpha]
 
 This major release is adjusted to the changed API of Bitmovin Player v8.

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -5,6 +5,7 @@ import {Label, LabelConfig} from './label';
 import {ComponentConfig, Component} from './component';
 import {ControlBar} from './controlbar';
 import { EventDispatcher } from '../eventdispatcher';
+import {DOM} from '../dom';
 
 /**
  * Overlays the player to display subtitles.
@@ -65,6 +66,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       this.show();
     });
+
     player.on(player.exports.Event.CueExit, (event: SubtitleCueEvent) => {
       let labelToRemove = subtitleManager.cueExit(event);
 
@@ -318,9 +320,22 @@ class ActiveSubtitleManager {
   cueEnter(event: SubtitleCueEvent): SubtitleLabel {
     let id = ActiveSubtitleManager.calculateId(event);
 
+    let generateImageTagText = (imageData: string): string => {
+      if (!imageData) {
+        return;
+      }
+
+      const imgTag = new DOM('img', {
+        src: imageData,
+      });
+      imgTag.css('width', '100%');
+      return imgTag.get()[0].outerHTML; // return the html as string
+    };
+
     let label = new SubtitleLabel({
-      // Prefer the HTML subtitle text if set, else use the plain text
-      text: event.html || event.text,
+      // Prefer the HTML subtitle text if set, else try generating a image tag as string from the image attribute,
+      // else use the plain text
+      text: event.html || generateImageTagText(event.image) || event.text,
     });
 
     // Create array for id if it does not exist

--- a/src/ts/player-events.d.ts
+++ b/src/ts/player-events.d.ts
@@ -512,6 +512,7 @@ declare namespace bitmovin {
       end: number;
       text: string;
       html?: string;
+      image?: string;
       region?: string;
       regionStyle?: string;
       position?: {


### PR DESCRIPTION
## Description

Issue: The image attribute for the `cueEnterEvent ` was ignored.

## Fix

Generate a `imageTag` if the html attribute is missing but the image attribute is present.

Priority is defined as followed:
1) `event.html`
2) `event.image`
3) `event.text`

## TODO

- [ ] Backport to `support-v2.x`