### PR TITLE
Fix an issue when metadata is undefined in uiconfig

### DIFF
--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -125,6 +125,10 @@ export class UIManager {
     }
 
     this.player = player;
+
+    // ensure that at least the metadata object does exist in the uiconfig
+    uiconfig.metadata = uiconfig.metadata ? uiconfig.metadata : {};
+
     this.config = {
       ...uiconfig,
       events: {


### PR DESCRIPTION
Fix an issue that appears when initializing the uimanager without metadata within the uiconfig.