### PR TITLE
Fix box-sizing for seekbar elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `box-sizing: border-box` to `.-seekbar` to improve playback position marker
+- `simple.html` to test plain UI css without bootstrap
 
 ### Fixed
 - Stopping timeshift offset updater of `SeekBar` when player is destroyed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Added
-- `box-sizing: border-box` to `.-seekbar` to improve playback position marker
-- `simple.html` to test plain UI css without bootstrap
+- `simple.html` to test plain UI CSS without Bootstrap
 
 ### Fixed
 - Stopping timeshift offset updater of `SeekBar` when player is destroyed
-- Size of the `SeekbarLabel` by adding `box-sizing: border-box` to `.-seekbar-label-metadata` 
+- `box-sizing` style of `SeekBar` and `SeekBarLabel` 
 
 ## [3.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Added
+- `box-sizing: border-box` to `.-seekbar` to improve playback position marker
+
 ### Fixed
 - Stopping timeshift offset updater of `SeekBar` when player is destroyed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Stopping timeshift offset updater of `SeekBar` when player is destroyed
+- Size of the `SeekbarLabel` by adding `box-sizing: border-box` to `.-seekbar-label-metadata` 
 
 ## [3.4.0]
 

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -18,7 +18,10 @@
     <br>
 
     <div class="card">
-        <h3 class="card-header">Playground</h3>
+        <div class="card-header">
+            <h3 class="float-sm-left">Playground</h3>
+            <a class="float-sm-right" href="simple.html">Test plain CSS</a>
+        </div>
 
         <div class="card-block">
             <h4 class="card-title">Player Config</h4>

--- a/src/html/simple.html
+++ b/src/html/simple.html
@@ -22,22 +22,6 @@
     <link rel="stylesheet" href="css/bitmovinplayer-ui.css">
 
     <style>
-        .container {
-            color: white;
-            text-align: center;
-        }
-        .container a {
-            color: white;
-        }
-        .container h1 {
-            margin-bottom: 22px;
-            line-height: 66px;
-        }
-        .container h2 {
-            font-weight: normal;
-            margin-bottom: 36px;
-            line-height: 26px;
-        }
         .player-wrapper {
             width: 95%;
             margin: 20px auto;
@@ -48,6 +32,7 @@
 <body>
 <div class="container">
     <div class="content">
+        <a href="index.html"><- Back to playground</a>
         <div class="player-wrapper">
             <div id="player"></div>
         </div>

--- a/src/html/simple.html
+++ b/src/html/simple.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<!--
+*
+* Copyright (C) 2019, bitmovin GmbH, All Rights Reserved
+*
+* This source code and its use and distribution, is subject to the terms
+* and conditions of the applicable license agreement.
+*
+-->
+<html lang="en">
+<head>
+    <title>Bitmovin Player UI Demo</title>
+    <meta charset="UTF-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- Bitmovin Player -->
+    <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
+
+    <!-- UI -->
+    <script src="js/bitmovinplayer-ui.js"></script>
+    <link rel="stylesheet" href="css/bitmovinplayer-ui.css">
+
+    <style>
+        .container {
+            color: white;
+            text-align: center;
+        }
+        .container a {
+            color: white;
+        }
+        .container h1 {
+            margin-bottom: 22px;
+            line-height: 66px;
+        }
+        .container h2 {
+            font-weight: normal;
+            margin-bottom: 36px;
+            line-height: 26px;
+        }
+        .player-wrapper {
+            width: 95%;
+            margin: 20px auto;
+            box-shadow: 0 0 30px rgba(0,0,0,0.7);
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="content">
+        <div class="player-wrapper">
+            <div id="player"></div>
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    var conf = {
+        key: '',
+        ui: false,
+        playback: {
+            muted: true,
+            autoplay: true,
+        }
+    };
+
+    var source = {
+        dash: '//bitdash-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+        hls: '//bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+        progressive: '//bitdash-a.akamaihd.net/content/MI201109210084_1/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
+        poster: '//bitdash-a.akamaihd.net/content/art-of-motion_drm/art-of-motion_poster.jpg',
+        thumbnailTrack: {
+            url: 'https://bitdash-a.akamaihd.net/content/MI201109210084_1/thumbnails/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.vtt',
+        },
+    };
+
+    var player = new bitmovin.player.Player(document.getElementById('player'), conf);
+    var uiManager = bitmovin.playerui.UIFactory.buildDefaultUI(player, {});
+    player.load(source);
+</script>
+</body>
+</html>

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -23,6 +23,7 @@ $seekbar-height: .3125em;
       -ms-transform-origin: 0 0; // required for IE9
       -webkit-transform-origin: 0 0; // required for Android 4.4 WebView
       bottom: 0;
+      box-sizing: border-box;
       height: $seekbar-height;
       left: 0;
       margin: auto;

--- a/src/scss/skin-modern/components/_seekbarlabel.scss
+++ b/src/scss/skin-modern/components/_seekbarlabel.scss
@@ -52,6 +52,7 @@
       .#{$prefix}-seekbar-label-metadata {
         background: linear-gradient(to bottom, $color-transparent, $color-background-bars);
         bottom: 0;
+        box-sizing: border-box;
         display: block;
         padding: .5em;
         position: absolute;


### PR DESCRIPTION
## Description
Currently, there are two issues within the `seekbar` related to the `box-sizing` attribute.

![Bildschirmfoto 2019-03-20 um 16 30 09](https://user-images.githubusercontent.com/6216959/54697385-be4f7280-4b2d-11e9-9540-dad029acedfd.png)

1) `metadataLabel` in the thumbnail preview is too long
2) `playbackPositionMarker` is too big

This didn't show up during developing due to the face that we use bootstrap on our `index.html` and bootstrap applies `box-sizing: border-box` to _all_ elements.

Therefore this PR also introduces a `simple.html` page where no bootstrap is included.