### PR TITLE
Fix TTML subtitle background on Chromecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-### Development
+## [develop]
 
 ### Fixed
 - Subtitle background when TTML subtitles are used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Fixed
-- Subtitle background when TTML subtitles are used
+- Empty background boxes with TTML subtitles on Chromecast
 
 ## [3.9.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### Development
+
+### Fixed
+- Subtitle background when TTML subtitles are used
+
 ## [3.9.2]
 
 ### Added

--- a/src/scss/skin-modern/_skin-cast-receiver.scss
+++ b/src/scss/skin-modern/_skin-cast-receiver.scss
@@ -53,6 +53,7 @@
         line-height: 2em;
         padding: .3em .5em;
         text-shadow: none;
+        display: inline-flex;
       }
     }
 


### PR DESCRIPTION
Added a fix for empty transparent boxes when TTML subtitles are used with Chromecast devices.