### PR TITLE
Do not hide `SettingsPanel` in `modernSmallScreenUI` automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Do not hide `SettingsPanel` in `modernSmallScreenUI` automatically
+
 ## [3.8.0]
 
 ### Added

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -203,6 +203,7 @@ export namespace UIFactory {
       ],
       hidden: true,
       pageTransitionAnimation: false,
+      hideDelay: -1,
     });
 
     let subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({


### PR DESCRIPTION
### Description
On mobile devices the `SettingsPanel` hides automatically after the configured default delay.
This lead to the issue that a user must be fast to change settings.

### Fix
Do not hide the `SettingsPanel` automatically.
_This is the same behaviour as in v2_