### PR TITLE
Show UI in not playing states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Changed
+- UI no longer hides in `Prepared`, `Paused` or `Finished` state
+
 ## [3.6.1]
 
 ### Fixed

--- a/spec/components/uicontainer.spec.ts
+++ b/spec/components/uicontainer.spec.ts
@@ -1,18 +1,19 @@
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 import { UIContainer } from '../../src/ts/components/uicontainer';
 import { UIInstanceManager } from '../../src/ts/uimanager';
+import { PlayerUtils } from '../../src/ts/playerutils';
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;
 
 describe('UIContainer', () => {
+  let uiContainer: UIContainer;
   beforeEach(() => {
     playerMock = MockHelper.getPlayerMock();
     uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
   });
 
   describe('release', () => {
-    let uiContainer: UIContainer;
     beforeEach(() => {
       uiContainer = new UIContainer({
         hideDelay: -1, // With an hideDelay of -1 the uiHideTimeout and userInteractionEvents never will be initialized
@@ -31,6 +32,23 @@ describe('UIContainer', () => {
         uiContainer.configure(playerMock, uiInstanceManagerMock);
 
         uiContainer.release();
+      });
+    });
+  });
+
+  describe('automatically hiding', () => {
+    describe('hidePlayerStateExceptions', () => {
+      it('UI does not hide itself when switching into prevented state', () => {
+        uiContainer = new UIContainer({
+          components: [],
+          hidePlayerStateExceptions: [PlayerUtils.PlayerState.Prepared],
+        });
+        uiContainer.configure(playerMock, uiInstanceManagerMock);
+
+        let uiHideTimeoutSpy: any = jest.spyOn((uiContainer as any).uiHideTimeout, 'start');
+        playerMock.eventEmitter.fireSourceLoadedEvent();
+
+        expect(uiHideTimeoutSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -31,6 +31,8 @@ export namespace MockHelper {
       onComponentHide: getEventDispatcherMock(),
       onComponentShow: getEventDispatcherMock(),
       onSeekPreview: getEventDispatcherMock(),
+      onSeek: getEventDispatcherMock(),
+      onSeeked: getEventDispatcherMock(),
     }));
 
     return new UiInstanceManagerMockClass();

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -148,6 +148,13 @@ export class PlayerEventEmitter {
     });
   }
 
+  fireSourceLoadedEvent(): void {
+    this.fireEvent<PlayerEventBase>({
+      timestamp: Date.now(),
+      type: PlayerEvent.SourceLoaded,
+    });
+  }
+
   fireSourceUnloadedEvent(): void {
     this.fireEvent<PlayerEventBase>({
       timestamp: Date.now(),
@@ -279,7 +286,7 @@ export class PlayerEventEmitter {
         id,
         label,
       },
-    }as AudioTrackEvent);
+    } as AudioTrackEvent);
   }
 
   fireAudioRemovedEvent(id: string): void {

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -243,8 +243,6 @@ export class UIContainer extends Container<UIContainerConfig> {
     uimanager.getConfig().events.onUpdated.subscribe(() => {
       updateState(PlayerUtils.getState(player));
     });
-    // Init in current player state
-    updateState(PlayerUtils.getState(player));
 
     // Fullscreen marker class
     player.on(player.exports.PlayerEvent.ViewModeChanged, () => {

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -178,7 +178,9 @@ export class UIContainer extends Container<UIContainerConfig> {
     });
     uimanager.onSeeked.subscribe(() => {
       isSeeking = false;
-      this.uiHideTimeout.start(); // Re-enable UI hide timeout after a seek
+      if (!hidingPrevented()) {
+        this.uiHideTimeout.start(); // Re-enable UI hide timeout after a seek
+      }
     });
     player.on(player.exports.PlayerEvent.CastStarted, () => {
       showUi(); // Show UI when a Cast session has started (UI will then stay permanently on during the session)

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -53,7 +53,12 @@ export class UIContainer extends Container<UIContainerConfig> {
 
     this.config = this.mergeConfig(config, <UIContainerConfig>{
       cssClass: 'ui-uicontainer',
-      hideDelay: 5000,
+      hideDelay: 2000,
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
     }, this.config);
 
     this.playerStateChange = new EventDispatcher<UIContainer, PlayerUtils.PlayerState>();

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -53,12 +53,7 @@ export class UIContainer extends Container<UIContainerConfig> {
 
     this.config = this.mergeConfig(config, <UIContainerConfig>{
       cssClass: 'ui-uicontainer',
-      hideDelay: 2000,
-      hidePlayerStateExceptions: [
-        PlayerUtils.PlayerState.Prepared,
-        PlayerUtils.PlayerState.Paused,
-        PlayerUtils.PlayerState.Finished,
-      ],
+      hideDelay: 5000,
     }, this.config);
 
     this.playerStateChange = new EventDispatcher<UIContainer, PlayerUtils.PlayerState>();

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -253,7 +253,6 @@ export namespace UIFactory {
         new ErrorMessageOverlay(),
       ],
       cssClasses: ['ui-skin-smallscreen'],
-      hidePlayerStateExceptions: [PlayerUtils.PlayerState.Finished],
     });
   }
 

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -138,6 +138,12 @@ export namespace UIFactory {
         new Watermark(),
         new ErrorMessageOverlay(),
       ],
+      hideDelay: 2000,
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
     });
   }
 
@@ -170,6 +176,12 @@ export namespace UIFactory {
         }),
       ],
       cssClasses: ['ui-skin-ads'],
+      hideDelay: 2000,
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
     });
   }
 
@@ -253,6 +265,12 @@ export namespace UIFactory {
         new ErrorMessageOverlay(),
       ],
       cssClasses: ['ui-skin-smallscreen'],
+      hideDelay: 2000,
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
     });
   }
 
@@ -278,6 +296,12 @@ export namespace UIFactory {
         }),
       ],
       cssClasses: ['ui-skin-ads', 'ui-skin-smallscreen'],
+      hideDelay: 2000,
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
     });
   }
 
@@ -306,6 +330,12 @@ export namespace UIFactory {
         new ErrorMessageOverlay(),
       ],
       cssClasses: ['ui-skin-cast-receiver'],
+      hideDelay: 2000,
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
     });
   }
 


### PR DESCRIPTION
## Description
In order to improve UX we decided to show the UI per default in the following states:
- Prepared
- Paused
- Finished

As the UI is visible per default now we decided to lower the default `hideDelay` value.

**This works around multiple issues:**
- First tap not starting playback on iOS 13
- UI hides if user is scrubbing longer than the `hideDelay`