### PR TITLE
Change the AirPlay icon into active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- AirPlay icon does not change into active state
+
 ## [3.4.2]
 
 ### Changed

--- a/src/ts/components/airplaytogglebutton.ts
+++ b/src/ts/components/airplaytogglebutton.ts
@@ -43,7 +43,7 @@ export class AirPlayToggleButton extends ToggleButton<ToggleButtonConfig> {
       }
     };
 
-    let airPlayChangeHandler = () => {
+    let airPlayChangedHandler = () => {
       if (player.isAirplayActive()) {
         this.on();
       } else {
@@ -52,10 +52,10 @@ export class AirPlayToggleButton extends ToggleButton<ToggleButtonConfig> {
     };
 
     player.on(player.exports.PlayerEvent.AirplayAvailable, airPlayAvailableHandler);
-    player.on(player.exports.PlayerEvent.AirplayChanged, airPlayChangeHandler);
+    player.on(player.exports.PlayerEvent.AirplayChanged, airPlayChangedHandler);
 
     // Startup init
     airPlayAvailableHandler(); // Hide button if AirPlay is not available
-    airPlayChangeHandler();
+    airPlayChangedHandler();
   }
 }

--- a/src/ts/components/airplaytogglebutton.ts
+++ b/src/ts/components/airplaytogglebutton.ts
@@ -35,7 +35,7 @@ export class AirPlayToggleButton extends ToggleButton<ToggleButtonConfig> {
       }
     });
 
-    let airPlayAvailableHandler = () => {
+    const airPlayAvailableHandler = () => {
       if (player.isAirplayAvailable()) {
         this.show();
       } else {
@@ -43,7 +43,7 @@ export class AirPlayToggleButton extends ToggleButton<ToggleButtonConfig> {
       }
     };
 
-    let airPlayChangedHandler = () => {
+    const airPlayChangedHandler = () => {
       if (player.isAirplayActive()) {
         this.on();
       } else {

--- a/src/ts/components/airplaytogglebutton.ts
+++ b/src/ts/components/airplaytogglebutton.ts
@@ -43,9 +43,19 @@ export class AirPlayToggleButton extends ToggleButton<ToggleButtonConfig> {
       }
     };
 
+    let airPlayChangeHandler = () => {
+      if (player.isAirplayActive()) {
+        this.on();
+      } else {
+        this.off();
+      }
+    };
+
     player.on(player.exports.PlayerEvent.AirplayAvailable, airPlayAvailableHandler);
+    player.on(player.exports.PlayerEvent.AirplayChanged, airPlayChangeHandler);
 
     // Startup init
     airPlayAvailableHandler(); // Hide button if AirPlay is not available
+    airPlayChangeHandler();
   }
 }


### PR DESCRIPTION
## Description
Currently there was no event listener in place to check if AirPlay is currently active.

## Fix
Add an event listener for `AirPlayChanged` event and turn on the active state of the icon.