### PR TITLE
Fix generic typing of config objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Improved documentation about time / number formats which can be used in `AdMessageLabel` placeholders
+- TypeScript update to 3.4.5
+- Improved generic type inheritance of `Component` `Config`s ([#74](https://github.com/bitmovin/bitmovin-player-ui/issues/74))
 
 ## [3.5.0]
 
@@ -19,8 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - `ListBox` no longer recreates itself after the list was updated
-- TypeScript update to 3.4.5
-- Improved generic type inheritance of `Component` `Config`s ([#74](https://github.com/bitmovin/bitmovin-player-ui/issues/74))
 
 ### Fixed
 - UI not hiding after selecting an item within a `ListBox`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - `ListBox` no longer recreates itself after the list was updated
+- TypeScript update to 3.4.5
+- Improved generic type inheritance of `Component` `Config`s ([#74](https://github.com/bitmovin/bitmovin-player-ui/issues/74))
 
 ### Fixed
 - UI not hiding after selecting an item within a `ListBox`

--- a/package-lock.json
+++ b/package-lock.json
@@ -3735,8 +3735,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3779,8 +3778,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -3791,8 +3789,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3909,8 +3906,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3922,7 +3918,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3952,7 +3947,6 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3971,7 +3965,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4065,7 +4058,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4151,8 +4143,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -4188,7 +4179,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4208,7 +4198,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -4252,14 +4241,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7996,7 +7983,6 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8015,7 +8001,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8109,7 +8094,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8195,8 +8179,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8302,8 +8285,7 @@
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9387,7 +9369,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -9407,7 +9389,7 @@
     },
     "http-proxy": {
       "version": "1.15.2",
-      "resolved": "http://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
       "dev": true,
       "requires": {
@@ -11288,7 +11270,6 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11307,7 +11288,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -11487,8 +11467,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11594,8 +11573,7 @@
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13078,7 +13056,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
@@ -14660,7 +14638,7 @@
     },
     "opn": {
       "version": "5.3.0",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
@@ -18359,9 +18337,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "ua-parser-js": {
@@ -19603,7 +19581,7 @@
     },
     "yargs-parser": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ts-jest": "^24.0.2",
     "tsify": "^2.0.2",
     "tslint": "^5.11.0",
-    "typescript": "^3.0.3",
+    "typescript": "^3.4.5",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "watchify": "^3.11.1",

--- a/src/ts/components/adskipbutton.ts
+++ b/src/ts/components/adskipbutton.ts
@@ -37,7 +37,7 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <AdSkipButtonConfig>this.getConfig(); // TODO get rid of generic cast
+    let config = this.getConfig();
     let untilSkippableMessage = config.untilSkippableMessage;
     let skippableMessage = config.skippableMessage;
     let skipOffset = -1;

--- a/src/ts/components/bufferingoverlay.ts
+++ b/src/ts/components/bufferingoverlay.ts
@@ -43,7 +43,7 @@ export class BufferingOverlay extends Container<BufferingOverlayConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <BufferingOverlayConfig>this.getConfig();
+    let config = this.getConfig();
 
     let overlayShowTimeout = new Timeout(config.showDelayMs, () => {
       this.show();

--- a/src/ts/components/button.ts
+++ b/src/ts/components/button.ts
@@ -15,18 +15,18 @@ export interface ButtonConfig extends ComponentConfig {
 /**
  * A simple clickable button.
  */
-export class Button<Config extends ButtonConfig> extends Component<ButtonConfig> {
+export class Button<Config extends ButtonConfig> extends Component<Config> {
 
   private buttonEvents = {
     onClick: new EventDispatcher<Button<Config>, NoArgs>(),
   };
 
-  constructor(config: ButtonConfig) {
+  constructor(config: Config) {
     super(config);
 
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-button',
-    }, this.config);
+    } as Config, this.config);
   }
 
   protected toDomElement(): DOM {

--- a/src/ts/components/castuicontainer.ts
+++ b/src/ts/components/castuicontainer.ts
@@ -18,7 +18,7 @@ export class CastUIContainer extends UIContainer {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <UIContainerConfig>this.getConfig();
+    let config = this.getConfig();
 
     /*
      * Show UI on Cast devices at certain playback events

--- a/src/ts/components/closebutton.ts
+++ b/src/ts/components/closebutton.ts
@@ -24,7 +24,7 @@ export class CloseButton extends Button<CloseButtonConfig> {
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-closebutton',
       text: 'Close',
-    }, this.config);
+    } as CloseButtonConfig, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/closebutton.ts
+++ b/src/ts/components/closebutton.ts
@@ -30,7 +30,7 @@ export class CloseButton extends Button<CloseButtonConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <CloseButtonConfig>this.getConfig();
+    let config = this.getConfig();
 
     this.onClick.subscribe(() => {
       config.target.hide();

--- a/src/ts/components/container.ts
+++ b/src/ts/components/container.ts
@@ -31,7 +31,7 @@ export interface ContainerConfig extends ComponentConfig {
  *     </div>
  * </code>
  */
-export class Container<Config extends ContainerConfig> extends Component<ContainerConfig> {
+export class Container<Config extends ContainerConfig> extends Component<Config> {
 
   /**
    * A reference to the inner element that contains the components of the container.
@@ -46,7 +46,7 @@ export class Container<Config extends ContainerConfig> extends Component<Contain
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-container',
       components: [],
-    }, this.config);
+    } as Config, this.config);
 
     this.componentsToAdd = [];
     this.componentsToRemove = [];

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -98,7 +98,7 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <ErrorMessageOverlayConfig>this.getConfig();
+    let config = this.getConfig();
 
     player.on(player.exports.PlayerEvent.Error, (event: ErrorEvent) => {
       let message = ErrorUtils.defaultErrorMessageTranslator(event);

--- a/src/ts/components/label.ts
+++ b/src/ts/components/label.ts
@@ -20,7 +20,7 @@ export interface LabelConfig extends ComponentConfig {
  *     <span class='ui-label'>...some text...</span>
  * </code>
  */
-export class Label<Config extends LabelConfig> extends Component<LabelConfig> {
+export class Label<Config extends LabelConfig> extends Component<Config> {
 
   private text: string;
 
@@ -29,12 +29,12 @@ export class Label<Config extends LabelConfig> extends Component<LabelConfig> {
     onTextChanged: new EventDispatcher<Label<Config>, string>(),
   };
 
-  constructor(config: LabelConfig = {}) {
+  constructor(config: Config = {} as Config) {
     super(config);
 
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-label',
-    }, this.config);
+    } as Config, this.config);
 
     this.text = this.config.text;
   }

--- a/src/ts/components/listbox.ts
+++ b/src/ts/components/listbox.ts
@@ -133,11 +133,11 @@ class ListBoxItemButton extends ToggleButton<ListBoxItemButtonConfig> {
   constructor(config: ListBoxItemButtonConfig) {
     super(config);
 
-    this.config = this.mergeConfig<ToggleButtonConfig>(config, {
+    this.config = this.mergeConfig(config, {
       cssClass: 'ui-listbox-button',
       onClass: 'selected',
       offClass: '',
-    }, this.config);
+    } as ListBoxItemButtonConfig, this.config);
   }
 
   get key(): string {

--- a/src/ts/components/metadatalabel.ts
+++ b/src/ts/components/metadatalabel.ts
@@ -42,7 +42,7 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <MetadataLabelConfig>this.getConfig();
+    let config = this.getConfig();
     let uiconfig = uimanager.getConfig();
 
     let init = () => {

--- a/src/ts/components/metadatalabel.ts
+++ b/src/ts/components/metadatalabel.ts
@@ -36,7 +36,7 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
 
     this.config = this.mergeConfig(config, {
       cssClasses: ['label-metadata', 'label-metadata-' + MetadataLabelContent[config.content].toLowerCase()],
-    }, this.config);
+    } as MetadataLabelConfig, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -37,7 +37,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <PlaybackTimeLabelConfig>this.getConfig();
+    let config = this.getConfig();
     let live = false;
     let liveCssClass = this.prefixCss('ui-playbacktimelabel-live');
     let liveEdgeCssClass = this.prefixCss('ui-playbacktimelabel-live-edge');

--- a/src/ts/components/recommendationoverlay.ts
+++ b/src/ts/components/recommendationoverlay.ts
@@ -100,7 +100,7 @@ class RecommendationItem extends Component<RecommendationItemConfig> {
   }
 
   protected toDomElement(): DOM {
-    let config = (<RecommendationItemConfig>this.config).itemConfig; // TODO fix generics and get rid of cast
+    let config = this.config.itemConfig;
 
     let itemElement = new DOM('a', {
       'id': this.config.id,

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -55,7 +55,7 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <SettingsPanelConfig>this.getConfig(); // TODO fix generics type inference
+    let config = this.getConfig();
 
     uimanager.onControlsHide.subscribe(() => this.hideHoveredSelectBoxes());
 

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -45,11 +45,11 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
   constructor(config: SettingsPanelConfig) {
     super(config);
 
-    this.config = this.mergeConfig<SettingsPanelConfig>(config, {
+    this.config = this.mergeConfig(config, {
       cssClass: 'ui-settings-panel',
       hideDelay: 3000,
       pageTransitionAnimation: true,
-    }, this.config);
+    } as SettingsPanelConfig, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/settingspanelitem.ts
+++ b/src/ts/components/settingspanelitem.ts
@@ -1,7 +1,7 @@
 import {Container, ContainerConfig} from './container';
 import {Component, ComponentConfig} from './component';
 import {Event, EventDispatcher, NoArgs} from '../eventdispatcher';
-import {Label} from './label';
+import { Label, LabelConfig } from './label';
 import {UIInstanceManager} from '../uimanager';
 import {SelectBox} from './selectbox';
 import {ListBox} from './listbox';
@@ -37,7 +37,7 @@ export class SettingsPanelItem extends Container<ContainerConfig> {
       if (label instanceof Component) {
         this.label = label;
       } else {
-        this.label = new Label({text: label});
+        this.label = new Label({text: label} as LabelConfig);
       }
       this.addComponent(this.label);
     }

--- a/src/ts/components/settingspanelpagebackbutton.ts
+++ b/src/ts/components/settingspanelpagebackbutton.ts
@@ -10,7 +10,7 @@ export class SettingsPanelPageBackButton extends SettingsPanelPageNavigatorButto
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-settingspanelpagebackbutton',
       text: 'back',
-    }, this.config);
+    } as SettingsPanelPageNavigatorConfig, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/settingspanelpagenavigatorbutton.ts
+++ b/src/ts/components/settingspanelpagenavigatorbutton.ts
@@ -23,7 +23,7 @@ export class SettingsPanelPageNavigatorButton extends Button<SettingsPanelPageNa
 
   constructor(config: SettingsPanelPageNavigatorConfig) {
     super(config);
-    this.config = this.mergeConfig(config, {}, this.config);
+    this.config = this.mergeConfig(config, {} as SettingsPanelPageNavigatorConfig, this.config);
 
     this.container = (this.config as SettingsPanelPageNavigatorConfig).container;
     this.targetPage = (this.config as SettingsPanelPageNavigatorConfig).targetPage;

--- a/src/ts/components/settingspanelpageopenbutton.ts
+++ b/src/ts/components/settingspanelpageopenbutton.ts
@@ -9,7 +9,7 @@ export class SettingsPanelPageOpenButton extends SettingsPanelPageNavigatorButto
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-settingspanelpageopenbutton',
       text: 'open',
-    }, this.config);
+    } as SettingsPanelPageNavigatorConfig, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/settingstogglebutton.ts
+++ b/src/ts/components/settingstogglebutton.ts
@@ -46,7 +46,7 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <SettingsToggleButtonConfig>this.getConfig(); // TODO fix generics type inference
+    let config = this.getConfig();
     let settingsPanel = config.settingsPanel;
 
     this.onClick.subscribe(() => {

--- a/src/ts/components/titlebar.ts
+++ b/src/ts/components/titlebar.ts
@@ -37,7 +37,7 @@ export class TitleBar extends Container<TitleBarConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = <TitleBarConfig>this.getConfig();
+    let config = this.getConfig();
     let shouldBeShown = !this.isHidden();
     let hasMetadataText = true; // Flag to track if any metadata label contains text
 

--- a/src/ts/components/togglebutton.ts
+++ b/src/ts/components/togglebutton.ts
@@ -48,7 +48,7 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Conf
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
-    const config = this.getConfig() as ToggleButtonConfig;
+    const config = this.getConfig();
     this.getDomElement().addClass(this.prefixCss(config.offClass));
   }
 
@@ -57,7 +57,7 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Conf
    */
   on() {
     if (this.isOff()) {
-      const config = this.getConfig() as ToggleButtonConfig;
+      const config = this.getConfig();
 
       this.onState = true;
       this.getDomElement().removeClass(this.prefixCss(config.offClass));
@@ -73,7 +73,7 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Conf
    */
   off() {
     if (this.isOn()) {
-      const config = this.getConfig() as ToggleButtonConfig;
+      const config = this.getConfig();
 
       this.onState = false;
       this.getDomElement().removeClass(this.prefixCss(config.onClass));

--- a/src/ts/components/togglebutton.ts
+++ b/src/ts/components/togglebutton.ts
@@ -24,7 +24,7 @@ export interface ToggleButtonConfig extends ButtonConfig {
 /**
  * A button that can be toggled between 'on' and 'off' states.
  */
-export class ToggleButton<Config extends ToggleButtonConfig> extends Button<ToggleButtonConfig> {
+export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Config> {
 
   private onState: boolean;
 
@@ -34,7 +34,7 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Togg
     onToggleOff: new EventDispatcher<ToggleButton<Config>, NoArgs>(),
   };
 
-  constructor(config: ToggleButtonConfig) {
+  constructor(config: Config) {
     super(config);
 
     const defaultConfig: ToggleButtonConfig = {
@@ -43,7 +43,7 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Togg
       offClass: 'off',
     };
 
-    this.config = this.mergeConfig(config, defaultConfig, this.config);
+    this.config = this.mergeConfig(config, defaultConfig as Config, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -60,7 +60,7 @@ export class UIContainer extends Container<UIContainerConfig> {
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
-    const config = <UIContainerConfig>this.getConfig();
+    const config = this.getConfig();
 
     if (config.userInteractionEventSource) {
       this.userInteractionEventSource = new DOM(config.userInteractionEventSource);
@@ -75,7 +75,7 @@ export class UIContainer extends Container<UIContainerConfig> {
   }
 
   private configureUIShowHide(player: PlayerAPI, uimanager: UIInstanceManager): void {
-    let config = <UIContainerConfig>this.getConfig();
+    let config = this.getConfig();
 
     if (config.hideDelay === -1) {
       uimanager.onConfigured.subscribe(() => uimanager.onControlsShow.dispatch(this));

--- a/src/ts/components/volumecontrolbutton.ts
+++ b/src/ts/components/volumecontrolbutton.ts
@@ -57,7 +57,7 @@ export class VolumeControlButton extends Container<VolumeControlButtonConfig> {
     let volumeToggleButton = this.getVolumeToggleButton();
     let volumeSlider = this.getVolumeSlider();
 
-    this.volumeSliderHideTimeout = new Timeout((<VolumeControlButtonConfig>this.getConfig()).hideDelay, () => {
+    this.volumeSliderHideTimeout = new Timeout(this.getConfig().hideDelay, () => {
       volumeSlider.hide();
     });
 


### PR DESCRIPTION
Removes all casts around `component.getConfig()` calls which used to return a base type instead of the config type of the actual component. Closes #74.

This has been bugging me since writing the very first version of this framework. Now it is finally fixed (except for a few still required type hints in `mergeConfig`) 🎈 🎉🎈🍾🎈🍸