### PR TITLE
Fix unhandled error in SeekBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Uncaught `PlayerAPINotAvailableError` in `SeekBar` position updater when player is destroyed
+
 ## [3.0.1]
 
 ### Fixed
@@ -432,6 +437,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.0.1...develop
 [3.0.1]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.18.0...v3.0.0
 [2.18.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v2.17.1...v2.18.0

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -377,7 +377,18 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     this.smoothPlaybackPositionUpdater = new Timeout(updateIntervalMs, () => {
       currentTimeSeekBar += currentTimeUpdateDeltaSecs;
-      currentTimePlayer = player.getCurrentTime();
+
+      try {
+        currentTimePlayer = player.getCurrentTime();
+      } catch (error) {
+        // Detect if the player has been destroyed and stop updating if so
+        if (error instanceof player.exports.PlayerAPINotAvailableError) {
+          this.smoothPlaybackPositionUpdater.clear();
+        }
+
+        // If the current time cannot be read it makes no sense to continue
+        return;
+      }
 
       // Sync currentTime of seekbar to player
       let currentTimeDelta = currentTimeSeekBar - currentTimePlayer;


### PR DESCRIPTION
If the player was destroyed (`player.destroy()`) without destroying the UI first (`uimanager.release()`) - like it happens in the UI module of player 8.0.0 - the playback position updater of the `SeekBar` attempted to call `player.getCurrentTime()` and provoked a `PlayerAPINotAvailableError`.

The `player.getCurrentTime()` is now wrapped in a `try/catch` and the position updater is stopped when this error happens (once the player is destroyed, the UI becomes unusable anyway so the updater can safely be stopped).