### PR TITLE
Add enable and disable functionality to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - CSS selector to default elements
 - `VolumeController` to control and manage volume and mute state by multiple `Component`s in a single place
+- `disable()` / `enable()` functionality to `Component`s
+- Preventing click event on a disabled `Button`
 
 ### Changed
 - Set `UIConfig.playbackSpeedSelectionEnabled` to true per default

--- a/src/scss/skin-modern/components/_button.scss
+++ b/src/scss/skin-modern/components/_button.scss
@@ -21,6 +21,21 @@
     display: none;
   }
 
+  &.#{$prefix}-disabled {
+    cursor: default;
+
+    &,
+    > * {
+      pointer-events: none;
+    }
+
+    .#{$prefix}-label {
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+
   @include hidden;
 }
 

--- a/src/ts/components/adskipbutton.ts
+++ b/src/ts/components/adskipbutton.ts
@@ -47,8 +47,10 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       if (player.getCurrentTime() < skipOffset) {
         this.setText(
           StringUtils.replaceAdMessagePlaceholders(skipMessage.countdown, skipOffset, player));
+        this.disable();
       } else {
         this.setText(skipMessage.skip);
+        this.enable();
       }
     };
 


### PR DESCRIPTION
## Description
As we want to disable the `AdSkipButton` during the countdown we needed some mechanism to enable / disable components. (Ads UI PR #201)

## Added
This will add `disable()` / `enable()` methods and disable click events on buttons.