### PR TITLE
Fix issues with visible UI in prepared state

### DIFF
--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -226,6 +226,9 @@ export class UIContainer extends Container<UIContainerConfig> {
     player.on(player.exports.PlayerEvent.Play, () => {
       updateState(PlayerUtils.PlayerState.Playing);
     });
+    player.on(player.exports.PlayerEvent.Playing, () => {
+      updateState(PlayerUtils.PlayerState.Playing);
+    });
     player.on(player.exports.PlayerEvent.Paused, () => {
       updateState(PlayerUtils.PlayerState.Paused);
     });

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -133,7 +133,7 @@ export class UIContainer extends Container<UIContainerConfig> {
           // instead. The first touch is not prevented to let other listeners receive the event and trigger an
           // initial action, e.g. the huge playback button can directly start playback instead of requiring a double
           // tap which 1. reveals the UI and 2. starts playback.
-          if (isFirstTouch) {
+          if (isFirstTouch && !player.isPlaying()) {
             isFirstTouch = false;
           } else {
             e.preventDefault();


### PR DESCRIPTION
### Description
After #265 we had the issue that the first touch (after the UI faced out) would trigger a `pause` which is not intended.

Another issue is that in the case of autoplay the UI does not fade out. The reason for this was that the `play` event is triggered too early from the native SDKs. 

### Fix
- Add a check if the player is currently playing when the user taps the UI. And only if not playing we want to let the click through to the toggle button
- Trigger internal state update in the `playing` event as well.

**No changelog entry added as this was not yet released**

**TODO:**
- [ ] Backport to v2