### PR TITLE
Do not keep updating the skipMessage if the ad is not skippable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `UIContainerConfig.userInteractionEventSource` to allow tracking of user interaction events (which toggle the visibility of certain components like the `ControlBar`) on a custom element
 
 ### Changed
-- Hidden `adSkipButton` is not constantly updated anymore if a non skippable ad is playing
+- Avoid unnecessary updating of hidden `AdSkipButton`
 
 ## [3.3.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `UIContainerConfig.userInteractionEventSource` to allow tracking of user interaction events (which toggle the visibility of certain components like the `ControlBar`) on a custom element
 
+### Changed
+- Hidden `SkipMessage` is not constantly updated anymore if an ad is playing and is not skippable
+
 ## [3.3.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `UIContainerConfig.userInteractionEventSource` to allow tracking of user interaction events (which toggle the visibility of certain components like the `ControlBar`) on a custom element
 
 ### Changed
-- Hidden `SkipMessage` is not constantly updated anymore if an ad is playing and is not skippable
+- Hidden `adSkipButton` is not constantly updated anymore if a non skippable ad is playing
 
 ## [3.3.1]
 

--- a/src/ts/components/adskipbutton.ts
+++ b/src/ts/components/adskipbutton.ts
@@ -44,12 +44,13 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
 
     let updateSkipMessageHandler = () => {
       // Display this button only if ad is skippable
-      // non skippable ads will return -1 for skippableAfter
-      if (skipOffset >= 0) {
-        this.show();
-      } else {
-        this.hide();
+      // non skippable ads will return -1 for skippableAfter for player version < v8.3.0
+      if (!skipOffset || skipOffset < 0) {
+        this.hide()
+        return;
       }
+
+      this.show();
 
       // Update the skip message on the button
       if (player.getCurrentTime() < skipOffset) {

--- a/src/ts/components/adskipbutton.ts
+++ b/src/ts/components/adskipbutton.ts
@@ -46,7 +46,7 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       // Display this button only if ad is skippable
       // non skippable ads will return -1 for skippableAfter for player version < v8.3.0
       if (!skipOffset || skipOffset < 0) {
-        this.hide()
+        this.hide();
         return;
       }
 

--- a/src/ts/components/adskipbutton.ts
+++ b/src/ts/components/adskipbutton.ts
@@ -43,13 +43,6 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
     let skipOffset = -1;
 
     let updateSkipMessageHandler = () => {
-      // Display this button only if ad is skippable
-      // non skippable ads will return -1 for skippableAfter for player version < v8.3.0
-      if (!skipOffset || skipOffset < 0) {
-        this.hide();
-        return;
-      }
-
       this.show();
 
       // Update the skip message on the button
@@ -68,9 +61,14 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       untilSkippableMessage = ad.uiConfig && ad.uiConfig.untilSkippableMessage || config.untilSkippableMessage;
       skippableMessage = ad.uiConfig && ad.uiConfig.skippableMessage || config.skippableMessage;
 
-      updateSkipMessageHandler();
-
-      player.on(player.exports.PlayerEvent.TimeChanged, updateSkipMessageHandler);
+      // Display this button only if ad is skippable.
+      // Non-skippable ads will return -1 for skippableAfter for player version < v8.3.0.
+      if (typeof skipOffset === 'number' && skipOffset >= 0) {
+        updateSkipMessageHandler();
+        player.on(player.exports.PlayerEvent.TimeChanged, updateSkipMessageHandler);
+      } else {
+        this.hide();
+      }
     };
 
     let adEndHandler = () => {


### PR DESCRIPTION
### Description
The text of the skip button was constantly re-set to the same message, even though the button is hidden because the active ad is not skippable.

### Fix
`updateSkipMessageHandler` now returns early if the active ad is not skippable.

Additionally, in player version < `v8.3.0`, `Ad.skippableAfter` was always set to `-1` if an ad was not skippable. Starting with `v8.3.0`, `Ad.skippableAfter` will not be set if an ad is not skippable. I adjusted the relevant check to support both cases.