### PR TITLE
Fix stopping time shift offset updater of SeekBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Stopping time shift offset updater of `SeekbBar` when player is destroyed
+
 ## [3.4.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Fixed
-- Stopping time shift offset updater of `SeekbBar` when player is destroyed
+- Stopping timeshift offset updater of `SeekBar` when player is destroyed
 
 ## [3.4.0]
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -484,6 +484,10 @@ export class SeekBar extends Component<SeekBarConfig> {
     if (this.smoothPlaybackPositionUpdater) { // object must not necessarily exist, e.g. in volume slider subclass
       this.smoothPlaybackPositionUpdater.clear();
     }
+
+    if (this.pausedTimeshiftUpdater) {
+      this.pausedTimeshiftUpdater.clear();
+    }
   }
 
   protected toDomElement(): DOM {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -86,6 +86,7 @@ export class SeekBar extends Component<SeekBarConfig> {
   private playbackPositionPercentage = 0;
 
   private smoothPlaybackPositionUpdater: Timeout;
+  private pausedTimeshiftUpdater: Timeout;
 
   // https://hacks.mozilla.org/2013/04/detecting-touch-its-the-why-not-the-how/
   private touchSupported = ('ontouchstart' in window);
@@ -350,17 +351,17 @@ export class SeekBar extends Component<SeekBarConfig> {
   private configureLivePausedTimeshiftUpdater(player: PlayerAPI, uimanager: UIInstanceManager,
                                               playbackPositionHandler: () => void): void {
     // Regularly update the playback position while the timeout is active
-    const pausedTimeshiftUpdater = new Timeout(1000, playbackPositionHandler, true);
+     this.pausedTimeshiftUpdater = new Timeout(1000, playbackPositionHandler, true);
 
     // Start updater when a live stream with timeshift window is paused
     player.on(player.exports.PlayerEvent.Paused, () => {
       if (player.isLive() && player.getMaxTimeShift() < 0) {
-        pausedTimeshiftUpdater.start();
+        this.pausedTimeshiftUpdater.start();
       }
     });
 
-    // Stop updater when playback continues (no matter if the updater was started before)
-    player.on(player.exports.PlayerEvent.Play, () => pausedTimeshiftUpdater.clear());
+    // Stop updater when playback continues or player is destroyed (no matter if the updater was started before)
+    player.on(player.exports.PlayerEvent.Play, () => this.pausedTimeshiftUpdater.clear());
   }
 
   private configureSmoothPlaybackPositionUpdater(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -360,7 +360,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       }
     });
 
-    // Stop updater when playback continues or player is destroyed (no matter if the updater was started before)
+    // Stop updater when playback continues (no matter if the updater was started before)
     player.on(player.exports.PlayerEvent.Play, () => this.pausedTimeshiftUpdater.clear());
   }
 


### PR DESCRIPTION
### Issue

If the player is paused on a live stream that has a time shift window, a `Timeout` is started which periodically updates the displayed time shift offset of the seek bar. In case the player is destroyed in this state, the updater would not get stopped and would cause uncaught `PlayerAPINotAvailableError`s.


### Fix
Added clearing the updater when `release` is called on the `SeekBar`.