### PR TITLE
Feature/disable focus for ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - `onActive` and `onInactive` not fired for root `SettingsPanelPage` when `SettingsPanel` was configured with `hideDelay` of `-1`
+- Disabled focus on settings panel when clicked for iOS, behavior opens keyboard controls when focused 
 
 ## [3.9.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - `onActive` and `onInactive` not fired for root `SettingsPanelPage` when `SettingsPanel` was configured with `hideDelay` of `-1`
-- Disabled focus on settings panel when clicked for iOS, behavior opens keyboard controls when focused 
+- Automatic opening of the first select box when the `SettingsPanel` becomes visible on iOS devices
 
 ## [3.9.1]
 

--- a/src/ts/browserutils.ts
+++ b/src/ts/browserutils.ts
@@ -29,7 +29,7 @@ export class BrowserUtils {
     if (!this.windowExists()) {
       return false;
     }
-    return navigator && navigator.userAgent && /iPad|iPhone|iPod/.test(navigator.userAgent);
+    return navigator && navigator.userAgent && (/iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1));
   }
 
   private static windowExists(): boolean {

--- a/src/ts/browserutils.ts
+++ b/src/ts/browserutils.ts
@@ -25,6 +25,13 @@ export class BrowserUtils {
     return navigator && navigator.userAgent && /Android/.test(navigator.userAgent);
   }
 
+  static get isIOS(): boolean {
+    if (!this.windowExists()) {
+      return false;
+    }
+    return navigator && navigator.userAgent && /iPad|iPhone|iPod/.test(navigator.userAgent);
+  }
+
   private static windowExists(): boolean {
     return typeof window !== 'undefined';
   }

--- a/src/ts/browserutils.ts
+++ b/src/ts/browserutils.ts
@@ -32,6 +32,20 @@ export class BrowserUtils {
     return navigator && navigator.userAgent && (/iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1));
   }
 
+  static get isMacIntel(): boolean {
+    if (!this.windowExists()) {
+      return false;
+    }
+    return navigator && navigator.userAgent && navigator.platform === 'MacIntel';
+  }
+  // https://hacks.mozilla.org/2013/04/detecting-touch-its-the-why-not-the-how/
+  static get isTouchSupported() {
+    if (!this.windowExists()) {
+      return false;
+    }
+    return 'ontouchstart' in window || navigator && navigator.userAgent && (navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0);
+  }
+
   private static windowExists(): boolean {
     return typeof window !== 'undefined';
   }

--- a/src/ts/browserutils.ts
+++ b/src/ts/browserutils.ts
@@ -38,6 +38,7 @@ export class BrowserUtils {
     }
     return navigator && navigator.userAgent && navigator.platform === 'MacIntel';
   }
