### PR TITLE
[v2] Improve volume handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Support for image subtitles
+- `VolumeController` to control and manage volume and mute state by multiple `Component`s in a single place
 
 ### Fixed
 - Missing custom `SkipMessage` texts while playing an advertisement
+- `VolumeToggleButton` interfered player API `setVolume`/`mute`/`unmute` calls
 
 ## [2.18.0] (2018-08-08)
 

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -85,6 +85,9 @@ export class VolumeSlider extends SeekBar {
     uimanager.onConfigured.subscribe(() => {
       this.refreshPlaybackPosition();
     });
+
+    // Init
+    volumeController.onChangedEvent();
   }
 
   private detectVolumeControlAvailability(): boolean {

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -1,6 +1,6 @@
 import {SeekBar, SeekBarConfig} from './seekbar';
 import {UIInstanceManager} from '../uimanager';
-import { VolumeController, VolumeTransition } from '../volumecontroller';
+import { VolumeTransition } from '../volumecontroller';
 
 /**
  * Configuration interface for the {@link VolumeSlider} component.

--- a/src/ts/components/volumeslider.ts
+++ b/src/ts/components/volumeslider.ts
@@ -10,7 +10,7 @@ export interface VolumeSliderConfig extends SeekBarConfig {
    * browser or platform. This currently only applies to iOS.
    * Default: true
    */
-  hideIfVolumeControlProhibited: boolean;
+  hideIfVolumeControlProhibited?: boolean;
 }
 
 /**
@@ -20,7 +20,7 @@ export class VolumeSlider extends SeekBar {
 
   private static readonly issuerName = 'ui';
 
-  constructor(config: SeekBarConfig = {}) {
+  constructor(config: VolumeSliderConfig = {}) {
     super(config);
 
     this.config = this.mergeConfig(config, <VolumeSliderConfig>{

--- a/src/ts/components/volumetogglebutton.ts
+++ b/src/ts/components/volumetogglebutton.ts
@@ -36,7 +36,11 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
     });
 
     this.onClick.subscribe(() => {
-      volumeController.toggleMuted();
+      if (volumeController.isMuted() || volumeController.getVolume() === 0) {
+        volumeController.recallVolume();
+      } else {
+        volumeController.toggleMuted();
+      }
     });
   }
 }

--- a/src/ts/components/volumetogglebutton.ts
+++ b/src/ts/components/volumetogglebutton.ts
@@ -27,28 +27,12 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
     volumeController.onChanged.subscribe((_, args) => {
       if (args.muted) {
         this.on();
-
-        // When the volume is unmuted and the volume level is veeeery low, we increase it to 10%. This especially helps
-        // in the case when the volume is first turned down to 0 and then the player is muted; when the player gets
-        // unmuted it would switch to volume level 0 which would seem like unmuting did not work, and increasing the
-        // level a bit helps to overcome this issue.
-        if (args.volume < 10) {
-          volumeController.setVolume(10);
-        }
       } else {
         this.off();
       }
 
       const volumeLevelTens = Math.ceil(args.volume / 10);
       this.getDomElement().data(this.prefixCss('volume-level-tens'), String(volumeLevelTens));
-
-      // When the volume is turned down to zero, switch into the mute state of the button. This avoids the usability
-      // issue where the volume is turned down to zero, the button shows the muted icon but is not really unmuted, and
-      // the next button press would switch it into the mute state, visually staying the same which would seem like
-      // an expected unmute did not work.
-      if (volumeLevelTens === 0) {
-        this.off();
-      }
     });
 
     this.onClick.subscribe(() => {

--- a/src/ts/components/volumetogglebutton.ts
+++ b/src/ts/components/volumetogglebutton.ts
@@ -22,24 +22,24 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
   configure(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let muteStateHandler = () => {
-      if (player.isMuted()) {
+    const volumeController = uimanager.getConfig().volumeController;
+
+    volumeController.onChanged.subscribe((_, args) => {
+      if (args.muted) {
         this.on();
 
         // When the volume is unmuted and the volume level is veeeery low, we increase it to 10%. This especially helps
         // in the case when the volume is first turned down to 0 and then the player is muted; when the player gets
         // unmuted it would switch to volume level 0 which would seem like unmuting did not work, and increasing the
         // level a bit helps to overcome this issue.
-        if (player.getVolume() < 10) {
-          player.setVolume(10);
+        if (args.volume < 10) {
+          volumeController.setVolume(10);
         }
       } else {
         this.off();
       }
-    };
 
-    let volumeLevelHandler = () => {
-      const volumeLevelTens = Math.ceil(player.getVolume() / 10);
+      const volumeLevelTens = Math.ceil(args.volume / 10);
       this.getDomElement().data(this.prefixCss('volume-level-tens'), String(volumeLevelTens));
 
       // When the volume is turned down to zero, switch into the mute state of the button. This avoids the usability
@@ -49,22 +49,10 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
       if (volumeLevelTens === 0) {
         this.off();
       }
-    };
-
-    player.addEventHandler(player.EVENT.ON_MUTED, muteStateHandler);
-    player.addEventHandler(player.EVENT.ON_UNMUTED, muteStateHandler);
-    player.addEventHandler(player.EVENT.ON_VOLUME_CHANGED, volumeLevelHandler);
-
-    this.onClick.subscribe(() => {
-      if (player.isMuted()) {
-        player.unmute('ui-volumetogglebutton');
-      } else {
-        player.mute('ui-volumetogglebutton');
-      }
     });
 
-    // Startup init
-    muteStateHandler();
-    volumeLevelHandler();
+    this.onClick.subscribe(() => {
+      volumeController.toggleMuted();
+    });
   }
 }

--- a/src/ts/components/volumetogglebutton.ts
+++ b/src/ts/components/volumetogglebutton.ts
@@ -36,11 +36,7 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
     });
 
     this.onClick.subscribe(() => {
-      if (volumeController.isMuted() || volumeController.getVolume() === 0) {
-        volumeController.recallVolume();
-      } else {
-        volumeController.toggleMuted();
-      }
+      volumeController.toggleMuted();
     });
 
     // Init

--- a/src/ts/components/volumetogglebutton.ts
+++ b/src/ts/components/volumetogglebutton.ts
@@ -42,5 +42,8 @@ export class VolumeToggleButton extends ToggleButton<ToggleButtonConfig> {
         volumeController.toggleMuted();
       }
     });
+
+    // Init
+    volumeController.onChangedEvent();
   }
 }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -51,6 +51,7 @@ import {UIUtils} from './uiutils';
 import {ArrayUtils} from './arrayutils';
 import {BrowserUtils} from './browserutils';
 import { PlayerUtils } from './playerutils';
+import { VolumeController } from './volumecontroller';
 
 export interface UIRecommendationConfig {
   title: string;
@@ -123,6 +124,7 @@ export interface InternalUIConfig extends UIConfig {
      */
     onUpdated: EventDispatcher<UIManager, void>;
   };
