### PR TITLE
Handle durationChanged event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Localization
+- `DurationChanged` event support
 
 ## [3.8.1]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2554,9 +2554,9 @@
       "dev": true
     },
     "bitmovin-player": {
-      "version": "8.1.0-rc1",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.1.0-rc1.tgz",
-      "integrity": "sha512-LrCNKueSLL/WP+FY9SVAM+0TgIkjJWnKLdl1+UixxpbZFwpqY2PLd5km2ekK839T5zEVhjMAn6/JcFvTbuWQSw==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.19.1.tgz",
+      "integrity": "sha512-wZSjBqIQTsEB+1e4iY5j8rmTkqpxNcvIReIaasD9gR18VpTFmA487PqM0rDDEn5ssdc6OtmU8CqO4Fh3I3y0Xg==",
       "dev": true
     },
     "bl": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.11",
     "autoprefixer": "^6.5.2",
-    "bitmovin-player": "^8.1.0-rc1",
+    "bitmovin-player": "^8.19.1",
     "browser-sync": "^2.26.3",
     "browserify": "^13.1.1",
     "cssnano": "^3.8.0",

--- a/spec/audioutils.spec.ts
+++ b/spec/audioutils.spec.ts
@@ -1,6 +1,7 @@
 import { MockHelper } from './helper/MockHelper';
 import { ListSelector, ListSelectorConfig } from '../src/ts/components/listselector';
 import { AudioTrackSwitchHandler } from '../src/ts/audiotrackutils';
+import { AudioTrack } from 'bitmovin-player';
 
 let playerMock = MockHelper.getPlayerMock();
 let audioTrackSwitchHandler: AudioTrackSwitchHandler;
@@ -27,19 +28,19 @@ describe('AudioUtils', () => {
         id: 'a-1',
         label: 'A1',
         lang: 'en',
-      },
+      } as AudioTrack,
       {
         id: 'a-2',
         label: 'A2',
         lang: 'de',
-      },
+      } as AudioTrack,
     ]);
 
     jest.spyOn(playerMock, 'getAudio').mockReturnValue({
       id: 'a-1',
       label: 'A1',
       lang: 'en',
-    });
+    } as AudioTrack);
 
     audioTrackSwitchHandler = new AudioTrackSwitchHandler(playerMock, listSelectorMock, uiManagerMock);
   });
@@ -87,12 +88,12 @@ describe('AudioUtils', () => {
           id: 'a-1',
           label: 'A1',
           lang: 'en',
-        },
+        } as AudioTrack,
         {
           id: 'a-3',
           label: 'A3',
           lang: 'fr',
-        },
+        } as AudioTrack,
       ]);
       playerMock.eventEmitter.firePeriodSwitchedEvent();
 
@@ -110,7 +111,7 @@ describe('AudioUtils', () => {
         id: 'a-2',
         label: 'A1',
         lang: 'en',
-      });
+      } as AudioTrack);
       playerMock.eventEmitter.fireAudioChangedEvent();
       expect(listSelectorMock.selectItem).toHaveBeenCalledWith('a-2');
     });

--- a/spec/components/playbacktimelabel.spec.ts
+++ b/spec/components/playbacktimelabel.spec.ts
@@ -76,4 +76,44 @@ describe('PlaybackTimeLabel', () => {
       expect(playbackTimeLabel.getText()).toEqual('01:40');
     });
   });
