### PR TITLE
Fix iOS 13 first touch input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- First touch input does not start playback on iOS 13
+
 ## [3.6.1]
 
 ### Fixed

--- a/spec/components/uicontainer.spec.ts
+++ b/spec/components/uicontainer.spec.ts
@@ -34,4 +34,46 @@ describe('UIContainer', () => {
       });
     });
   });
+
+  describe('user interaction handling', () => {
+    let uiContainer: UIContainer;
+    const jsEventCallbacks: { [eventName: string]: EventListener; } = {};
+
+    const prepareUserEventMocking = () => {
+      const userInteractionEventSource = uiContainer.getDomElement();
+
+      // Prepare event faking
+      userInteractionEventSource.on = (eventName: string, eventHandler: EventListener) => {
+        jsEventCallbacks[eventName] = eventHandler;
+        return userInteractionEventSource;
+      };
+    };
+
+    beforeEach(() => {
+      uiContainer = new UIContainer({
+        components: [],
+      });
+
+      prepareUserEventMocking();
+    });
+
+    it('does trigger onControlsShow on mouse move event', () => {
+      uiContainer.configure(playerMock, uiInstanceManagerMock);
+
+      // For this test it's fine to call without event object
+      jsEventCallbacks['mousemove'](null);
+
+      expect(uiInstanceManagerMock.onControlsShow.dispatch).toHaveBeenCalled();
+    });
+
+    it('does not trigger onControlsShow on mouse move event if we are in touch phase', () => {
+      uiContainer.configure(playerMock, uiInstanceManagerMock);
+
+      // For this test it's fine to call without event object
+      jsEventCallbacks['touchstart'](null);
+      jsEventCallbacks['mousemove'](null);
+
+      expect(uiInstanceManagerMock.onControlsShow.dispatch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -29,6 +29,8 @@ export namespace MockHelper {
       onControlsHide: getEventDispatcherMock(),
       onComponentHide: getEventDispatcherMock(),
       onComponentShow: getEventDispatcherMock(),
+      onSeek: getEventDispatcherMock(),
+      onSeeked: getEventDispatcherMock(),
     }));
 
     return new UiInstanceManagerMockClass();


### PR DESCRIPTION
## Description

### Problem
On iOS 13 the first touch, on the UI, does not trigger playback. This is due to the fact that `mouse` events are also fired on that touch interaction which causes problems on iOS 13.

### Fix
We now ignore the `mouse` events if the UI is currently touched. _This does not change any current behaviour._

**TODO:**
- [ ] Backport to UIv2