### PR TITLE
Improve rateLimiting handling of RateLimitedEventListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Changed
+- Dispatch last event of a rate-limited event sequence to `Event.subscribeRateLimited` listeners
+
 ### Fixed
 - Inaccurate time within `SeekBarLabel` on seek preview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Inaccurate time within `SeekBarLabel` on seek preview
+
 ## [3.4.1]
 
 ### Added

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -255,7 +255,7 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
   }
 
   private shouldFireEvent(): boolean {
-    return !this.rateLimitTimout.isRunning();
+    return !this.rateLimitTimout.isActive();
   }
 
   private fireSuper(sender: Sender, args: Args) {

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -244,6 +244,7 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
       if (this.shouldFireEvent()) {
         this.fireSuper(sender, args);
         startRateLimiting();
+        return;
       }
 
       this.lastSeenEvent = {

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -197,9 +197,6 @@ class EventListenerWrapper<Sender, Args> {
  */
 class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper<Sender, Args> {
 
-  // Timout in MS where the last seen event is delayed
-  private static NEXT_EVENT_TIMEOUT_MS = 50;
-
   private readonly rateMs: number;
   private readonly rateLimitingEventListener: EventListener<Sender, Args>;
 
@@ -207,7 +204,6 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
   private lastSeenEvent: any;
 
   private rateLimitTimout: Timeout;
-  private waitAndFireLastTimout: Timeout;
 
   // Boolean to track if rateLimit timeout is currently active
   private isRateLimiting: boolean = false;
@@ -217,49 +213,36 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
 
     this.rateMs = rateMs;
 
-    // delegating the received event
-    const fireEvent = (sender: Sender, args: Args) => {
-      this.fireSuper(sender, args);
-    };
-
     // starting limiting the events to the given value
     const startRateLimiting = () => {
-      if (this.lastSeenEvent) {
-        this.isRateLimiting = true;
-        this.rateLimitTimout.start();
-      }
+      this.isRateLimiting = true;
+      this.rateLimitTimout.start();
     };
-
-    // We need to wait a short time-windows to allow a current event to get delegated instead of the last saved one.
-    // Otherwise the lastSaveEvent will always be triggered after the rateLimiting.
-    this.waitAndFireLastTimout = new Timeout(RateLimitedEventListenerWrapper.NEXT_EVENT_TIMEOUT_MS, () => {
-      if (this.lastSeenEvent) {
-        fireEvent(this.lastSeenEvent.sender, this.lastSeenEvent.args);
-        startRateLimiting(); // start rateLimiting again to keep rate limit active even after firing the last seen event
-        this.lastSeenEvent = null;
-      }
-    });
 
     // timout for limiting the events
     this.rateLimitTimout = new Timeout(this.rateMs, () => {
-      this.waitAndFireLastTimout.start();
-      this.isRateLimiting = false;
+      if (this.lastSeenEvent) {
+        this.fireSuper(this.lastSeenEvent.sender, this.lastSeenEvent.args);
+        startRateLimiting(); // start rateLimiting again to keep rate limit active even after firing the last seen event
+        this.lastSeenEvent = null;
+      } else {
+        this.isRateLimiting = false;
+      }
     });
 
     // In case the events stopping during the rateLimiting we need to track the last seen one and delegate after the
     // rate limiting is finished. This prevents missing the last update due to the rate limit.
     this.rateLimitingEventListener = (sender: Sender, args: Args) => {
+      // only fire events if the rateLimiting is not running
+      if (this.shouldFireEvent()) {
+        this.fireSuper(sender, args);
+        startRateLimiting();
+      }
+
       this.lastSeenEvent = {
         sender: sender,
         args: args,
       };
-
-      // only fire events if the rateLimiting is not running
-      if (this.shouldFireEvent()) {
-        this.waitAndFireLastTimout.clear();
-        fireEvent(sender, args);
-        startRateLimiting();
-      }
     };
   }
 

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -214,9 +214,6 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
 
   private rateLimitTimout: Timeout;
 
-  // Boolean to track if rateLimit timeout is currently active
-  private isRateLimiting: boolean = false;
-
   constructor(listener: EventListener<Sender, Args>, rateMs: number) {
     super(listener); // sets the event listener sink
 
@@ -224,7 +221,6 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
 
     // starting limiting the events to the given value
     const startRateLimiting = () => {
-      this.isRateLimiting = true;
       this.rateLimitTimout.start();
     };
 
@@ -234,8 +230,6 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
         this.fireSuper(this.lastSeenEvent.sender, this.lastSeenEvent.args);
         startRateLimiting(); // start rateLimiting again to keep rate limit active even after firing the last seen event
         this.lastSeenEvent = null;
-      } else {
-        this.isRateLimiting = false;
       }
     });
 
@@ -256,7 +250,7 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
   }
 
   private shouldFireEvent(): boolean {
-    return !this.isRateLimiting;
+    return !this.rateLimitTimout.isRunning();
   }
 
   private fireSuper(sender: Sender, args: Args) {

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -96,6 +96,7 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
     for (let i = 0; i < this.listeners.length; i++) {
       let subscribedListener = this.listeners[i];
       if (subscribedListener.listener === listener) {
+        subscribedListener.clear();
         ArrayUtils.remove(this.listeners, subscribedListener);
         return true;
       }

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -197,7 +197,6 @@ class EventListenerWrapper<Sender, Args> {
   }
 
   clear(): void {
-    // empty
   }
 }
 

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -201,6 +201,11 @@ class EventListenerWrapper<Sender, Args> {
   }
 }
 