+  volumeController: VolumeController;
 }
 
 /**
@@ -234,13 +236,14 @@ export class UIManager {
     }
 
     this.player = player;
+    this.managerPlayerWrapper = new PlayerWrapper(player);
     this.config = {
       ...config,
       events: {
         onUpdated: new EventDispatcher<UIManager, void>(),
       },
+      volumeController: new VolumeController(this.managerPlayerWrapper.getPlayer()),
     };
-    this.managerPlayerWrapper = new PlayerWrapper(player);
 
     /**
      * Gathers configuration data from the UI config and player source config and creates a merged UI config

--- a/src/ts/volumecontroller.ts
+++ b/src/ts/volumecontroller.ts
@@ -70,7 +70,13 @@ export class VolumeController {
   }
 
   protected onChangedEvent() {
-    this.events.onChanged.dispatch(this, { volume: this.getVolume(), muted: this.isMuted() });
+    const playerMuted = this.isMuted();
+    const playerVolume = this.getVolume();
+
+    const uiMuted = playerMuted || playerVolume === 0;
+    const uiVolume = playerMuted ? 0 : playerVolume;
+
+    this.events.onChanged.dispatch(this, { volume: uiVolume, muted: uiMuted });
   }
 
   /**

--- a/src/ts/volumecontroller.ts
+++ b/src/ts/volumecontroller.ts
@@ -1,0 +1,82 @@
+import { Event, EventDispatcher } from './eventdispatcher';
+
+export interface VolumeSettingChangedArgs {
+  volume: number;
+  muted: boolean;
+}
+
+/**
+ * Can be used to centrally manage and control the volume and mute state of the player from multiple components.
+ */
+export class VolumeController {
+
+  private static readonly issuerName = 'ui-volumecontroller';
+
+  private readonly events = {
+    onChanged: new EventDispatcher<VolumeController, VolumeSettingChangedArgs>(),
+  };
+
+  private storedVolume: number;
+
+  constructor(private readonly player: bitmovin.PlayerAPI) {
+    this.storeVolume();
+
+    const handler = () => {
+      this.onChangedEvent();
+    };
+
+    player.addEventHandler(player.EVENT.ON_READY, handler);
+    player.addEventHandler(player.EVENT.ON_VOLUME_CHANGED, handler);
+    player.addEventHandler(player.EVENT.ON_MUTED, handler);
+    player.addEventHandler(player.EVENT.ON_UNMUTED, handler);
+  }
+
+  setVolume(volume: number): void {
+    this.player.setVolume(volume, VolumeController.issuerName);
+  }
+
+  getVolume(): number {
+    return this.player.getVolume();
+  }
+
+  setMuted(muted: boolean): void {
+    if (muted) {
+      this.player.mute(VolumeController.issuerName);
+    } else {
+      this.player.unmute(VolumeController.issuerName);
+    }
+  }
+
+  toggleMuted(): void {
+    this.setMuted(!this.isMuted());
+  }
+
+  isMuted(): boolean {
+    return this.player.isMuted();
+  }
+
+  /**
+   * Stores (saves) the current volume so it can later be restored with {@link recallVolume}.
+   */
+  storeVolume(): void {
+    this.storedVolume = this.getVolume();
+  }
+
+  /**
+   * Recalls (sets) the volume previously stored with {@link storeVolume}.
+   */
+  recallVolume(): void {
+    this.setVolume(this.storedVolume);
+  }
+
+  protected onChangedEvent() {
+    this.events.onChanged.dispatch(this, { volume: this.getVolume(), muted: this.isMuted() });
+  }
+
+  /**
+   * Gets the event that is fired when the volume settings have changed.
+   */
+  get onChanged(): Event<VolumeController, VolumeSettingChangedArgs> {
+    return this.events.onChanged.getEvent();
+  }
+}

