### PR TITLE
Remove outline when buttons have focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Avoid unnecessary animation when `BufferingOverlay` is hidden
 - Avoid unnecessary DOM modification when the text of a `Label` does not change
 
+### Removed
+- Blue outlines on buttons when they have focus
+
 ## [3.0.1]
 
 ### Fixed

--- a/src/scss/skin-modern/components/_button.scss
+++ b/src/scss/skin-modern/components/_button.scss
@@ -18,6 +18,10 @@
     display: none;
   }
 
+  &:focus {
+    outline: none;
+  }
+
   @include hidden;
 }
 


### PR DESCRIPTION
## Description
As discussed some time ago this will remove the blue outline from buttons when they are pressed.
![bildschirmfoto 2018-10-01 um 13 24 42](https://user-images.githubusercontent.com/6216959/46286013-d16d8680-c57d-11e8-842b-07a3c48ea6c0.png)