+interface EventAttributes<Sender, Args> {
+  sender: Sender;
+  args: Args;
+}
+
 /**
  * Extends the basic {@link EventListenerWrapper} with rate-limiting functionality.
  */
@@ -210,7 +215,7 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
   private readonly rateLimitingEventListener: EventListener<Sender, Args>;
 
   // save last seen event attributes
-  private lastSeenEvent: any;
+  private lastSeenEvent: EventAttributes<Sender, Args>;
 
   private rateLimitTimout: Timeout;
 

--- a/src/ts/eventdispatcher.ts
+++ b/src/ts/eventdispatcher.ts
@@ -108,6 +108,11 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
    * Removes all listeners from this dispatcher.
    */
   unsubscribeAll(): void {
+    // In case of RateLimitedEventListenerWrapper we need to make sure that the timeout callback won't be called
+    for (let listener of this.listeners) {
+      listener.clear();
+    }
+
     this.listeners = [];
   }
 
@@ -190,6 +195,10 @@ class EventListenerWrapper<Sender, Args> {
   isOnce(): boolean {
     return this.once;
   }
+
+  clear(): void {
+    // empty
+  }
 }
 
 /**
@@ -258,5 +267,10 @@ class RateLimitedEventListenerWrapper<Sender, Args> extends EventListenerWrapper
   fire(sender: Sender, args: Args) {
     // Fire the internal rate-limiting listener instead of the external event listener
     this.rateLimitingEventListener(sender, args);
+  }
+
+  clear(): void {
+    super.clear();
+    this.rateLimitTimout.clear();
   }
 }

--- a/src/ts/timeout.ts
+++ b/src/ts/timeout.ts
@@ -54,7 +54,10 @@ export class Timeout {
     if (this.repeat) {
       this.timeoutOrIntervalId = setInterval(this.callback, this.delay);
     } else {
-      this.timeoutOrIntervalId = setTimeout(this.callback, this.delay);
+      this.timeoutOrIntervalId = setTimeout(() => {
+        this.active = false;
+        this.callback();
+      }, this.delay);
     }
     this.active = true;
   }

--- a/src/ts/timeout.ts
+++ b/src/ts/timeout.ts
@@ -13,7 +13,7 @@ export class Timeout {
   // To work around the issue we use type "any". The type does not matter anyway because we're not working with
   // this value except providing it to clearTimeout.
   private timeoutOrIntervalId: any;
-  private running: boolean;
+  private active: boolean;
 
   /**
    * Creates a new timeout callback handler.
@@ -26,7 +26,7 @@ export class Timeout {
     this.callback = callback;
     this.repeat = repeat;
     this.timeoutOrIntervalId = 0;
-    this.running = false;
+    this.active = false;
   }
 
   /**
@@ -56,11 +56,11 @@ export class Timeout {
     } else {
       this.timeoutOrIntervalId = setTimeout(this.callback, this.delay);
     }
-    this.running = true;
+    this.active = true;
   }
 
-  isRunning(): boolean {
-    return this.running;
+  isActive(): boolean {
+    return this.active;
   }
 
   private clearInternal(): void {
@@ -69,6 +69,6 @@ export class Timeout {
     } else {
       clearTimeout(this.timeoutOrIntervalId);
     }
-    this.running = false;
+    this.active = false;
   }
 }

--- a/src/ts/timeout.ts
+++ b/src/ts/timeout.ts
@@ -13,6 +13,7 @@ export class Timeout {
   // To work around the issue we use type "any". The type does not matter anyway because we're not working with
   // this value except providing it to clearTimeout.
   private timeoutOrIntervalId: any;
+  private running: boolean;
 
   /**
    * Creates a new timeout callback handler.
@@ -25,6 +26,7 @@ export class Timeout {
     this.callback = callback;
     this.repeat = repeat;
     this.timeoutOrIntervalId = 0;
+    this.running = false;
   }
 
   /**
@@ -54,6 +56,11 @@ export class Timeout {
     } else {
       this.timeoutOrIntervalId = setTimeout(this.callback, this.delay);
     }
+    this.running = true;
+  }
+
+  isRunning(): boolean {
+    return this.running;
   }
 
   private clearInternal(): void {
@@ -62,5 +69,6 @@ export class Timeout {
     } else {
       clearTimeout(this.timeoutOrIntervalId);
     }
+    this.running = false;
   }
 }


### PR DESCRIPTION
## Description
Currently, the `RateLimitedEventListener` is checking if the delta of the `lastFiredTime` to the current timestamp is greater than the rate limit and if it will delegate the event. This lead to all events during the delta period will not be received.

## Problem
This leads to an issue e.g that the time in the `seekbarLabel` could be inaccurate if the user moves the mouse fast enough over the `seekbar`. (Moving during the delta period) Those events won't be delegated to the label and the time won't update. This again leads to the impression that the seeking is inaccurate 'cause the `currentTime` after seeking is different to the time seen in the `seekbarLabel`.

## Fix
We came up with the solution that the last seen event need to be triggered anyway after the `rateLimit` period.

## How to test
The easiest way to test this is to modify the `rateMs` value within the `seekbarlabel.ts#86` to something like 5000 and move the mouse over the seekbar and stop somewhen within the rate limit. The time in the `seekbarLabel` should then update after the period.
_The longer the stream is the easier this is to reproduce_

## Discussion
Should we add a flag if this feature (`fire-last-seen-event-after-rate-limit`) should be enabled or not?
_Currently there is no such flag_ 