### PR TITLE
Fix misplaced SettingsPanelPageOpenButton in Firefox and IE / Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Unresponsive UI when a user canceled connection establishment to a Cast receiver
 - Avoid unnecessary animation when `BufferingOverlay` is hidden
 - Avoid unnecessary DOM modification when the text of a `Label` does not change
+- Offset positioning of `SettingsPanelPageOpenButton` in some Browsers
 
 ### Changed
 - Improved `Button` hit-boxes by changing margins to paddings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Unresponsive UI when a user canceled connection establishment to a Cast receiver
 - Avoid unnecessary animation when `BufferingOverlay` is hidden
 - Avoid unnecessary DOM modification when the text of a `Label` does not change
-- Offset positioning of `SettingsPanelPageOpenButton` in some Browsers
+- Positioning of `SettingsPanelPageOpenButton` in some browsers
 - `Timeout` could not be cleared from within the timeout callback function
 
 ## [3.0.1]

--- a/src/scss/skin-modern/components/_settingspanelpageopenbutton.scss
+++ b/src/scss/skin-modern/components/_settingspanelpageopenbutton.scss
@@ -7,6 +7,7 @@
   background-image: svg('assets/skin-modern/images/settings.svg');
   max-height: .8em;
   padding: .3em 0;
+  vertical-align: bottom;
 
   &:hover {
     @include svg-icon-shadow;


### PR DESCRIPTION
## Description
As noticed in a test for #180 this is a fix for the misplaced SettingsPanelPageOpenButton in Firefox and IE / Edge.