### PR TITLE
Fix localization in IE

### DIFF
--- a/src/ts/localization/i18n.ts
+++ b/src/ts/localization/i18n.ts
@@ -138,7 +138,7 @@ class I18n {
   }
 
   private replaceVariableWithPlaceholderIfExists(text: string, config: any) {
-    const matches = Array.from(text.match(new RegExp('{[a-zA-Z0-9]+}')));
+    const matches = text.match(new RegExp('{[a-zA-Z0-9]+}', 'g'));
     if (matches.length === 0) {
       return text;
     }


### PR DESCRIPTION
related to `Player localization: broke IE since `Array.from` is not supported`

- removed the misuse of `array.match` (was confused with array.matchAll)
- removed `array.from` 