### PR TITLE
Fix crash within uicontainer.release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Crash of `UIContainer.release` when initialized with `hideDelay: -1`
+
 ## [3.4.3]
 
 ### Fixed

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -317,10 +317,15 @@ export class UIContainer extends Container<UIContainerConfig> {
   release(): void {
     // Explicitly unsubscribe user interaction event handlers because they could be attached to an external element
     // that isn't owned by the UI and therefore not removed on release.
-    this.userInteractionEvents.forEach((event) => this.userInteractionEventSource.off(event.name, event.handler));
+    if (this.userInteractionEvents) {
+      this.userInteractionEvents.forEach((event) => this.userInteractionEventSource.off(event.name, event.handler));
+    }
 
     super.release();
-    this.uiHideTimeout.clear();
+
+    if (this.uiHideTimeout) {
+      this.uiHideTimeout.clear();
+    }
   }
 
   protected toDomElement(): DOM {


### PR DESCRIPTION
## Description
The problem is that when the `UIContainer` gets initialized with `hideDelay: -1` the `release` method does not check if `userInteractionEvents` or the `uiHideTimeout` is undefined or not.

## Solution
Add safety checks when releasing the `UIContainer`