### PR TITLE
Fix issue that the UI becomes unresponsive when user cancels Cast connection establishment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Uncaught `PlayerAPINotAvailableError` in `SeekBar` position updater when player is destroyed
+- Unresponsive UI when a user canceled connection establishment to a Cast receiver
 
 ## [3.0.1]
 

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -109,20 +109,6 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
       }
     });
 
-    // Hide button while initializing a Cast session
-    let castInitializationHandler = (event: PlayerEventBase) => {
-      if (event.type === player.exports.PlayerEvent.CastStart) {
-        // Hide button when session is being initialized
-        this.hide();
-      } else {
-        // Show button when session is established or initialization was aborted
-        this.show();
-      }
-    };
-    player.on(player.exports.PlayerEvent.CastStart, castInitializationHandler);
-    player.on(player.exports.PlayerEvent.CastStarted, castInitializationHandler);
-    player.on(player.exports.PlayerEvent.CastStopped, castInitializationHandler);
-
     const suppressPlayButtonTransitionAnimation = () => {
       // Disable the current animation
       this.setTransitionAnimationsEnabled(false);


### PR DESCRIPTION
How to test:

* Press the cast button in the player ui
  - The cast device selection should open

* Exit the the cast device selection popup without selecting a device (Press X on the popup)
* Wait until the Player UI fades out

-> UI will never come again (before the fix)