### PR TITLE
Add support for es6 inheritance of the player which is passed to the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Added
+- Support for player instances which inherits from the `BitmovinPlayer`
+
 ## [3.4.5]
 
 ### Fixed

--- a/spec/uimanager.spec.ts
+++ b/spec/uimanager.spec.ts
@@ -1,0 +1,65 @@
+import { PlayerWrapper } from '../src/ts/uimanager';
+import { PlayerAPI } from 'bitmovin-player';
+
+// This just simulates a Class that can be wrapped by our PlayerWrapper.
+// To enable this simple class structure we need a lot of any casts in the tests.
+class A {
+  private value: object = undefined;
+
+  get a() {
+    return this.value;
+  }
+
+  // This is needed to change the actual value of the property
+  giveValueAValue() {
+    this.value = { foo: 'bar' };
+  }
+}
+
+class B extends A {
+  get b() {
+    return {};
+  }
+}
+
+class C extends B {
+  get c() {
+    return {};
+  }
+}
+
+describe('UIManager', () => {
+  describe('PlayerWrapper', () => {
+    let playerWrapper: PlayerWrapper;
+
+    describe('without inheritance', () => {
+      let superClassInstance: A;
+
+      beforeEach(() => {
+        const testInstance: PlayerAPI = new A() as any as PlayerAPI;
+        playerWrapper = new PlayerWrapper(testInstance);
+        (testInstance as any).giveValueAValue(); // Change the value of the actual property to simulate async loaded module
+        superClassInstance = playerWrapper.getPlayer() as any as A;
+      });
+
+      it('wraps functions', () => {
+        expect(superClassInstance.a).not.toBeUndefined();
+      });
+    });
+
+    describe('with inheritance', () => {
+      let inheritedClassInstance: C;
+
+      beforeEach(() => {
+        const testInstance: PlayerAPI = new C() as any as PlayerAPI;
+        playerWrapper = new PlayerWrapper(testInstance);
+        (testInstance as any).giveValueAValue(); // Change the value of the actual property to simulate async loaded module
+        inheritedClassInstance = playerWrapper.getPlayer() as any as C;
+      });
+
+      it('wraps functions of super class', () => {
+        expect(inheritedClassInstance.a).not.toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -763,23 +763,16 @@ class PlayerWrapper {
     for (let property of properties) {
       // Get an eventually existing property descriptor to differentiate between plain properties and properties with
       // getters/setters.
-      const getPropertyDescriptor = (object: PlayerAPI): PropertyDescriptor => {
-        const propertyDescriptor = Object.getOwnPropertyDescriptor(object, property);
-        if (propertyDescriptor) {
-          return propertyDescriptor;
-        } else {
-          const childPrototype = Object.getPrototypeOf(object);
-          if (childPrototype) {
-            // Check if the PropertyDescriptor exists on a child prototype in case we have an inheritance of the player
-            return getPropertyDescriptor(childPrototype);
-          } else {
-            // No property descriptor found in any child prototype
-            return;
+      const propertyDescriptor = ((target: PlayerAPI) => {
+        while (target) {
+          const propertyDescriptor = Object.getOwnPropertyDescriptor(target, property);
+          if (propertyDescriptor) {
+            return propertyDescriptor;
           }
+          // Check if the PropertyDescriptor exists on a child prototype in case we have an inheritance of the player
+          target = Object.getPrototypeOf(target);
         }
-      };
-
-      const propertyDescriptor: PropertyDescriptor = getPropertyDescriptor(player);
+      })(player);
 
       // If the property has getters/setters, wrap them accordingly...
       if (propertyDescriptor && (propertyDescriptor.get || propertyDescriptor.set)) {

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -719,7 +719,7 @@ interface WrappedPlayer extends PlayerAPI {
  * Wraps the player to track event handlers and provide a simple method to remove all registered event
  * handlers from the player.
  */
-class PlayerWrapper {
+export class PlayerWrapper {
 
   private player: PlayerAPI;
   private wrapper: WrappedPlayer;

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -763,8 +763,23 @@ class PlayerWrapper {
     for (let property of properties) {
       // Get an eventually existing property descriptor to differentiate between plain properties and properties with
       // getters/setters.
-      let propertyDescriptor: PropertyDescriptor = Object.getOwnPropertyDescriptor(player, property) ||
-        Object.getOwnPropertyDescriptor(Object.getPrototypeOf(player), property);
+      const getPropertyDescriptor = (object: PlayerAPI): PropertyDescriptor => {
+        const propertyDescriptor = Object.getOwnPropertyDescriptor(object, property);
+        if (propertyDescriptor) {
+          return propertyDescriptor;
+        } else {
+          const childPrototype = Object.getPrototypeOf(object);
+          if (childPrototype) {
+            // Check if the PropertyDescriptor exists on a child prototype in case we have an inheritance of the player
+            return getPropertyDescriptor(childPrototype);
+          } else {
+            // No property descriptor found in any child prototype
+            return;
+          }
+        }
+      };
+
+      const propertyDescriptor: PropertyDescriptor = getPropertyDescriptor(player);
 
       // If the property has getters/setters, wrap them accordingly...
       if (propertyDescriptor && (propertyDescriptor.get || propertyDescriptor.set)) {


### PR DESCRIPTION
## Description
When an instance of an inherited player is passed to the UI our `PlayerWrapper` does not wrap all properties of the superclass correctly.

## Solution
Search for `PropertyDescriptor`s also of the prototype of the passed player instance.