### PR TITLE
Replace margins with paddings to improve hit boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Avoid unnecessary animation when `BufferingOverlay` is hidden
 - Avoid unnecessary DOM modification when the text of a `Label` does not change
 
+### Changed
+- Margin to padding to improve hit-boxes
+
 ## [3.0.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Avoid unnecessary DOM modification when the text of a `Label` does not change
 
 ### Changed
-- Margin to padding to improve hit-boxes
+- Improved `Button` hit-boxes by changing margins to paddings
 
 ## [3.0.1]
 

--- a/src/scss/skin-modern/_skin-smallscreen.scss
+++ b/src/scss/skin-modern/_skin-smallscreen.scss
@@ -35,10 +35,6 @@
     > .#{$prefix}-container-wrapper {
       display: flex;
 
-      > * {
-        margin: 0 .25em;
-      }
-
       .#{$prefix}-ui-label {
         display: inline;
         font-size: 1em;

--- a/src/scss/skin-modern/components/_button.scss
+++ b/src/scss/skin-modern/components/_button.scss
@@ -6,13 +6,15 @@
   background-color: transparent;
   background-position: center;
   background-repeat: no-repeat;
+  background-origin: content-box;
   background-size: 1.5em;
   border: 0;
+  box-sizing: content-box;
   cursor: pointer;
   font-size: 1em;
   height: 1.5em;
   min-width: 1.5em;
-  padding: 1em;
+  padding: .25em;
 
   .#{$prefix}-label {
     color: $color-primary;

--- a/src/scss/skin-modern/components/_button.scss
+++ b/src/scss/skin-modern/components/_button.scss
@@ -6,12 +6,13 @@
   background-color: transparent;
   background-position: center;
   background-repeat: no-repeat;
+  background-size: 1.5em;
   border: 0;
   cursor: pointer;
   font-size: 1em;
   height: 1.5em;
   min-width: 1.5em;
-  padding: 0;
+  padding: 1em;
 
   .#{$prefix}-label {
     color: $color-primary;

--- a/src/scss/skin-modern/components/_button.scss
+++ b/src/scss/skin-modern/components/_button.scss
@@ -4,9 +4,9 @@
   @extend %ui-component;
 
   background-color: transparent;
+  background-origin: content-box;
   background-position: center;
   background-repeat: no-repeat;
-  background-origin: content-box;
   background-size: 1.5em;
   border: 0;
   box-sizing: content-box;

--- a/src/scss/skin-modern/components/_controlbar.scss
+++ b/src/scss/skin-modern/components/_controlbar.scss
@@ -15,7 +15,7 @@
   .#{$prefix}-controlbar-bottom {
     > .#{$prefix}-container-wrapper {
       display: flex;
-      margin: .5em;
+      margin: .5em 0;
     }
   }
 
@@ -33,12 +33,9 @@
     white-space: nowrap; // Required for iOS 8.2 to avoid wrapped controlbar due to wrong size calculation
 
     > .#{$prefix}-container-wrapper {
-      > * {
-        margin: 0 .25em;
-      }
 
       .#{$prefix}-ui-volumeslider {
-        margin: .25em .5em;
+        margin: auto .5em;
         width: 5em;
       }
     }

--- a/src/scss/skin-modern/components/_settingspanelpagebackbutton.scss
+++ b/src/scss/skin-modern/components/_settingspanelpagebackbutton.scss
@@ -4,10 +4,10 @@
   @extend %ui-button;
 
   font-size: .8em;
+  padding-bottom: .25em;
+  padding-top: .25em;
   position: relative;
   width: 9em;
-  padding-top: .25em;
-  padding-bottom: .25em;
 
   .#{$prefix}-label {
     display: inline-block;

--- a/src/scss/skin-modern/components/_settingspanelpagebackbutton.scss
+++ b/src/scss/skin-modern/components/_settingspanelpagebackbutton.scss
@@ -6,6 +6,8 @@
   font-size: .8em;
   position: relative;
   width: 9em;
+  padding-top: .25em;
+  padding-bottom: .25em;
 
   .#{$prefix}-label {
     display: inline-block;
@@ -17,7 +19,7 @@
       height: .6em;
       margin-left: -.8em;
       position: absolute;
-      top: .5em;
+      top: .6em;
       transform: rotate(45deg);
       width: .6em;
     }

--- a/src/scss/skin-modern/components/_settingspanelpagebackbutton.scss
+++ b/src/scss/skin-modern/components/_settingspanelpagebackbutton.scss
@@ -4,10 +4,8 @@
   @extend %ui-button;
 
   font-size: .8em;
-  padding-bottom: .25em;
-  padding-top: .25em;
   position: relative;
-  width: 9em;
+  width: 8em;
 
   .#{$prefix}-label {
     display: inline-block;

--- a/src/scss/skin-modern/components/_settingspanelpageopenbutton.scss
+++ b/src/scss/skin-modern/components/_settingspanelpageopenbutton.scss
@@ -5,7 +5,8 @@
   @extend %ui-button;
 
   background-image: svg('assets/skin-modern/images/settings.svg');
-  padding: .3em;
+  max-height: .8em;
+  padding: .3em 0;
 
   &:hover {
     @include svg-icon-shadow;

--- a/src/scss/skin-modern/components/_watermark.scss
+++ b/src/scss/skin-modern/components/_watermark.scss
@@ -6,6 +6,7 @@
   $watermark-size: 4em;
 
   background-image: svg('assets/skin-modern/images/logo.svg');
+  background-size: initial;
   height: $watermark-size;
   margin: 2em;
   opacity: .8;

--- a/src/scss/skin-modern/components/subtitlesettings/_subtitlesettingsresetbutton.scss
+++ b/src/scss/skin-modern/components/subtitlesettings/_subtitlesettingsresetbutton.scss
@@ -4,8 +4,6 @@
   @extend %ui-button;
 
   font-size: .8em;
-  padding-bottom: .25em;
-  padding-top: .25em;
   width: 12em;
 
   .#{$prefix}-label {

--- a/src/scss/skin-modern/components/subtitlesettings/_subtitlesettingsresetbutton.scss
+++ b/src/scss/skin-modern/components/subtitlesettings/_subtitlesettingsresetbutton.scss
@@ -4,9 +4,9 @@
   @extend %ui-button;
 
   font-size: .8em;
-  width: 12em;
-  padding-top: .25em;
   padding-bottom: .25em;
+  padding-top: .25em;
+  width: 12em;
 
   .#{$prefix}-label {
     display: inline-block;

--- a/src/scss/skin-modern/components/subtitlesettings/_subtitlesettingsresetbutton.scss
+++ b/src/scss/skin-modern/components/subtitlesettings/_subtitlesettingsresetbutton.scss
@@ -5,6 +5,8 @@
 
   font-size: .8em;
   width: 12em;
+  padding-top: .25em;
+  padding-bottom: .25em;
 
   .#{$prefix}-label {
     display: inline-block;


### PR DESCRIPTION
## Description
This is extracted from #178 as **part 1**.

We deiced do split #178 into two parts: first will be to just replace margins with paddings to have a slight improvement for the hit boxes. Part two would be to use available space until the edge of the UI.