### PR TITLE
Hide UI even if a control-bar-element is hovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Changed
+- Hide UI even a element in `ControlBar` is currently hovered
+
 ## [3.8.0]
 
 ### Added

--- a/src/ts/components/controlbar.ts
+++ b/src/ts/components/controlbar.ts
@@ -29,33 +29,10 @@ export class ControlBar extends Container<ControlBarConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    // Counts how many components are hovered and block hiding of the control bar
-    let hoverStackCount = 0;
-
-    // Track hover status of child components
-    UIUtils.traverseTree(this, (component) => {
-      // Do not track hover status of child containers or spacers, only of 'real' controls
-      if (component instanceof Container || component instanceof Spacer) {
-        return;
-      }
-
-      // Subscribe hover event and keep a count of the number of hovered children
-      component.onHoverChanged.subscribe((sender, args) => {
-        if (args.hovered) {
-          hoverStackCount++;
-        } else {
-          hoverStackCount--;
-        }
-      });
-    });
-
     uimanager.onControlsShow.subscribe(() => {
       this.show();
     });
-    uimanager.onPreviewControlsHide.subscribe((sender, args) => {
-      // Cancel the hide event if hovered child components block hiding
-      args.cancel = (hoverStackCount > 0);
-    });
+
     uimanager.onControlsHide.subscribe(() => {
       this.hide();
     });


### PR DESCRIPTION
### Description
Touching an element within the `ControlBar` causes the UI to not disappear after the standard few seconds. Instead, it will stay visible until another manual action is performed.

This is due to the issue that on touch devices a `mouseEnter` is fired when touching an element.

### Fix
Reverting this commit 6176130 without breaking the API.

### Changes
This changes the behaviour of the UI that it will now hide after the configured delay even an element in the `ControlBar` is hovered (on desktop)

**TODO:**
- [ ] back-port