+
+  describe('updates when a live stream switches to vod', () => {
+    beforeEach(() => {
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(true);
+      jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(0);
+
+      const mockDomElement = MockHelper.generateDOMMock();
+      playbackTimeLabel = new PlaybackTimeLabel();
+
+      jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
+
+      playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+    });
+
+    it('becomes visible', () => {
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
+      const showSpy = jest.spyOn(playbackTimeLabel, 'show');
+
+      playerMock.eventEmitter.fireDurationChangedEvent();
+
+      expect(showSpy).toHaveBeenCalled();
+    });
+
+    it('displays the current time', () => {
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
+      jest.spyOn(playerMock, 'getSeekableRange').mockReturnValue({
+        start: 100,
+        end: 200,
+      });
+      jest.spyOn(playerMock, 'getDuration').mockReturnValue(100);
+      jest.spyOn(playerMock, 'getCurrentTime').mockReturnValue(150);
+
+      const setTimeSpy = jest.spyOn(playbackTimeLabel, 'setTime');
+
+      playerMock.eventEmitter.fireDurationChangedEvent();
+      playerMock.eventEmitter.fireTimeChangedEvent(150);
+
+      expect(setTimeSpy).toHaveBeenCalledWith(50, 100);
+    });
+  });
 });

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -1,0 +1,33 @@
+import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
+import { SeekBar } from '../../src/ts/components/seekbar';
+import { UIInstanceManager } from '../../src/ts/uimanager';
+
+let playerMock: TestingPlayerAPI;
+let uiInstanceManagerMock: UIInstanceManager;
+
+let seekbar: SeekBar;
+
+describe('SeekBar', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+
+    seekbar = new SeekBar();
+  });
+
+  describe('becomes visible when switching from live to vod', () => {
+    it('when live had no time shift', () => {
+      jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(0);
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(true);
+
+      seekbar.configure(playerMock, uiInstanceManagerMock);
+
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
+      const showSpy = jest.spyOn(seekbar, 'show');
+
+      playerMock.eventEmitter.fireDurationChangedEvent();
+
+      expect(showSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/spec/components/seekbarlabel.spec.ts
+++ b/spec/components/seekbarlabel.spec.ts
@@ -76,6 +76,22 @@ describe('SeekBarLabel', () => {
 
         expect(playerMock.getThumbnail).toHaveBeenCalledWith(1);
       });
+
+      it('with correct seek target value respecting seekable range', () => {
+        jest.spyOn(playerMock, 'getSeekableRange').mockReturnValue({
+          start: 10,
+          end: 20,
+        });
+
+        let args: SeekPreviewEventArgs = {
+          scrubbing: false,
+          position: 10,
+        };
+
+        (seekbarLabel as any).handleSeekPreview(seekbarLabel, args);
+
+        expect(playerMock.getThumbnail).toHaveBeenCalledWith(11);
+      });
     });
   });
 });

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -25,6 +25,9 @@ export namespace MockHelper {
         events: {
           onUpdated: getEventDispatcherMock(),
         },
+        metadata: {
+          markers: [],
+        },
       }),
       onControlsShow: getEventDispatcherMock(),
       onControlsHide: getEventDispatcherMock(),
@@ -33,6 +36,7 @@ export namespace MockHelper {
       onSeekPreview: getEventDispatcherMock(),
       onSeek: getEventDispatcherMock(),
       onSeeked: getEventDispatcherMock(),
+      onRelease: getEventDispatcherMock(),
     }));
 
     return new UiInstanceManagerMockClass();
@@ -87,6 +91,11 @@ export namespace MockHelper {
         getAvailableAudio: jest.fn(),
         getAudio: jest.fn(),
         getThumbnail: jest.fn(),
+        getSeekableRange: jest.fn(() => {
+          return { start: 0, end: 0 };
+        }),
+        getVideoBufferLength: jest.fn(),
+        getAudioBufferLength: jest.fn(),
         hasEnded: jest.fn(),
         isStalled: jest.fn(),
         isCasting: jest.fn(),

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -1,8 +1,10 @@
 import {
   AdBreakEvent,
   AdEvent,
-  AirplayChangedEvent, AudioChangedEvent,
+  AirplayChangedEvent,
+  AudioChangedEvent,
   AudioTrackEvent,
+  DurationChangedEvent,
   ErrorEvent,
   LinearAd,
   PeriodSwitchedEvent,
@@ -14,6 +16,7 @@ import {
   SubtitleCueEvent,
   SubtitleEvent,
   SubtitleTrack,
+  TimeChangedEvent,
   TimeShiftEvent,
   VideoPlaybackQualityChangedEvent
 } from 'bitmovin-player';
@@ -149,6 +152,15 @@ export class PlayerEventEmitter {
     });
   }
 
