### PR TITLE
Fix UIManager.release with destroyed player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Crash of `UIManager.release` when player instance was already destroyed
+
 ## [3.0.0]
 
 Major release for Bitmovin Player 8, mainly adjusted to the changed player API. For player 7, please use UI v2.x.
@@ -426,6 +431,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.0.0...develop
 [3.0.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.18.0...v3.0.0
 [2.18.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.17.1...v2.18.0
 [2.17.1]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.17.0...v2.17.1

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -818,6 +818,18 @@ class PlayerWrapper {
    * Clears all registered event handlers from the player that were added through the wrapped player.
    */
   clearEventHandlers(): void {
+    try {
+      // Call the player API to check if the instance is still valid or already destroyed.
+      // This can be any call throwing the PlayerAPINotAvailableError when the player instance is destroyed.
+      this.player.getSource();
+    } catch (error) {
+      if (error instanceof this.player.exports.PlayerAPINotAvailableError) {
+        // We have detected that the player instance is already destroyed, so we clear the event handlers to avoid
+        // event handler unsubscription attempts (which would result in PlayerAPINotAvailableError errors).
+        this.eventHandlers = {};
+      }
+    }
+
     for (let eventType in this.eventHandlers) {
       for (let callback of this.eventHandlers[eventType]) {
         this.player.off(eventType as PlayerEvent, callback);


### PR DESCRIPTION
Player v8.0.0 calls `UIManager.release` from within a `PlayerEvent.Destroy` handler, which, due to its async nature, is executed after the player is already destroyed. `UIManager.release` then attempted to unsubscribe all UI event handlers, which led to uncaught `PlayerAPINotAvailableError`s because the `player.off` method wasn't available any more.

This PR adds a detection if the player is still alive, and only unsubscribes the event handler in that case. If the player is already destroyed, the handlers are already invalid and just thrown away.