### PR TITLE
fix timeline ui flicking back and forth on live streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Fixed
-- UI Flickering back and forth on live streams after AD's
-
-### Changed
-- Seekbar doesn't use `SmoothPositionUpdater` on Live streams anymore.
+- UI flickering back and forth on live streams after ads
 
 ## [3.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- UI Flickering back and forth on live streams after AD's
+
+### Changed
+- Seekbar doesn't use `SmoothPositionUpdater` on Live streams anymore.
+
 ## [3.9.0]
 
 ### Added

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -1,8 +1,6 @@
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 import { SeekBar } from '../../src/ts/components/seekbar';
 import { UIInstanceManager } from '../../src/ts/uimanager';
-import { PlayerUtils } from '../../src/ts/playerutils';
-import { anyTypeAnnotation } from '@babel/types';
 import { Timeout } from '../../src/ts/timeout';
 
 let playerMock: TestingPlayerAPI;

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -394,7 +394,6 @@ export class SeekBar extends Component<SeekBarConfig> {
     let updateIntervalMs = 50;
     let currentTimeUpdateDeltaSecs = updateIntervalMs / 1000;
 
-
     this.smoothPlaybackPositionUpdater = new Timeout(updateIntervalMs, () => {
       currentTimeSeekBar += currentTimeUpdateDeltaSecs;
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -333,13 +333,15 @@ export class SeekBar extends Component<SeekBarConfig> {
 
   private calculatePlaybackPositionPercentage(relativeCurrentTime: number = this.getRelativeCurrentTime()) {
     if (this.player.isLive()) {
-      let maxTimeShift = this.player.getMaxTimeShift();
+      const maxTimeShift = this.player.getMaxTimeShift();
       if (maxTimeShift === 0) {
         // This case must be explicitly handled to avoid division by zero
         return 0;
       }
+
       return 100 - (100 / maxTimeShift * this.player.getTimeShift());
     }
+
     return 100 / this.player.getDuration() * relativeCurrentTime;
   }
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -290,6 +290,9 @@ export class SeekBar extends Component<SeekBarConfig> {
     let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
     liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
       isLive = args.live;
+      if (isLive && this.smoothPlaybackPositionUpdater != null) {
+        this.smoothPlaybackPositionUpdater.clear();
+      }
       switchVisibility(isLive, hasTimeShift);
     });
     let timeShiftDetector = new PlayerUtils.TimeShiftAvailabilityDetector(player);
@@ -298,6 +301,7 @@ export class SeekBar extends Component<SeekBarConfig> {
         switchVisibility(isLive, hasTimeShift);
       },
     );
+
     // Initial detection
     liveStreamDetector.detect();
     timeShiftDetector.detect();
@@ -396,8 +400,10 @@ export class SeekBar extends Component<SeekBarConfig> {
     let updateIntervalMs = 50;
     let currentTimeUpdateDeltaSecs = updateIntervalMs / 1000;
 
+
     this.smoothPlaybackPositionUpdater = new Timeout(updateIntervalMs, () => {
       currentTimeSeekBar += currentTimeUpdateDeltaSecs;
+      console.log('update!');
 
       try {
         currentTimePlayer = this.getRelativeCurrentTime();
@@ -429,7 +435,9 @@ export class SeekBar extends Component<SeekBarConfig> {
         currentTimeSeekBar -= currentTimeUpdateDeltaSecs;
       }
 
-      this.setPlaybackPosition(this.calculatePlaybackPositionPercentage(currentTimeSeekBar));
+      let playbackPositionPercentage = 100 / player.getDuration() * currentTimeSeekBar;
+
+      this.setPlaybackPosition(playbackPositionPercentage);
     }, true);
 
     let startSmoothPlaybackPositionUpdater = () => {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -158,12 +158,12 @@ export class SeekBar extends Component<SeekBarConfig> {
       }
 
       if (player.isLive()) {
-        if (player.getMaxTimeShift() === 0) {	
-          // This case must be explicitly handled to avoid division by zero	
-          this.setPlaybackPosition(100);	
-        } else {	
-          let playbackPositionPercentage = 100 - (100 / player.getMaxTimeShift() * player.getTimeShift());	
-          this.setPlaybackPosition(playbackPositionPercentage);	
+        if (player.getMaxTimeShift() === 0) {
+          // This case must be explicitly handled to avoid division by zero
+          this.setPlaybackPosition(100);
+        } else {
+          let playbackPositionPercentage = 100 - (100 / player.getMaxTimeShift() * player.getTimeShift());
+          this.setPlaybackPosition(playbackPositionPercentage);
         }
 
         // Always show full buffer for live streams
@@ -362,9 +362,9 @@ export class SeekBar extends Component<SeekBarConfig> {
    * The playback position stays still and the position indicator visually moves towards the back.
    */
   private configureLivePausedTimeshiftUpdater(
-    player: PlayerAPI, 
-    uimanager: UIInstanceManager, 
-    playbackPositionHandler: () => void
+    player: PlayerAPI,
+    uimanager: UIInstanceManager,
+    playbackPositionHandler: () => void,
   ): void {
     // Regularly update the playback position while the timeout is active
     this.pausedTimeshiftUpdater = new Timeout(1000, playbackPositionHandler, true);

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -157,14 +157,21 @@ export class SeekBar extends Component<SeekBarConfig> {
         return;
       }
 
-      const playbackPositionPercentage = this.calculatePlaybackPositionPercentage();
 
       if (player.isLive()) {
-        this.setPlaybackPosition(playbackPositionPercentage);
+        if (player.getMaxTimeShift() === 0) {	
+          // This case must be explicitly handled to avoid division by zero	
+          this.setPlaybackPosition(100);	
+        } else {	
+          let playbackPositionPercentage = 100 - (100 / player.getMaxTimeShift() * player.getTimeShift());	
+          this.setPlaybackPosition(playbackPositionPercentage);	
+        }
+
         // Always show full buffer for live streams
         this.setBufferPosition(100);
       }
       else {
+        let playbackPositionPercentage = 100 / player.getDuration() * this.getRelativeCurrentTime();
 
         let videoBufferLength = player.getVideoBufferLength();
         let audioBufferLength = player.getAudioBufferLength();
@@ -333,20 +340,6 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.configureSmoothPlaybackPositionUpdater(player, uimanager);
     }
     this.configureMarkers(player, uimanager);
-  }
-
-  private calculatePlaybackPositionPercentage(relativeCurrentTime: number = this.getRelativeCurrentTime()) {
-    if (this.player.isLive()) {
-      const maxTimeShift = this.player.getMaxTimeShift();
-      if (maxTimeShift === 0) {
-        // This case must be explicitly handled to avoid division by zero
-        return 0;
-      }
-
-      return 100 - (100 / maxTimeShift * this.player.getTimeShift());
-    }
-
-    return 100 / this.player.getDuration() * relativeCurrentTime;
   }
 
   private seekWhileScrubbing = (sender: SeekBar, args: SeekPreviewEventArgs) => {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -157,7 +157,6 @@ export class SeekBar extends Component<SeekBarConfig> {
         return;
       }
 
-
       if (player.isLive()) {
         if (player.getMaxTimeShift() === 0) {	
           // This case must be explicitly handled to avoid division by zero	
@@ -169,8 +168,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
         // Always show full buffer for live streams
         this.setBufferPosition(100);
-      }
-      else {
+      } else {
         let playbackPositionPercentage = 100 / player.getDuration() * this.getRelativeCurrentTime();
 
         let videoBufferLength = player.getVideoBufferLength();
@@ -308,7 +306,6 @@ export class SeekBar extends Component<SeekBarConfig> {
         switchVisibility(isLive, hasTimeShift);
       },
     );
-
     // Initial detection
     liveStreamDetector.detect();
     timeShiftDetector.detect();
@@ -364,7 +361,11 @@ export class SeekBar extends Component<SeekBarConfig> {
    * Update seekbar while a live stream with DVR window is paused.
    * The playback position stays still and the position indicator visually moves towards the back.
    */
-  private configureLivePausedTimeshiftUpdater(player: PlayerAPI, uimanager: UIInstanceManager, playbackPositionHandler: () => void): void {
+  private configureLivePausedTimeshiftUpdater(
+    player: PlayerAPI, 
+    uimanager: UIInstanceManager, 
+    playbackPositionHandler: () => void
+  ): void {
     // Regularly update the playback position while the timeout is active
     this.pausedTimeshiftUpdater = new Timeout(1000, playbackPositionHandler, true);
 
@@ -396,7 +397,6 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     this.smoothPlaybackPositionUpdater = new Timeout(updateIntervalMs, () => {
       currentTimeSeekBar += currentTimeUpdateDeltaSecs;
-      console.log('update!');
 
       try {
         currentTimePlayer = this.getRelativeCurrentTime();
@@ -429,7 +429,6 @@ export class SeekBar extends Component<SeekBarConfig> {
       }
 
       let playbackPositionPercentage = 100 / player.getDuration() * currentTimeSeekBar;
-
       this.setPlaybackPosition(playbackPositionPercentage);
     }, true);
 

--- a/src/ts/playerutils.ts
+++ b/src/ts/playerutils.ts
@@ -153,6 +153,10 @@ export namespace PlayerUtils {
       if (player.exports.PlayerEvent.DurationChanged) {
         player.on(player.exports.PlayerEvent.DurationChanged, liveDetector);
       }
+
+      // Ad video's isLive() might be different than the actual video's isLive().
+      player.on(player.exports.PlayerEvent.AdBreakStarted, liveDetector);
+      player.on(player.exports.PlayerEvent.AdBreakFinished, liveDetector);
     }
 
     detect(): void {

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -765,9 +765,7 @@ export class PlayerWrapper {
     // (Object.getOwnPropertyNames(player) does not work with the player TypeScript class starting in 7.2)
     let members: string[] = [];
     for (let member in player) {
-      if ((player as any)[member]) {
-        members.push(member);
-      }
+      members.push(member);
     }
 
     // Split the members into methods and properties

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -764,11 +764,6 @@ export class PlayerWrapper {
     // Collect all members of the player (public API methods and properties of the player)
     // (Object.getOwnPropertyNames(player) does not work with the player TypeScript class starting in 7.2)
     let members: string[] = [];
-
-
-    // const mss = Object.keys(player).filter(key => player[key] != null);
-
-
     for (let member in player) {
       if ((player as any)[member]) {
         members.push(member);
@@ -779,17 +774,10 @@ export class PlayerWrapper {
     let methods = <any[]>[];
     let properties = <any[]>[];
 
-
-    console.log(player.getConfig());
-    console.log(player)
-    console.log(members);
-
     for (let member of members) {
-
       if (typeof (<any>player)[member] === 'function') {
         methods.push(member);
       } else {
-        // console.log("non-fn:member: ", member)
         properties.push(member);
       }
     }
@@ -800,7 +788,6 @@ export class PlayerWrapper {
     // Add function wrappers for all API methods that do nothing but calling the base method on the player
     for (let method of methods) {
       wrapper[method] = function() {
-        // console.log('called ' + method); // track method calls on the player
         return (<any>player)[method].apply(player, arguments);
       };
     }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -764,18 +764,32 @@ export class PlayerWrapper {
     // Collect all members of the player (public API methods and properties of the player)
     // (Object.getOwnPropertyNames(player) does not work with the player TypeScript class starting in 7.2)
     let members: string[] = [];
+
+
+    // const mss = Object.keys(player).filter(key => player[key] != null);
+
+
     for (let member in player) {
-      members.push(member);
+      if ((player as any)[member]) {
+        members.push(member);
+      }
     }
 
     // Split the members into methods and properties
     let methods = <any[]>[];
     let properties = <any[]>[];
 
+
+    console.log(player.getConfig());
+    console.log(player)
+    console.log(members);
+
     for (let member of members) {
+
       if (typeof (<any>player)[member] === 'function') {
         methods.push(member);
       } else {
+        // console.log("non-fn:member: ", member)
         properties.push(member);
       }
     }
@@ -786,7 +800,7 @@ export class PlayerWrapper {
     // Add function wrappers for all API methods that do nothing but calling the base method on the player
     for (let method of methods) {
       wrapper[method] = function() {
-        // console.log('called ' + member); // track method calls on the player
+        // console.log('called ' + method); // track method calls on the player
         return (<any>player)[method].apply(player, arguments);
       };
     }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -786,6 +786,7 @@ export class PlayerWrapper {
     // Add function wrappers for all API methods that do nothing but calling the base method on the player
     for (let method of methods) {
       wrapper[method] = function() {
+        // console.log('called ' + member); // track method calls on the player
         return (<any>player)[method].apply(player, arguments);
       };
     }


### PR DESCRIPTION

moved playback position calculation logic inside a method and used each time for consistency.

