### PR TITLE
Chromecast UI doesn't disappear when playing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- `CastReceiverUI` does not hide when start casting during playback
+
 ## [3.4.2]
 
 ### Changed

--- a/src/ts/components/castuicontainer.ts
+++ b/src/ts/components/castuicontainer.ts
@@ -15,9 +15,7 @@ export class CastUIContainer extends UIContainer {
     super(config);
   }
 
-  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
-    super.configure(player, uimanager);
-
+  protected configureUIShowHide(player: PlayerAPI, uimanager: UIInstanceManager): void {
     let config = <UIContainerConfig>this.getConfig();
 
     /*
@@ -30,19 +28,17 @@ export class CastUIContainer extends UIContainer {
      * hide delay time.
      */
 
-    let isUiShown = false;
-
     let hideUi = () => {
       uimanager.onControlsHide.dispatch(this);
-      isUiShown = false;
+      this.isUiShown = false;
     };
 
     this.castUiHideTimeout = new Timeout(config.hideDelay, hideUi);
 
     let showUi = () => {
-      if (!isUiShown) {
+      if (!this.isUiShown) {
         uimanager.onControlsShow.dispatch(this);
-        isUiShown = true;
+        this.isUiShown = true;
       }
     };
 
@@ -56,18 +52,10 @@ export class CastUIContainer extends UIContainer {
       this.castUiHideTimeout.start();
     };
 
-    let showUiAfterSeek = () => {
-      if (player.isPlaying()) {
-        showUiWithTimeout();
-      } else {
-        showUiPermanently();
-      }
-    };
-
-    player.on(player.exports.PlayerEvent.Play, showUiWithTimeout);
+    player.on(player.exports.PlayerEvent.Play, showUiPermanently);
+    player.on(player.exports.PlayerEvent.Playing, showUiWithTimeout);
     player.on(player.exports.PlayerEvent.Paused, showUiPermanently);
     player.on(player.exports.PlayerEvent.Seek, showUiPermanently);
-    player.on(player.exports.PlayerEvent.Seeked, showUiAfterSeek);
 
     uimanager.getConfig().events.onUpdated.subscribe(showUiWithTimeout);
   }


### PR DESCRIPTION
## Problem
When starting casting during playback the UI on the cast receiver sometimes doesn't disappear. This is due to the issue that the `player.isPlaying()` call returns `false` within the `seeked` event.

## Fix
The fix is to listen to the `playing` event and start the hide timer there instead of the seeked event. This is more reliable and we can remove the `seeked` handling.

## How to Test
- Check out this branch
- Build a custom receiver app which uses the `UIFactory.modernCastReceiverUI()` UI
- Start casting during playback.