### PR TITLE
Cleanup box-sizing

### DIFF
--- a/src/scss/skin-modern/_skin.scss
+++ b/src/scss/skin-modern/_skin.scss
@@ -53,13 +53,6 @@
   text-align: left;
   user-select: none;
 
-  // Include padding and border in the element's total width and height
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-
   &.#{$prefix}-player-state-idle {
     .#{$prefix}-ui-controlbar,
     .#{$prefix}-ui-titlebar,

--- a/src/scss/skin-modern/components/_controlbar.scss
+++ b/src/scss/skin-modern/components/_controlbar.scss
@@ -8,6 +8,7 @@
   @include layout-align-bottom;
 
   background: linear-gradient(to bottom, $color-transparent, $color-background-bars);
+  box-sizing: border-box;
   line-height: 1em;
   padding: 1em 1em .5em;
 

--- a/src/scss/skin-modern/components/_titlebar.scss
+++ b/src/scss/skin-modern/components/_titlebar.scss
@@ -8,6 +8,7 @@
   @include layout-align-top;
 
   background: linear-gradient(to top, $color-transparent, $color-background-bars);
+  box-sizing: border-box;
   padding: .5em 1em 1em;
   pointer-events: none;
 


### PR DESCRIPTION
#169 introduced a generic `box-sizing: border-box;` for all elements within the `UIContainer` to fix styling issues that appeared in an environment without Bootstrap or similar frameworks with certain style baseline resets.

Unfortunately this introduces the issue that UI components could not override this setting without `!important` or other complicated selector hacks.

This PR removes the generic `box-sizing` reset and only sets it in the appropriate places where necessary.