--- a/src/ts/volumecontroller.ts
+++ b/src/ts/volumecontroller.ts
@@ -48,7 +48,13 @@ export class VolumeController {
   }
 
   toggleMuted(): void {
-    this.setMuted(!this.isMuted());
+    if (this.isMuted() || this.getVolume() === 0) {
+      // Unmuting from the mute or zero-volume state recalls the previously saved volume setting. Setting the
+      // volume automatically unmutes the player in v7.
+      this.recallVolume();
+    } else {
+      this.setMuted(true);
+    }
   }
 
   isMuted(): boolean {

--- a/src/ts/volumecontroller.ts
+++ b/src/ts/volumecontroller.ts
@@ -69,7 +69,7 @@ export class VolumeController {
     this.setVolume(this.storedVolume);
   }
 
-  protected onChangedEvent() {
+  onChangedEvent() {
     const playerMuted = this.isMuted();
     const playerVolume = this.getVolume();
 


### PR DESCRIPTION
Once upon a time, the `VolumeToggleButton` displayed the mute icon when the volume was turned down to `0`. `player.isMuted()` still returned `false` because it was only the volume that was turned down, but no `player.mute()` call was done. When the user then pressed the `VolumeToggleButton`, it changed the mute state to `isMuted() === true`. In the mute state the muted icon is shown, but because it was already shown for the zero volume, nothing changed in the UI and to the user it seemed as if pressing the button did not work.

Then came #94 with the aspiration to mitigate this UX issue. Since then, it considered both `muted === true` and `volume === 0` to be muted states, so no matter if the player was muted or just the volume was turned down, a click on the button while showing the muted icon unmuted the player and raised the volume to 10% to give the user a feedback that pressing the button actually worked and the muted icon would change to the low-volume icon.

It turned out that this badly influences the player API, as `player.mute()` did not always work correctly when the UI was used: 

```ts
player.setVolume(0); // [player.isMuted(), player.getVolume()] => [false, 0]

// Mute the player. It is expected that isMuted() returns true afterwards
player.mute(); // [player.isMuted(), player.getVolume()] => [false, 10]
// Actually, it turned the volume to 10 instead of muting because the UI unexpectedly interfered

// A second mute call was needed to get the player into the muted state
player.mute(); // [player.isMuted(), player.getVolume()] => [true, 10]
```

The UI must not have any influence on the mechanics of the API though, so this PR rewrites the volume and mute state handling by moving all logic into a single `VolumeController` instance. Unmuting now sets the volume to the last "valid" value instead of an arbitrary 10%. 

Replaces #196.