### PR TITLE
Fix jumpy seekbar on iOS and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Jumpy seekbar if isLive flag is set to late
+
 ## [2.21.0] (2018-11-30)
 
 ### Added

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -291,6 +291,8 @@ export class SeekBar extends Component<SeekBarConfig> {
     liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
       isLive = args.live;
       switchVisibility(isLive, hasTimeShift);
+
+      this.updateSmoothPlaybackPositionUpdaterState(isLive);
     });
     let timeShiftDetector = new PlayerUtils.TimeShiftAvailabilityDetector(player);
     timeShiftDetector.onTimeShiftAvailabilityChanged.subscribe((sender, args: TimeShiftAvailabilityChangedArgs) => {
@@ -411,6 +413,14 @@ export class SeekBar extends Component<SeekBarConfig> {
     if (player.isPlaying()) {
       startSmoothPlaybackPositionUpdater();
     }
+  }
+
+  private updateSmoothPlaybackPositionUpdaterState(isLive: Boolean): void {
+    if (!this.smoothPlaybackPositionUpdater) {
+      return;
+    }
+
+    isLive ? this.smoothPlaybackPositionUpdater.clear() : this.smoothPlaybackPositionUpdater.start();
   }
 
   private configureMarkers(player: bitmovin.PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -1,5 +1,5 @@
 import {Event, EventDispatcher, NoArgs} from './eventdispatcher';
-import {BrowserUtils} from './browserutils';
+import { BrowserUtils } from './browserutils';
 
 export namespace PlayerUtils {
 
@@ -106,10 +106,9 @@ export namespace PlayerUtils {
       // Re-evaluate when playback starts
       player.addEventHandler(player.EVENT.ON_PLAY, liveDetector);
 
-      // HLS live detection workaround for Android:
-      // Also re-evaluate during playback, because that is when the live flag might change.
-      // (Doing it only in Android Chrome saves unnecessary overhead on other plattforms)
-      if (BrowserUtils.isAndroid && BrowserUtils.isChrome) {
+      // Live detection workaround for Android and iOS:
+      // It could be that the isLive flag change to late in our native SDK's so we check the status also on time changed
+      if (BrowserUtils.isMobile) {
         player.addEventHandler(player.EVENT.ON_TIME_CHANGED, liveDetector);
       }
     }


### PR DESCRIPTION
## Description
In some use-cases the `isLive` returns `false` when initializing the seekbar but changes to `true` shortly afterwards. In this case the seekbar position marker will jump back and forth all the time.

## Solution
Check for `isLive` within `onTimeChanged` on all mobile platforms.

## How to test
The easiest way to test this is to build an app with our iOS SDK v2.18.0 and load a live stream. To test the fix simple set 
```swift
config.styleConfiguration.playerUiCss = URL(string: "http://your_ip/css/bitmovinplayer-ui.css")!
config.styleConfiguration.playerUiJs = URL(string: "http://your_ip/js/bitmovinplayer-ui.js")!
```

_If you prefer android this should work as well_

## TODO
- [ ] forward port