### PR TITLE
Adding CSS selectors for default elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Added
+- CSS selector to default elements
+
 ### Fixed
 - Handling of `null` keys in `SelectBox` (fixes subtitle deselection in IE11)
 

--- a/src/ts/components/audioqualityselectbox.ts
+++ b/src/ts/components/audioqualityselectbox.ts
@@ -10,6 +10,10 @@ export class AudioQualitySelectBox extends SelectBox {
 
   constructor(config: ListSelectorConfig = {}) {
     super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-audio-quality-selectbox'],
+    }, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/audioqualityselectbox.ts
+++ b/src/ts/components/audioqualityselectbox.ts
@@ -12,7 +12,7 @@ export class AudioQualitySelectBox extends SelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-audio-quality-selectbox'],
+      cssClasses: ['ui-audioqualityselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/audiotrackselectbox.ts
+++ b/src/ts/components/audiotrackselectbox.ts
@@ -11,6 +11,10 @@ export class AudioTrackSelectBox extends SelectBox {
 
   constructor(config: ListSelectorConfig = {}) {
     super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-audio-track-selectbox'],
+    }, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/audiotrackselectbox.ts
+++ b/src/ts/components/audiotrackselectbox.ts
@@ -13,7 +13,7 @@ export class AudioTrackSelectBox extends SelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-audio-track-selectbox'],
+      cssClasses: ['ui-audiotrackselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -12,6 +12,10 @@ export class PlaybackSpeedSelectBox extends SelectBox {
   constructor(config: ListSelectorConfig = {}) {
     super(config);
     this.defaultPlaybackSpeeds = [0.25, 0.5, 1, 1.5, 2];
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-playback-speed-selectbox'],
+    }, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/playbackspeedselectbox.ts
+++ b/src/ts/components/playbackspeedselectbox.ts
@@ -14,7 +14,7 @@ export class PlaybackSpeedSelectBox extends SelectBox {
     this.defaultPlaybackSpeeds = [0.25, 0.5, 1, 1.5, 2];
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-playback-speed-selectbox'],
+      cssClasses: ['ui-playbackspeedselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitleselectbox.ts
+++ b/src/ts/components/subtitleselectbox.ts
@@ -13,7 +13,7 @@ export class SubtitleSelectBox extends SelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-subtitle-selectbox'],
+      cssClasses: ['ui-subtitleselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitleselectbox.ts
+++ b/src/ts/components/subtitleselectbox.ts
@@ -11,6 +11,10 @@ export class SubtitleSelectBox extends SelectBox {
 
   constructor(config: ListSelectorConfig = {}) {
     super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-subtitle-selectbox'],
+    }, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/subtitlesettings/backgroundcolorselectbox.ts
+++ b/src/ts/components/subtitlesettings/backgroundcolorselectbox.ts
@@ -11,7 +11,7 @@ export class BackgroundColorSelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-background-color-selectbox'],
+      cssClasses: ['ui-subtitlesettingsbackgroundcolorselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/backgroundcolorselectbox.ts
+++ b/src/ts/components/subtitlesettings/backgroundcolorselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different background colors.
  */
 export class BackgroundColorSelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-background-color-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/subtitlesettings/backgroundopacityselectbox.ts
+++ b/src/ts/components/subtitlesettings/backgroundopacityselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different background opacity.
  */
 export class BackgroundOpacitySelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-background-opacity-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/subtitlesettings/backgroundopacityselectbox.ts
+++ b/src/ts/components/subtitlesettings/backgroundopacityselectbox.ts
@@ -11,7 +11,7 @@ export class BackgroundOpacitySelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-background-opacity-selectbox'],
+      cssClasses: ['ui-subtitlesettingsbackgroundopacityselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/characteredgeselectbox.ts
+++ b/src/ts/components/subtitlesettings/characteredgeselectbox.ts
@@ -11,7 +11,7 @@ export class CharacterEdgeSelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-character-edge-selectbox'],
+      cssClasses: ['ui-subtitlesettingscharacteredgeselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/characteredgeselectbox.ts
+++ b/src/ts/components/subtitlesettings/characteredgeselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different character edge.
  */
 export class CharacterEdgeSelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-character-edge-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/subtitlesettings/fontcolorselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontcolorselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different font colors.
  */
 export class FontColorSelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-font-color-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/subtitlesettings/fontcolorselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontcolorselectbox.ts
@@ -11,7 +11,7 @@ export class FontColorSelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-font-color-selectbox'],
+      cssClasses: ['ui-subtitlesettingsfontcolorselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/fontfamilyselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontfamilyselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different font family.
  */
 export class FontFamilySelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-font-family-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/subtitlesettings/fontfamilyselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontfamilyselectbox.ts
@@ -11,7 +11,7 @@ export class FontFamilySelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-font-family-selectbox'],
+      cssClasses: ['ui-subtitlesettingsfontfamilyselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/fontopacityselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontopacityselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different font colors.
  */
 export class FontOpacitySelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-font-opacity-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/subtitlesettings/fontopacityselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontopacityselectbox.ts
@@ -11,7 +11,7 @@ export class FontOpacitySelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-font-opacity-selectbox'],
+      cssClasses: ['ui-subtitlesettingsfontopacityselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/fontsizeselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontsizeselectbox.ts
@@ -11,7 +11,7 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-font-size-selectbox'],
+      cssClasses: ['ui-subtitlesettingsfontsizeselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/fontsizeselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontsizeselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different font colors.
  */
 export class FontSizeSelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-font-size-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/subtitlesettings/windowcolorselectbox.ts
+++ b/src/ts/components/subtitlesettings/windowcolorselectbox.ts
@@ -11,7 +11,7 @@ export class WindowColorSelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-window-color-selectbox'],
+      cssClasses: ['ui-subtitlesettingswindowcolorselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/windowcolorselectbox.ts
+++ b/src/ts/components/subtitlesettings/windowcolorselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different background colors.
  */
 export class WindowColorSelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-window-color-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/subtitlesettings/windowopacityselectbox.ts
+++ b/src/ts/components/subtitlesettings/windowopacityselectbox.ts
@@ -11,7 +11,7 @@ export class WindowOpacitySelectBox extends SubtitleSettingSelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-window-opacity-selectbox'],
+      cssClasses: ['ui-subtitlesettingswindowopacityselectbox'],
     }, this.config);
   }
 

--- a/src/ts/components/subtitlesettings/windowopacityselectbox.ts
+++ b/src/ts/components/subtitlesettings/windowopacityselectbox.ts
@@ -1,4 +1,4 @@
-import {SubtitleSettingSelectBox} from './subtitlesettingselectbox';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 import {UIInstanceManager} from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,14 @@ import { PlayerAPI } from 'bitmovin-player';
  * A select box providing a selection of different background opacity.
  */
 export class WindowOpacitySelectBox extends SubtitleSettingSelectBox {
+
+  constructor(config: SubtitleSettingSelectBoxConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-window-opacity-selectbox'],
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/videoqualityselectbox.ts
+++ b/src/ts/components/videoqualityselectbox.ts
@@ -12,6 +12,10 @@ export class VideoQualitySelectBox extends SelectBox {
 
   constructor(config: ListSelectorConfig = {}) {
     super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClasses: ['ui-video-quality-selectbox'],
+    }, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/videoqualityselectbox.ts
+++ b/src/ts/components/videoqualityselectbox.ts
@@ -14,7 +14,7 @@ export class VideoQualitySelectBox extends SelectBox {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['ui-video-quality-selectbox'],
+      cssClasses: ['ui-videoqualityselectbox'],
     }, this.config);
   }
 


### PR DESCRIPTION
## Description
Some default elements such as select boxes to style the subtitles does not have specific css selectors.

## Changes
Adding css selectors where they were missing. 