+
   // https://hacks.mozilla.org/2013/04/detecting-touch-its-the-why-not-the-how/
   static get isTouchSupported() {
     if (!this.windowExists()) {

--- a/src/ts/browserutils.ts
+++ b/src/ts/browserutils.ts
@@ -29,7 +29,7 @@ export class BrowserUtils {
     if (!this.windowExists()) {
       return false;
     }
-    return navigator && navigator.userAgent && (/iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1));
+    return navigator && navigator.userAgent && /iPad|iPhone|iPod/.test(navigator.userAgent);
   }
 
   static get isMacIntel(): boolean {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -12,6 +12,7 @@ import { PlayerAPI, PlayerEventBase } from 'bitmovin-player';
 import { StringUtils } from '../stringutils';
 import { SeekBarType, SeekBarController } from './seekbarcontroller';
 import { i18n } from '../localization/i18n';
+import { BrowserUtils } from '../browserutils';
 
 /**
  * Configuration interface for the {@link SeekBar} component.
@@ -101,9 +102,6 @@ export class SeekBar extends Component<SeekBarConfig> {
 
   private smoothPlaybackPositionUpdater: Timeout;
   private pausedTimeshiftUpdater: Timeout;
-
-  // https://hacks.mozilla.org/2013/04/detecting-touch-its-the-why-not-the-how/
-  private touchSupported = ('ontouchstart' in window);
 
   private seekBarEvents = {
     /**
@@ -668,7 +666,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     // and mouseup handlers to the whole document. A seek is triggered when the user lifts the mouse key.
     // A seek mouse gesture is thus basically a click with a long time frame between down and up events.
     seekBar.on('touchstart mousedown', (e: MouseEvent | TouchEvent) => {
-      let isTouchEvent = this.touchSupported && e instanceof TouchEvent;
+      let isTouchEvent = BrowserUtils.isTouchSupported && e instanceof TouchEvent;
 
       // Prevent selection of DOM elements (also prevents mousedown if current event is touchstart)
       e.preventDefault();
@@ -812,7 +810,7 @@ export class SeekBar extends Component<SeekBarConfig> {
    * @see #getVerticalOffset
    */
   private getOffset(e: MouseEvent | TouchEvent): number {
-    if (this.touchSupported && e instanceof TouchEvent) {
+    if (BrowserUtils.isTouchSupported && e instanceof TouchEvent) {
       if (this.config.vertical) {
         return this.getVerticalOffset(e.type === 'touchend' ? e.changedTouches[0].pageY : e.touches[0].pageY);
       } else {

--- a/src/ts/components/settingspanelpage.ts
+++ b/src/ts/components/settingspanelpage.ts
@@ -77,8 +77,8 @@ export class SettingsPanelPage extends Container<ContainerConfig> {
     const activeItems = this.getItems().filter((item) => item.isActive());
 
     this.settingsPanelPageEvents.onActive.dispatch(this);
-    // Disable focus for iOS devices, automatically opens select inputs
-    if (activeItems.length > 0 && !BrowserUtils.isIOS) {
+    // Disable focus for iOS and iPad OS 13 because it automatically opens select inputs
+    if (activeItems.length > 0 && !BrowserUtils.isIOS && !(BrowserUtils.isMacIntel && BrowserUtils.isTouchSupported)) {
       activeItems[0].getDomElement().focusToFirstInput();
     }
   }

--- a/src/ts/components/settingspanelpage.ts
+++ b/src/ts/components/settingspanelpage.ts
@@ -77,7 +77,7 @@ export class SettingsPanelPage extends Container<ContainerConfig> {
     const activeItems = this.getItems().filter((item) => item.isActive());
 
     this.settingsPanelPageEvents.onActive.dispatch(this);
-    // Disable focus for iOS and iPad OS 13 because it automatically opens select inputs
+    // Disable focus for iOS and iPadOS 13 because it opens a select input
     if (activeItems.length > 0 && !BrowserUtils.isIOS && !(BrowserUtils.isMacIntel && BrowserUtils.isTouchSupported)) {
       activeItems[0].getDomElement().focusToFirstInput();
     }

--- a/src/ts/components/settingspanelpage.ts
+++ b/src/ts/components/settingspanelpage.ts
@@ -73,10 +73,12 @@ export class SettingsPanelPage extends Container<ContainerConfig> {
   }
 
   onActiveEvent() {
-    this.settingsPanelPageEvents.onActive.dispatch(this);
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
     const activeItems = this.getItems().filter((item) => item.isActive());
 
-    if (activeItems.length > 0) {
+    this.settingsPanelPageEvents.onActive.dispatch(this);
+    // Disable focus for iOS devices, automatically opens select inputs
+    if (activeItems.length > 0 && !isIOS) {
       activeItems[0].getDomElement().focusToFirstInput();
     }
   }

--- a/src/ts/components/settingspanelpage.ts
+++ b/src/ts/components/settingspanelpage.ts
@@ -3,6 +3,7 @@ import {SettingsPanelItem} from './settingspanelitem';
 import {UIInstanceManager} from '../uimanager';
 import {Event, EventDispatcher, NoArgs} from '../eventdispatcher';
 import { PlayerAPI } from 'bitmovin-player';
+import { BrowserUtils } from '../browserutils';
 
 /**
  * A panel containing a list of {@link SettingsPanelItem items} that represent labelled settings.
@@ -73,12 +74,11 @@ export class SettingsPanelPage extends Container<ContainerConfig> {
   }
 
   onActiveEvent() {
-    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
     const activeItems = this.getItems().filter((item) => item.isActive());
 
     this.settingsPanelPageEvents.onActive.dispatch(this);
     // Disable focus for iOS devices, automatically opens select inputs
-    if (activeItems.length > 0 && !isIOS) {
+    if (activeItems.length > 0 && !BrowserUtils.isIOS) {
       activeItems[0].getDomElement().focusToFirstInput();
     }
   }


### PR DESCRIPTION
Disable focus for iOS devices because it automatically opens select inputs