### PR TITLE
Support start time for live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Wrong state for live indicator when a `startTime` value is provided within the `SourceConfig` of the player
+
 ## [3.4.4]
 
 ### Fixed

--- a/spec/components/playbacktimelabel.spec.ts
+++ b/spec/components/playbacktimelabel.spec.ts
@@ -1,0 +1,50 @@
+import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
+import { UIInstanceManager } from '../../src/ts/uimanager';
+import { PlaybackTimeLabel } from '../../src/ts/components/playbacktimelabel';
+
+const liveEdgeActiveCssClassName = 'ui-playbacktimelabel-live-edge';
+
+let playerMock: TestingPlayerAPI;
+let uiInstanceManagerMock: UIInstanceManager;
+
+let playbackTimeLabel: PlaybackTimeLabel;
+
+describe('PlaybackTimeLabel', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+
+    jest.spyOn(playerMock, 'isLive').mockReturnValue(true);
+    jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(-20);
+
+    playbackTimeLabel = new PlaybackTimeLabel();
+  });
+
+  describe('live edge indicator', () => {
+    describe('switch to inactive', () => {
+      let removeClassSpy: any;
+      beforeEach(() => {
+        // When the player is setup with sourceOptions.startTime within a live stream, no TimeShifted event will be
+        // fired so we need to listen also on the Playing event
+
+        // During setup of the UI it could be that getTimeShift returns 0
+        jest.spyOn(playerMock, 'getTimeShift').mockReturnValue(0);
+
+        // Setup DOM Mock
+        const mockDomElement = MockHelper.generateDOMMock();
+        removeClassSpy = jest.spyOn(mockDomElement, 'removeClass');
+        jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
+        playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+
+      });
+
+      it('on Playing event', () => {
+        // getTimeShift value when the PlayingEvent is fired
+        jest.spyOn(playerMock, 'getTimeShift').mockReturnValue(-10);
+        playerMock.eventEmitter.firePlayingEvent();
+
+        expect(removeClassSpy).toHaveBeenCalledWith(expect.stringContaining(liveEdgeActiveCssClassName));
+      });
+    });
+  });
+});

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -14,6 +14,7 @@ import {
   VideoPlaybackQualityChangedEvent,
 } from 'bitmovin-player';
 import { UIInstanceManager } from '../../src/ts/uimanager';
+import { DOM } from '../../src/ts/dom';
 
 jest.mock('../../src/ts/dom');
 
@@ -35,6 +36,19 @@ export namespace MockHelper {
     }));
 
     return new UiInstanceManagerMockClass();
+  }
+
+  export function generateDOMMock(): DOM {
+    const DOMClass: jest.Mock<DOM> = jest.fn().mockImplementation(() => ({
+      addClass: jest.fn(),
+      removeClass: jest.fn(),
+      on: jest.fn(),
+      html: jest.fn(),
+      css: jest.fn(),
+      width: jest.fn(),
+    }));
+
+    return new DOMClass();
   }
 
   export function getPlayerMock(): TestingPlayerAPI {
@@ -66,6 +80,8 @@ export namespace MockHelper {
           return document.getElementById('player');
         }),
         getViewMode: jest.fn(),
+        getTimeShift: jest.fn(),
+        getMaxTimeShift: jest.fn(),
         hasEnded: jest.fn(),
         isStalled: jest.fn(),
         isCasting: jest.fn(),

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -116,6 +116,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.TimeShifted, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.Play, updateLiveTimeshiftState);
+    player.on(player.exports.PlayerEvent.Playing, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.Paused, updateLiveTimeshiftState);
 
     let init = () => {

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -115,7 +115,6 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
 
     player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.TimeShifted, updateLiveTimeshiftState);
-    player.on(player.exports.PlayerEvent.Play, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.Playing, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.Paused, updateLiveTimeshiftState);
 


### PR DESCRIPTION
## Description
The upcoming player version v8.8.0 will support the `SourceConfigOption` `startTime` also for livestreams.

## Problem
No initial `TimeShifted` event will be fired when a `startTime` is configured.

## Solution
We need to listen to the `Playing` event to update the live-edge status indicator.

