### PR TITLE
IE not turning off subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [support-v2]
 
+### Changed
+- Use strings as value in select box options for subtitles
+
 ### Fixed
 - Avoid unnecessary animation when `BufferingOverlay` is hidden
 - Avoid unnecessary DOM modification when the text of a `Label` does not change

--- a/src/ts/components/selectbox.ts
+++ b/src/ts/components/selectbox.ts
@@ -48,7 +48,7 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
     // Add updated children
     for (let item of this.items) {
       let optionElement = new DOM('option', {
-        'value': item.key,
+        'value': String(item.key),
       }).html(item.label);
 
       if (item.key === String(selectedValue)) { // convert selectedValue to string to catch 'null'/null case


### PR DESCRIPTION
## Description
We have an issue that in IE it is not possible to turn off subtitles after turning it on once.

### Fix
The issue was that `null` will not be rendered in IE for the value of a select box option. The fix is to use always strings for the option value like other browsers do it by default.