### PR TITLE
[v2] Set playbackSpeedSelectionEnabled to true per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [support-v2]
 
+### Changed
+- Set `UIConfig.playbackSpeedSelectionEnabled` to true per default
+
 ### Fixed
 - Avoid unnecessary animation when `BufferingOverlay` is hidden
 - Avoid unnecessary DOM modification when the text of a `Label` does not change

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -247,7 +247,6 @@
 //      {title: 'Recommendation 11', url: 'http://bitmovin.com', thumbnail: 'http://placehold.it/300x300', duration: 435},
 //      {title: 'Recommendation 12: Ain\'t no better video than this', url: 'http://bitmovin.com', thumbnail: 'http://placehold.it/300x300', duration: 34}
 //    ],
-      playbackSpeedSelectionEnabled: true
   };
 
   var player;

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -111,7 +111,7 @@ export interface UIConfig {
   autoUiVariantResolve?: boolean;
   /**
    * Specifies if the `PlaybackSpeedSelectBox` should be displayed within the `SettingsPanel`
-   * Default: false
+   * Default: true
    */
   playbackSpeedSelectionEnabled?: boolean;
 }
@@ -231,6 +231,11 @@ export class UIManager {
     else {
       // Default constructor (UIVariant[]) has been called
       this.uiVariants = <UIVariant[]>playerUiOrUiVariants;
+    }
+
+    // Switch on speed selector by default
+    if (config.playbackSpeedSelectionEnabled === undefined) {
+      config.playbackSpeedSelectionEnabled = true;
     }
 
     this.player = player;

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -233,13 +233,10 @@ export class UIManager {
       this.uiVariants = <UIVariant[]>playerUiOrUiVariants;
     }
 
-    // Switch on speed selector by default
-    if (config.playbackSpeedSelectionEnabled === undefined) {
-      config.playbackSpeedSelectionEnabled = true;
-    }
-
     this.player = player;
     this.config = {
+      playbackSpeedSelectionEnabled: true, // Switch on speed selector by default
+      autoUiVariantResolve: true, // Switch on auto UI resolving by default
       ...config,
       events: {
         onUpdated: new EventDispatcher<UIManager, void>(),
@@ -322,11 +319,6 @@ export class UIManager {
       throw Error('Invalid UI variant order: the default UI (without condition) must be at the end of the list');
     }
 
-    // Switch on auto UI resolving by default
-    if (config.autoUiVariantResolve === undefined) {
-      config.autoUiVariantResolve = true;
-    }
-
     let adStartedEvent: AdStartedEvent = null; // keep the event stored here during ad playback
 
     // Dynamically select a UI variant that matches the current UI condition.
@@ -383,7 +375,7 @@ export class UIManager {
     };
 
     // Listen to the following events to trigger UI variant resolution
-    if (config.autoUiVariantResolve) {
+    if (this.config.autoUiVariantResolve) {
       this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_READY, resolveUiVariant);
       this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_PLAY, resolveUiVariant);
       this.managerPlayerWrapper.getPlayer().addEventHandler(this.player.EVENT.ON_PAUSED, resolveUiVariant);


### PR DESCRIPTION
## Description
We disabled the playback speed selection per default as we implemented the `playbackSpeedSelectionEnabled` flag.

## Changes
We decided to enable the speed selection per default again.

## TODO

- [ ] forward port to v3