### PR TITLE
Hide UI during playback of ads without UI requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Changed
+- Default UI does not show any UI variant during an ad without UI requirement
+
 ## [3.3.0]
 
 ### Added
@@ -479,6 +484,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.3.0...develop
 [3.3.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.0.1...v3.1.0

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -328,10 +328,14 @@ export namespace UIFactory {
     }, {
       ui: modernSmallScreenUI(),
       condition: (context: UIConditionContext) => {
-        return context.isMobile && context.documentWidth < smallScreenSwitchWidth;
+        return !context.isAd && !context.adRequiresUi && context.isMobile
+          && context.documentWidth < smallScreenSwitchWidth;
       },
     }, {
       ui: modernUI(),
+      condition: (context: UIConditionContext) => {
+        return !context.isAd && !context.adRequiresUi;
+      },
     }], config);
   }
 
@@ -343,6 +347,9 @@ export namespace UIFactory {
       },
     }, {
       ui: modernSmallScreenUI(),
+      condition: (context: UIConditionContext) => {
+        return !context.isAd && !context.adRequiresUi;
+      },
     }], config);
   }
 


### PR DESCRIPTION
Fixes an issue when the UI is used with IMA advertising in the player. It could happen that the UI is visible during playback of ads, even if the ads do not require an UI and/or bring their own UI:

 * if the UI was loaded after the player / IMA advertising module, it was always overlaying the IMA container and thus shown during ads playback
 * if the UI was underlaying the IMA container but the IMA SDK reused the player's video element instead of creating its own (as it happens in Safari on iOS), IMA only rendered its transparent UI in the container and both UIs were visible in parallel

To fix this, the UI variant switching was changed so that there is no catch-all UI variant, but the "normal" content UI is only shown for actual content and excluded for ads.

This fix only works for the default UI, custom UIs with custom variant switching need to implement a similar fix on their own.