### PR TITLE
[v2] Simplify volume handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [support-v2]
 
+### Changed
+- Handle audio volume and mute state separately again (pre v2.14.0 behavior)
+
 ### Fixed
 - Avoid unnecessary animation when `BufferingOverlay` is hidden
 - Avoid unnecessary DOM modification when the text of a `Label` does not change

--- a/src/scss/skin-modern/components/_volumetogglebutton.scss
+++ b/src/scss/skin-modern/components/_volumetogglebutton.scss
@@ -13,10 +13,7 @@
   }
 
   &.#{$prefix}-unmuted {
-    &[data-#{$prefix}-volume-level-tens='0'] {
-      background-image: svg('assets/skin-modern/images/music-off.svg');
-    }
-
+    &[data-#{$prefix}-volume-level-tens='0'],
     &[data-#{$prefix}-volume-level-tens='1'],
     &[data-#{$prefix}-volume-level-tens='2'],
     &[data-#{$prefix}-volume-level-tens='3'],

--- a/src/ts/components/volumetogglebutton.ts
+++ b/src/ts/components/volumetogglebutton.ts
@@ -25,14 +25,6 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
     let muteStateHandler = () => {
       if (player.isMuted()) {
         this.on();
-
-        // When the volume is unmuted and the volume level is veeeery low, we increase it to 10%. This especially helps
-        // in the case when the volume is first turned down to 0 and then the player is muted; when the player gets
-        // unmuted it would switch to volume level 0 which would seem like unmuting did not work, and increasing the
-        // level a bit helps to overcome this issue.
-        if (player.getVolume() < 10) {
-          player.setVolume(10);
-        }
       } else {
         this.off();
       }
@@ -41,14 +33,6 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
     let volumeLevelHandler = () => {
       const volumeLevelTens = Math.ceil(player.getVolume() / 10);
       this.getDomElement().data(this.prefixCss('volume-level-tens'), String(volumeLevelTens));
-
-      // When the volume is turned down to zero, switch into the mute state of the button. This avoids the usability
-      // issue where the volume is turned down to zero, the button shows the muted icon but is not really unmuted, and
-      // the next button press would switch it into the mute state, visually staying the same which would seem like
-      // an expected unmute did not work.
-      if (volumeLevelTens === 0) {
-        this.off();
-      }
     };
 
     player.addEventHandler(player.EVENT.ON_MUTED, muteStateHandler);


### PR DESCRIPTION
Once upon a time, the `VolumeToggleButton` displayed the mute icon when the volume was turned down to `0`. `player.isMuted()` still returned `false` because it was only the volume that was turned down, but no `player.mute()` call was done. When the user then pressed the `VolumeToggleButton`, it changed the mute state to `isMuted() === true`. In the mute state the muted icon is shown, but because it was already shown for the zero volume, nothing changed in the UI and to the user it seemed as if pressing the button did not work.

Then came #94 with the aspiration to mitigate this UX issue. Since then, it considered both `muted === true` and `volume === 0` to be muted states, so no matter if the player was muted or just the volume was turned down, a click on the button while showing the muted icon unmuted the player and raised the volume to 10% to give the user a feedback that pressing the button actually worked and the muted icon would change to the low-volume icon.

Today it turned out that this badly influences the player API, as `player.mute()` did not always work correctly when the UI was used: 

```ts
player.setVolume(0); // [player.isMuted(), player.getVolume()] => [false, 0]

// Mute the player. It is expected that isMuted() returns true afterwards
player.mute(); // [player.isMuted(), player.getVolume()] => [false, 10]
// Actually, it turned the volume to 10 instead of muting because the UI unexpectedly interfered

// A second mute call was needed to get the player into the muted state
player.mute(); // [player.isMuted(), player.getVolume()] => [true, 10]
```

The UI must not have any influence on the mechanics of the API though, so this PR removes the "UX optimization" of unifying of the mute and zero-volume states.  It now simply displays the low-volume icon for zero volume and the mute icon when the player is muted. A press on the toggle button when the volume is zero thus switches the low-volume icon to the muted icon, and vice versa, so the user now always gets a visual feedback to button presses as well.