### PR TITLE
Fix unintended playback starts while scrubbing on seek-bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Handling of `null` keys in `SelectBox` (fixes subtitle deselection in IE11)
+- Unintended start of playback while scrubbing on seekbar
 
 ## [3.1.0]
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -219,7 +219,6 @@ export class SeekBar extends Component<SeekBarConfig> {
     let onPlayerSeeked = () => {
       isPlayerSeeking = false;
       this.setSeeking(false);
-      restorePlayingState();
     };
 
     let restorePlayingState = function() {
@@ -278,6 +277,9 @@ export class SeekBar extends Component<SeekBarConfig> {
 
       // Notify UI manager of finished seek
       uimanager.onSeeked.dispatch(sender);
+
+      // Continue playback after seek if player was playing when seek started
+      restorePlayingState();
     });
 
     if (this.hasLabel()) {


### PR DESCRIPTION
## Description
Our scrubbing behavior that the playback stops while scrubbing was lost after some v3 changes.

## Fix
Restore playback after user-seeking not player-seeking.

_This is no issues in the v2 branch_
