### PR TITLE
Feature/fix browserutils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.4.6]
+
+### Fixed
+- Allow npm package to be imported in server side app without `navigator` error.
+
 ## [3.4.5]
 
 ### Fixed

--- a/src/ts/browserutils.ts
+++ b/src/ts/browserutils.ts
@@ -1,4 +1,6 @@
 export namespace BrowserUtils {
+  // set default value for navigator when using package in nodejs or ssr app
+  const navigator = typeof window === 'undefined' ? {userAgent: ''} : window.navigator;
 
   // isMobile only needs to be evaluated once (it cannot change during a browser session)
   // Mobile detection according to Mozilla recommendation: "In summary, we recommend looking for the string “Mobi”


### PR DESCRIPTION
### Description
When importing this npm package in a server sider rendered app the following error occurs:
`ReferenceError: navigator is not defined`
https://d.pr/i/hPQEY9

Affected versions: `3.4.5` and possibly older versions

I wasn't sure if I should have created this PR against develop instead but just tried to follow the contrib guidelines.

This is obviously a suggestion and _one_ way on how to solve this issue but feel free to close the PR and address it in a different way you guys see fit.

Thanks!

### Problem
`navigator` is not available on the server side even though all we are trying to do is import the package, not instantiate it on the BE.

### Solution
Check if `window` is available before using `navigator` and set a default otherwise.

### Manual tests
Import the package in a node.js app (or server side rendered file). The file should be imported with no errors as long as not instantiated.