### PR TITLE
Fix misplaced UI

### DIFF
--- a/src/scss/skin-modern/_skin.scss
+++ b/src/scss/skin-modern/_skin.scss
@@ -47,6 +47,11 @@
 @import 'skin-smallscreen';
 
 .#{$prefix}-ui-uicontainer {
+  // Include padding and border in the element's total width and height
+  *, *:before, *:after {
+    box-sizing: border-box;
+  }
+
   color: $color-primary;
   font-family: $font-family;
   font-size: $font-size;


### PR DESCRIPTION
Issue: We found out that the entirety UI was misplaced when no bootstrap is on the side. So we added the default `box-sizing` from bootstrap to all elements within the `ui-container`