### PR TITLE
Custom user interaction event source element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Added
+- `UIContainerConfig.userInteractionEventSource` to allow tracking of user interaction events (to show/hide UI) on a custom element
+
 ## [3.3.1]
 
 ### Changed
@@ -484,6 +489,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.3.1...develop
 [3.3.1]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.1.0...v3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Added
-- `UIContainerConfig.userInteractionEventSource` to allow tracking of user interaction events (to show/hide UI) on a custom element
+- `UIContainerConfig.userInteractionEventSource` to allow tracking of user interaction events (which toggle the visibility of certain components like the `ControlBar`) on a custom element
 
 ## [3.3.1]
 


### PR DESCRIPTION
Currently the `UIContainer` (which is the root `Component` of a UI structure) tracks user interaction events, i.e. mouse and touch events, on its own HTML element to determine if the UI should be shown or hidden. This only works if the `UIContainer` actually spans over the video player, which only happens if a "filling" overlay is added as a child component, e.g. the `PlaybackToggleOverlay`. Without such a "filling" overlay, the `UIContainer` does not physically cover the video frame and therefore does not capture the necessary events to show/hide the UI.

Now the problem is that with interactive ads, i.e. ads with control buttons like with the IMA SDK or VPAID in general, we cannot use such filling overlays because they would capture all input events and thus block them from the buttons of the interactive ads that lie below them. When omitting these overlays howlever, we lose capturing of such events and cannot show/hide the UI by user interaction.

This PR adds an optional configuration property to the `UIContainer`, `UIContainerConfig.userInteractionEventSource`, which can be used to supply a n external HTML element that will be used to track the user interaction events instead of the `UIContainer` itself. This can be for example an ads container of the player container (`player.getContainer()`). This way, user interaction can becaptured without a filling overlay component in the UI and show/hide the UI as expected while still allowing user interaction on interactive ads.