### PR TITLE
Fix horizontal seek bar and playback position marker alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Changed
+- `Seekbar`/`VolumeSlider` position markers changed from SVG to pure CSS to improve vertical alignment with bar
+
 ### Fixed
 - Uncaught `PlayerAPINotAvailableError` in `SeekBar` position updater when player is destroyed
 - Unresponsive UI when a user canceled connection establishment to a Cast receiver

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -79,7 +79,7 @@
     </div>
 </div>
 
-<script src="https://bitmovin-a.akamaihd.net/bitmovin-player/staging/8/bitmovinplayer.js"></script>
+<script src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
 <script src="js/bitmovinplayer-ui.js"></script>
 <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
 <script type="text/javascript">

--- a/src/scss/skin-modern/_mixins.scss
+++ b/src/scss/skin-modern/_mixins.scss
@@ -116,3 +116,9 @@
 @mixin svg-icon-on-shadow {
   filter: drop-shadow(0 0 1px $color-highlight);
 }
+
+@mixin seekbar-position-marker($marker-dimension) {
+  height: $marker-dimension;
+  left: -$marker-dimension / 2;
+  width: $marker-dimension;
+}

--- a/src/scss/skin-modern/_variables.scss
+++ b/src/scss/skin-modern/_variables.scss
@@ -20,3 +20,5 @@ $subtitle-text-border-color: #000 !default;
 
 $animation-duration: .3s !default;
 $animation-duration-short: $animation-duration / 2 !default;
+
+$seekbar-height: 5px;

--- a/src/scss/skin-modern/_variables.scss
+++ b/src/scss/skin-modern/_variables.scss
@@ -20,5 +20,3 @@ $subtitle-text-border-color: #000 !default;
 
 $animation-duration: .3s !default;
 $animation-duration-short: $animation-duration / 2 !default;
-
-$seekbar-height: 0.3125em;

--- a/src/scss/skin-modern/_variables.scss
+++ b/src/scss/skin-modern/_variables.scss
@@ -21,4 +21,4 @@ $subtitle-text-border-color: #000 !default;
 $animation-duration: .3s !default;
 $animation-duration-short: $animation-duration / 2 !default;
 
-$seekbar-height: 5px;
+$seekbar-height: 0.3125em;

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -10,7 +10,7 @@ $seekbar-height: 0.3125em;
 
   cursor: pointer;
   font-size: 1em;
-  height: $seekbar-height * 3;
+  height: 1em;
   position: relative;
   width: 100%;
 

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -65,7 +65,7 @@
       @include seekbar-position-marker($seekbar-height * 3);
 
       background-color: transparentize($color-highlight, .5);
-      border: solid $color-highlight 3px;
+      border: solid $color-highlight 0.1875em;
       border-radius: 50%;
     }
 
@@ -74,7 +74,7 @@
 
       $marker-width: 2px;
 
-      height: $seekbar-height * 3 - 6px;
+      height: $seekbar-height * 3 - 0.375em;
 
       > .#{$prefix}-seekbar-marker {
         @extend %bar;

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -1,6 +1,8 @@
 @import '../variables';
 @import '../mixins';
 
+$seekbar-height: 0.3125em;
+
 %ui-seekbar {
   @extend %ui-component;
 

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -1,4 +1,5 @@
 @import '../variables';
+@import '../mixins';
 
 %ui-seekbar {
   @extend %ui-component;
@@ -7,24 +8,22 @@
 
   cursor: pointer;
   font-size: 1em;
-  height: 1em;
+  height: $seekbar-height * 3;
   position: relative;
   width: 100%;
 
   $bar-inset: auto;
-  $bar-height: .25em;
 
   .#{$prefix}-seekbar {
-    height: 100%;
-    position: relative;
 
     %bar {
       // sass-lint:disable no-vendor-prefixes
       -ms-transform-origin: 0 0; // required for IE9
       -webkit-transform-origin: 0 0; // required for Android 4.4 WebView
       bottom: 0;
-      height: $bar-height;
+      height: $seekbar-height;
       left: 0;
+      margin: auto;
       position: absolute;
       right: auto;
       top: 0;
@@ -63,15 +62,11 @@
 
     .#{$prefix}-seekbar-playbackposition-marker {
       @extend %bar;
+      @include seekbar-position-marker($seekbar-height * 3);
 
-      background-image: svg('assets/skin-modern/images/dot-play.svg');
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: 1.5em;
-      height: 1em;
-      left: -.5em;
-      position: absolute;
-      width: 1em;
+      background-color: transparentize($color-highlight, .5);
+      border: solid $color-highlight 3px;
+      border-radius: 50%;
     }
 
     .#{$prefix}-seekbar-markers {
@@ -79,8 +74,7 @@
 
       $marker-width: 2px;
 
-      height: $bar-height * 2;
-      margin: $bar-inset 0;
+      height: $seekbar-height * 3 - 6px;
 
       > .#{$prefix}-seekbar-marker {
         @extend %bar;

--- a/src/scss/skin-modern/components/_volumeslider.scss
+++ b/src/scss/skin-modern/components/_volumeslider.scss
@@ -1,5 +1,6 @@
 @import '../variables';
 @import '../mixins';
+@import './seekbar';
 
 .#{$prefix}-ui-volumeslider {
   @extend %ui-seekbar;

--- a/src/scss/skin-modern/components/_volumeslider.scss
+++ b/src/scss/skin-modern/components/_volumeslider.scss
@@ -1,11 +1,14 @@
 @import '../variables';
+@import '../mixins';
 
 .#{$prefix}-ui-volumeslider {
   @extend %ui-seekbar;
 
   .#{$prefix}-seekbar {
     .#{$prefix}-seekbar-playbackposition-marker {
-      background-image: svg('assets/skin-modern/images/dot-volume.svg');
+      @include seekbar-position-marker($seekbar-height * 3 - 4px);
+      background-color: $color-highlight;
+      border: 0;
     }
 
     .#{$prefix}-seekbar-bufferlevel {

--- a/src/scss/skin-modern/components/_volumeslider.scss
+++ b/src/scss/skin-modern/components/_volumeslider.scss
@@ -6,7 +6,7 @@
 
   .#{$prefix}-seekbar {
     .#{$prefix}-seekbar-playbackposition-marker {
-      @include seekbar-position-marker($seekbar-height * 3 - 4px);
+      @include seekbar-position-marker($seekbar-height * 3 - 0.25em);
       background-color: $color-highlight;
       border: 0;
     }


### PR DESCRIPTION
## Idea
The idea is to calculate all dimensions within the seekbar based on one value (bar-height).
For the position-maker multiply with `3` then there is the same space above and bottom (position center with `margin: auto`). When you would like to adjust the size more exact add / subtract an even number to it to always keep the same. (Same applies for `seek-bar-markers`) This requires to replace the background images with css styling.

![bildschirmfoto 2018-09-27 um 13 58 01](https://user-images.githubusercontent.com/6216959/46145019-08caf300-c25f-11e8-943d-1abe4047ad2f.png)

@protyposis what is your opinion on this change? Shouldn't this be at least similar in all browsers on all devices?
