### PR TITLE
Fix timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Improved `Button` hit-boxes by changing margins to paddings
 - `Seekbar`/`VolumeSlider` position markers changed from SVG to pure CSS to improve vertical alignment with bar
+- `Timeout` rewritten for better efficiency
 
 ### Fixed
 - Uncaught `PlayerAPINotAvailableError` in `SeekBar` position updater when player is destroyed
 - Unresponsive UI when a user canceled connection establishment to a Cast receiver
 - Avoid unnecessary animation when `BufferingOverlay` is hidden
 - Avoid unnecessary DOM modification when the text of a `Label` does not change
+- `Timeout` could not be cleared from within the timeout callback function
 
 ## [3.0.1]
 

--- a/src/ts/timeout.ts
+++ b/src/ts/timeout.ts
@@ -4,9 +4,9 @@
  */
 export class Timeout {
 
-  private delay: number;
-  private callback: () => void;
-  private repeat: boolean;
+  private readonly delay: number;
+  private readonly callback: () => void;
+  private readonly repeat: boolean;
   // There's two setTimeout declarations, one on Window which returns type "number" and one in NodeJS which returns
   // type "Timer". For unknown reasons builds on Jenkins fail due to a type mismatch when we use type "number" here,
   // although it works on other platforms (e.g. Windows, Codeship).


### PR DESCRIPTION
Fixes a bug in `Timeout` that prevented `clear()` to work from within the `callback` and improves efficiency by using `setInterval` instead of repeatedly nested `setTimeout` calls.

```ts
const timeout = new Timeout(1000, () => {
  // This did not work because due to the repeated `setTimeout` approach,
  // only the previous timeout that just triggered this callback was cleared and then
  // a new one was immediately created, and the timeout was never stopped.
 timeout.clear();
}, true);

// Worked as expected
timeout.clear();
```