+  fireDurationChangedEvent(): void {
+    this.fireEvent<DurationChangedEvent>({
+      timestamp: Date.now(),
+      type: PlayerEvent.DurationChanged,
+      from: Infinity,
+      to: 200,
+    });
+  }
+
   fireSourceLoadedEvent(): void {
     this.fireEvent<PlayerEventBase>({
       timestamp: Date.now(),
@@ -230,6 +242,14 @@ export class PlayerEventEmitter {
       time: Date.now(),
       type: PlayerEvent.AirplayChanged,
       airplayEnabled: true,
+    });
+  }
+
+  fireTimeChangedEvent(time: number): void {
+    this.fireEvent<TimeChangedEvent>({
+      time,
+      timestamp: Date.now(),
+      type: PlayerEvent.TimeChanged,
     });
   }
 

--- a/src/ts/components/adclickoverlay.ts
+++ b/src/ts/components/adclickoverlay.ts
@@ -2,10 +2,6 @@ import { ClickOverlay } from './clickoverlay';
 import { UIInstanceManager } from '../uimanager';
 import { Ad, AdEvent, PlayerAPI } from 'bitmovin-player';
 
-interface LocalAd extends Ad {
-  clickThroughUrlOpened?: () => void;
-}
-
 /**
  * A simple click capture overlay for clickThroughUrls of ads.
  */
@@ -17,7 +13,7 @@ export class AdClickOverlay extends ClickOverlay {
     let clickThroughCallback: () => void = null;
 
     player.on(player.exports.PlayerEvent.AdStarted, (event: AdEvent) => {
-      let ad = event.ad as LocalAd;
+      let ad = event.ad;
       this.setUrl(ad.clickThroughUrl);
       clickThroughCallback = ad.clickThroughUrlOpened;
     });

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -118,7 +118,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
 
     let playbackTimeHandler = () => {
       if (!live && player.getDuration() !== Infinity) {
-        this.setTime(player.getCurrentTime(), player.getDuration());
+        this.setTime(PlayerUtils.getCurrentTimeRelativeToSeekableRange(player), player.getDuration());
       }
 
       // To avoid 'jumping' in the UI by varying label sizes due to non-monospaced fonts,

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -349,7 +349,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       const maxTimeShift = this.player.getMaxTimeShift();
       this.player.timeShift(maxTimeShift - (maxTimeShift * (percentage / 100)), 'ui');
     } else {
-      const seekableRangeStart = this.player.getSeekableRange() && this.player.getSeekableRange().start || 0;
+      const seekableRangeStart = PlayerUtils.getSeekableRangeStart(this.player, 0);
       const relativeSeekTarget = this.player.getDuration() * (percentage / 100);
       const absoluteSeekTarget = relativeSeekTarget + seekableRangeStart;
       this.player.seek(absoluteSeekTarget, 'ui');

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -171,7 +171,7 @@ export class SeekBar extends Component<SeekBarConfig> {
         this.setBufferPosition(100);
       }
       else {
-        let playbackPositionPercentage = 100 / player.getDuration() * player.getCurrentTime();
+        let playbackPositionPercentage = 100 / player.getDuration() * this.getRelativeCurrentTime();
 
         let videoBufferLength = player.getVideoBufferLength();
         let audioBufferLength = player.getAudioBufferLength();
@@ -391,7 +391,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       currentTimeSeekBar += currentTimeUpdateDeltaSecs;
 
       try {
-        currentTimePlayer = player.getCurrentTime();
+        currentTimePlayer = this.getRelativeCurrentTime();
       } catch (error) {
         // Detect if the player has been destroyed and stop updating if so
         if (error instanceof player.exports.PlayerAPINotAvailableError) {
@@ -426,7 +426,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     let startSmoothPlaybackPositionUpdater = () => {
       if (!player.isLive()) {
-        currentTimeSeekBar = player.getCurrentTime();
+        currentTimeSeekBar = this.getRelativeCurrentTime();
         this.smoothPlaybackPositionUpdater.start();
       }
     };
@@ -440,13 +440,17 @@ export class SeekBar extends Component<SeekBarConfig> {
     player.on(player.exports.PlayerEvent.Paused, stopSmoothPlaybackPositionUpdater);
     player.on(player.exports.PlayerEvent.PlaybackFinished, stopSmoothPlaybackPositionUpdater);
     player.on(player.exports.PlayerEvent.Seeked, () => {
-      currentTimeSeekBar = player.getCurrentTime();
+      currentTimeSeekBar = this.getRelativeCurrentTime();
     });
     player.on(player.exports.PlayerEvent.SourceUnloaded, stopSmoothPlaybackPositionUpdater);
 
     if (player.isPlaying()) {
       startSmoothPlaybackPositionUpdater();
     }
+  }
+
+  private getRelativeCurrentTime(): number {
+    return PlayerUtils.getCurrentTimeRelativeToSeekableRange(this.player);
   }
 
   private configureMarkers(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -349,7 +349,9 @@ export class SeekBar extends Component<SeekBarConfig> {
       const maxTimeShift = this.player.getMaxTimeShift();
       this.player.timeShift(maxTimeShift - (maxTimeShift * (percentage / 100)), 'ui');
     } else {
-      this.player.seek(this.player.getDuration() * (percentage / 100), 'ui');
+      const relativeSeekTarget = this.player.getDuration() * (percentage / 100);
+      const absoluteSeekTarget = relativeSeekTarget + this.player.getSeekableRange().start;
+      this.player.seek(absoluteSeekTarget, 'ui');
     }
   };
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -349,8 +349,9 @@ export class SeekBar extends Component<SeekBarConfig> {
       const maxTimeShift = this.player.getMaxTimeShift();
       this.player.timeShift(maxTimeShift - (maxTimeShift * (percentage / 100)), 'ui');
     } else {
+      const seekableRangeStart = this.player.getSeekableRange() && this.player.getSeekableRange().start || 0;
       const relativeSeekTarget = this.player.getDuration() * (percentage / 100);
-      const absoluteSeekTarget = relativeSeekTarget + this.player.getSeekableRange().start;
+      const absoluteSeekTarget = relativeSeekTarget + seekableRangeStart;
       this.player.seek(absoluteSeekTarget, 'ui');
     }
   };

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -103,7 +103,9 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       }
       let time = this.player.getDuration() * (args.position / 100);
       this.setTime(time);
-      this.setThumbnail(this.player.getThumbnail(time));
+
+      const absoluteSeekTarget = time + this.player.getSeekableRange().start;
+      this.setThumbnail(this.player.getThumbnail(absoluteSeekTarget));
     }
 
     // Remove CSS classes from previous marker

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -7,6 +7,7 @@ import {ImageLoader} from '../imageloader';
 import {CssProperties} from '../dom';
 import { PlayerAPI, Thumbnail } from 'bitmovin-player';
 import { SeekBar, SeekPreviewEventArgs } from './seekbar';
+import { PlayerUtils } from '../playerutils';
 
 /**
  * Configuration interface for a {@link SeekBarLabel}.
@@ -104,7 +105,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       let time = this.player.getDuration() * (args.position / 100);
       this.setTime(time);
 
-      const seekableRangeStart = this.player.getSeekableRange() && this.player.getSeekableRange().start || 0;
+      const seekableRangeStart = PlayerUtils.getSeekableRangeStart(this.player, 0);
       const absoluteSeekTarget = time + seekableRangeStart;
       this.setThumbnail(this.player.getThumbnail(absoluteSeekTarget));
     }

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -104,7 +104,8 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       let time = this.player.getDuration() * (args.position / 100);
       this.setTime(time);
 
-      const absoluteSeekTarget = time + this.player.getSeekableRange().start;
+      const seekableRangeStart = this.player.getSeekableRange() && this.player.getSeekableRange().start || 0;
+      const absoluteSeekTarget = time + seekableRangeStart;
       this.setThumbnail(this.player.getThumbnail(absoluteSeekTarget));
     }
 

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -93,8 +93,20 @@ export namespace PlayerUtils {
 
   /**
    * Detects changes of the stream type, i.e. changes of the return value of the player#isLive method.
+   * Normally, a stream cannot change its type during playback, it's either VOD or live. Due to bugs on some
+   * platforms or browsers, it can still change. It is therefore unreliable to just check #isLive and this detector
+   * should be used as a workaround instead.
    *
-   * @deprecated use `PlayerEvent.DurationChanged` instead
+   * Additionally starting with player v8.19.0 we have the use-case that a live stream changes into a vod.
+   * The DurationChanged event indicates this switch.
+   *
+   * Known cases:
+   *
+   * - HLS VOD on Android 4.3
+   * Video duration is initially 'Infinity' and only gets available after playback starts, so streams are wrongly
+   * reported as 'live' before playback (the live-check in the player checks for infinite duration).
+   *
+   * @deprecated since UI v3.9.0 in combination with player v8.19.0 use PlayerEvent.DurationChanged instead
    *
    * TODO: remove this class in next major release
    */
@@ -124,7 +136,7 @@ export namespace PlayerUtils {
         player.on(player.exports.PlayerEvent.TimeChanged, liveDetector);
       }
 
-      // DurationChanged event was introduced with player v8.19.1
+      // DurationChanged event was introduced with player v8.19.0
       if (player.exports.PlayerEvent.DurationChanged) {
         player.on(player.exports.PlayerEvent.DurationChanged, liveDetector);
       }

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -38,7 +38,7 @@ export namespace PlayerUtils {
    */
   export function getCurrentTimeRelativeToSeekableRange(player: PlayerAPI): number {
     const currentTime = player.getCurrentTime();
-    if (this.player.isLive()) {
+    if (player.isLive()) {
       return currentTime;
     }
 

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -118,7 +118,7 @@ export namespace PlayerUtils {
 
       // HLS live detection workaround for Android:
       // Also re-evaluate during playback, because that is when the live flag might change.
-      // (Doing it only in Android Chrome saves unnecessary overhead on other plattforms)
+      // (Doing it only in Android Chrome saves unnecessary overhead on other platforms)
       if (BrowserUtils.isAndroid && BrowserUtils.isChrome) {
         player.on(player.exports.PlayerEvent.TimeChanged, liveDetector);
       }

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -113,6 +113,11 @@ export namespace PlayerUtils {
       if (BrowserUtils.isAndroid && BrowserUtils.isChrome) {
         player.on(player.exports.PlayerEvent.TimeChanged, liveDetector);
       }
+
+      // TODO:
+      if (Boolean(player.exports.PlayerEvent.DurationChanged)) {
+        player.on(player.exports.PlayerEvent.DurationChanged, liveDetector);
+      }
     }
 
     detect(): void {

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -123,8 +123,8 @@ export namespace PlayerUtils {
         player.on(player.exports.PlayerEvent.TimeChanged, liveDetector);
       }
 
-      // TODO:
-      if (Boolean(player.exports.PlayerEvent.DurationChanged)) {
+      // DurationChanged event was introduced with player v8.19.1
+      if (player.exports.PlayerEvent.hasOwnProperty('DurationChanged')) {
         player.on(player.exports.PlayerEvent.DurationChanged, liveDetector);
       }
     }

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -42,8 +42,21 @@ export namespace PlayerUtils {
       return currentTime;
     }
 
-    const seekableRangeStart = player.getSeekableRange() && player.getSeekableRange().start || 0;
+    const seekableRangeStart = PlayerUtils.getSeekableRangeStart(player, 0);
     return currentTime - seekableRangeStart;
+  }
+
+  /**
+   * Returns the start value of the seekable range or the defaultValue if no seekableRange is present.
+   * For now this happens only in combination with Mobile SDKs.
+   *
+   * TODO: remove this function in next major release
+   *
+   * @param player
+   * @param defaultValue
+   */
+  export function getSeekableRangeStart(player: PlayerAPI, defaultValue: number = 0) {
+    return player.getSeekableRange() && player.getSeekableRange().start || defaultValue;
   }
 
   export interface TimeShiftAvailabilityChangedArgs extends NoArgs {

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -42,7 +42,8 @@ export namespace PlayerUtils {
       return currentTime;
     }
 
-    return currentTime - player.getSeekableRange().start;
+    const seekableRangeStart = player.getSeekableRange() && player.getSeekableRange().start || 0;
+    return currentTime - seekableRangeStart;
   }
 
   export interface TimeShiftAvailabilityChangedArgs extends NoArgs {

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -92,15 +92,10 @@ export namespace PlayerUtils {
 
   /**
    * Detects changes of the stream type, i.e. changes of the return value of the player#isLive method.
-   * Normally, a stream cannot change its type during playback, it's either VOD or live. Due to bugs on some
-   * platforms or browsers, it can still change. It is therefore unreliable to just check #isLive and this detector
-   * should be used as a workaround instead.
    *
-   * Known cases:
+   * @deprecated use `PlayerEvent.DurationChanged` instead
    *
-   * - HLS VOD on Android 4.3
-   * Video duration is initially 'Infinity' and only gets available after playback starts, so streams are wrongly
-   * reported as 'live' before playback (the live-check in the player checks for infinite duration).
+   * TODO: remove this class in next major release
    */
   export class LiveStreamDetector {
 

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -31,6 +31,20 @@ export namespace PlayerUtils {
     }
   }
 
+  /**
+   * Returns the currentTime - seekableRange.start. This ensures a user-friendly currentTime after a live stream
+   * transitioned to VoD.
+   * @param player
+   */
+  export function getCurrentTimeRelativeToSeekableRange(player: PlayerAPI): number {
+    const currentTime = player.getCurrentTime();
+    if (this.player.isLive()) {
+      return currentTime;
+    }
+
+    return currentTime - player.getSeekableRange().start;
+  }
+
   export interface TimeShiftAvailabilityChangedArgs extends NoArgs {
     timeShiftAvailable: boolean;
   }

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -125,7 +125,7 @@ export namespace PlayerUtils {
       }
 
       // DurationChanged event was introduced with player v8.19.1
-      if (player.exports.PlayerEvent.hasOwnProperty('DurationChanged')) {
+      if (player.exports.PlayerEvent.DurationChanged) {
         player.on(player.exports.PlayerEvent.DurationChanged, liveDetector);
       }
     }


### PR DESCRIPTION
### Description
With player `v8.19.0` the `DurationChanged` event was introduced which will be fired when a live stream turned into a VoD. In that case, the player still returns the wall-clock-timestamps for `getCurrentTime`. Therefore we need to respect the `seekableRange` to properly translate the timestamps in a user-friendly value and back.

### Solution
This PR will handle the event accordingly and respects the `seekableRange` whenever needed.

### Tests
- New unit tests added
- For manual testing you can use any dash vod and following network API to fake the live part.

```js
  let availabilityStartTime;
  const streamDuration = 210;
  let switchToVod = false;
  config = {
  ...
    network: {
      preprocessHttpResponse: (type, response) => {
        availabilityStartTime = availabilityStartTime || Date.now() - streamDuration * 1000;

        return switchToVod
          ? Promise.resolve(response)
          : convertVodToLive(type, response, availabilityStartTime);
      },
    },
  ...
  };

  function convertVodToLive(type, response, availabilityStartTime = 0) {
    if (type === 'manifest/dash') {
      const mpdDocument = deserializeMpd(response.body);
      const mpd = mpdDocument.getElementsByTagName('MPD')[0];
      const availabilityStartTimeString = new Date(availabilityStartTime).toISOString();

      mpd.setAttribute('type', 'dynamic');
      mpd.setAttribute('availabilityStartTime', availabilityStartTimeString);
      mpd.setAttribute('publishTime', availabilityStartTimeString);
      mpd.setAttribute('minimumUpdatePeriod', 'PT1S');
      mpd.removeAttribute('mediaPresentationDuration');

      response.body = serializeMpd(mpdDocument);
    }

    return Promise.resolve(response);
  }

  function deserializeMpd(mpd) {
    return new DOMParser().parseFromString(mpd, 'text/xml');
  }

  function serializeMpd(mpd) {
    var xmlHeader = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
    return (
      xmlHeader +
      (mpd.documentElement.outerHTML ? mpd.documentElement.outerHTML : new XMLSerializer().serializeToString(mpd))
    );
  }

// peroform the switch manually by calling:
switchToVod = true;
```