### PR TITLE
Hide ads UI when unloading the Player while an ad is playing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## development
+
+### Fixed
+- Ads UI not being hidden when the Player is unloaded during ad playback
+
 ## [3.6.0]
 
 ### Added

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -249,6 +249,7 @@ export class UIManager {
             break;
           // When a new source is loaded during ad playback, there will be no Ad(Break)Finished event
           case player.exports.PlayerEvent.SourceLoaded:
+          case player.exports.PlayerEvent.SourceUnloaded:
             adStartedEvent = null;
             break;
         }
@@ -288,6 +289,7 @@ export class UIManager {
     // Listen to the following events to trigger UI variant resolution
     if (this.config.autoUiVariantResolve) {
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.SourceLoaded, resolveUiVariant);
+      this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.SourceUnloaded, resolveUiVariant);
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.Play, resolveUiVariant);
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.Paused, resolveUiVariant);
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.AdStarted, resolveUiVariant);


### PR DESCRIPTION
Fixes the ads UI still being shown after the Player was unloaded during ad playback.