### PR TITLE
Add VTT style properties and regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Added
-- Subtitle stlying with VTT properties and regions
+- Support for regions in VTT subtitles
 
 ### Fixed
 - UI hiding when actively using seek or volume slider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
+### Added
+- Subtitle stlying with VTT properties and regions
+
 ### Fixed
 - UI hiding when actively using seek or volume slider
 - Empty background boxes with TTML subtitles on Chromecast

--- a/package-lock.json
+++ b/package-lock.json
@@ -2554,9 +2554,9 @@
       "dev": true
     },
     "bitmovin-player": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.19.1.tgz",
-      "integrity": "sha512-wZSjBqIQTsEB+1e4iY5j8rmTkqpxNcvIReIaasD9gR18VpTFmA487PqM0rDDEn5ssdc6OtmU8CqO4Fh3I3y0Xg==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.28.0.tgz",
+      "integrity": "sha512-2gRZnqoUMmJY2oSyEYbokMKHVcqZ1KzRjnpB5TkorC79kLKqq09+/12p04T8iVkroPAosICkElxLKIstEIHzcQ==",
       "dev": true
     },
     "bl": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.11",
     "autoprefixer": "^6.5.2",
-    "bitmovin-player": "^8.19.1",
+    "bitmovin-player": "^8.28.0",
     "browser-sync": "^2.26.3",
     "browserify": "^13.1.1",
     "cssnano": "^3.8.0",

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -1,6 +1,7 @@
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 import { UIInstanceManager } from '../../src/ts/uimanager';
 import { SubtitleOverlay, SubtitleRegionContainerManager } from '../../src/ts/components/subtitleoverlay';
+import { DOM } from '../../src/ts/dom';
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;
@@ -12,6 +13,7 @@ let subtitleRegionContainerManagerMock: SubtitleRegionContainerManager;
 
 describe('SubtitleOverlay', () => {
   describe('Subtitle Region Container', () => {
+    let mockDomElement: DOM;
     beforeEach(() => {
       playerMock = MockHelper.getPlayerMock();
       uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
@@ -19,6 +21,9 @@ describe('SubtitleOverlay', () => {
       subtitleOverlay = new SubtitleOverlay();
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
       subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
+
+      mockDomElement = MockHelper.generateDOMMock();
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
     });
 
     it('adds a subtitle label on cueEnter', () => {
@@ -29,7 +34,6 @@ describe('SubtitleOverlay', () => {
 
     it('removes a subtitle label con cueExit', () => {
       playerMock.eventEmitter.fireSubtitleCueEnterEvent();
-      const mockDomElement = MockHelper.generateDOMMock();
       const removeLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'removeLabel');
       jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
       playerMock.eventEmitter.fireSubtitleCueExitEvent();

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -50,6 +50,7 @@ export namespace MockHelper {
       html: jest.fn(),
       css: jest.fn(),
       width: jest.fn(),
+      height: jest.fn()
     }));
 
     return new DOMClass();

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -4,10 +4,6 @@ import { VTTRegionProperties, VTTProperties } from 'bitmovin-player';
 import { MockHelper } from './helper/MockHelper';
 
 describe('Vtt Utils', () => {
-  beforeEach(() => {
-    // Setup DOM Mock
-
-  });
   describe('Vtt Region', () => {
     it('should set region css properties', () => {
         const mockRegionContainer = generateSubtitleRegionContainerMock();

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -11,7 +11,7 @@ describe('Vtt Utils', () => {
         mockRegionContainer.getDomElement = () => mockDomElement;
         const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
     
-        VttUtils.setVttRegionStyles(mockRegionContainer, vttRegionProps, {width: 1000, height: 800});
+        VttUtils.setVttRegionStyles(mockRegionContainer, vttRegionProps, { width: 1000, height: 800 });
 
         expect(spyCss).toHaveBeenCalledTimes(8);
         expect(spyCss).toHaveBeenNthCalledWith(1, 'position', 'absolute');
@@ -35,18 +35,7 @@ describe('Vtt Utils', () => {
       VttUtils.setVttCueBoxStyles(mockRegionContainer);
       
       expect(spyCss).toHaveBeenCalledTimes(11);
-      expect(spyCss).toHaveBeenNthCalledWith(8, 'text-align', 'left');
-    });
-
-    it('should not set default position', () => {
-      const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 50 } as VTTProperties);
-      const mockDomElement = MockHelper.generateDOMMock();
-      mockRegionContainer.getDomElement = () => mockDomElement;
-      const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-
-      VttUtils.setVttCueBoxStyles(mockRegionContainer);
-      
-      expect(spyCss).toHaveBeenCalledTimes(9);
+      expect(spyCss).toHaveBeenNthCalledWith(9, 'text-align', 'left');
     });
 
     describe('Default Cue Box Styles', () => {
@@ -116,7 +105,7 @@ describe('Vtt Utils', () => {
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
             expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '50%');
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'top', '50%');
           });
 
           it('should set positive line positioning', () => {
@@ -128,7 +117,7 @@ describe('Vtt Utils', () => {
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
             expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '112px');
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'top', '112px');
           });
 
           it('should set negative line positioning', () => {
@@ -140,7 +129,7 @@ describe('Vtt Utils', () => {
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
             expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(8, 'bottom', '112px');
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'bottom', '112px');
           });
 
           describe('Line Alignment', () => {
@@ -164,7 +153,7 @@ describe('Vtt Utils', () => {
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
               
               expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-14px');
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-top', '-14px');
             });
 
             it('should do end line alignment', () => {
@@ -176,7 +165,7 @@ describe('Vtt Utils', () => {
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
               
               expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-28px');
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-top', '-28px');
             });
           })
         });
@@ -191,7 +180,7 @@ describe('Vtt Utils', () => {
   
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
           
-          expect(spyCss).toHaveBeenCalledTimes(11);
+          expect(spyCss).toHaveBeenCalledTimes(12);
           expect(spyCss).toHaveBeenNthCalledWith(7, 'writing-mode', 'vertical-lr');
           expect(spyCss).toHaveBeenNthCalledWith(8, 'right', '0');
         });
@@ -205,7 +194,7 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenCalledTimes(12);
           });
 
           it('should set percentage line positioning', () => {
@@ -216,8 +205,8 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '50%');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'right', '50%');
           });
 
           it('should set positive line positioning', () => {
@@ -228,8 +217,8 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '112px');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'right', '112px');
           });
 
           it('should set negative line positioning', () => {
@@ -240,8 +229,8 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '112px');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '112px');
           });
 
           describe('Line alignment', () => {
@@ -253,7 +242,7 @@ describe('Vtt Utils', () => {
       
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
               
-              expect(spyCss).toHaveBeenCalledTimes(12);
+              expect(spyCss).toHaveBeenCalledTimes(13);
             });
 
             it('should do center line alignment', () => {
@@ -264,8 +253,8 @@ describe('Vtt Utils', () => {
       
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
               
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-14px');
+              expect(spyCss).toHaveBeenCalledTimes(14);
+              expect(spyCss).toHaveBeenNthCalledWith(11, 'margin-right', '-14px');
             });
 
             it('should do end line alignment', () => {
@@ -276,8 +265,8 @@ describe('Vtt Utils', () => {
       
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
               
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-28px');
+              expect(spyCss).toHaveBeenCalledTimes(14);
+              expect(spyCss).toHaveBeenNthCalledWith(11, 'margin-right', '-28px');
             });
           })
         });
@@ -292,7 +281,7 @@ describe('Vtt Utils', () => {
   
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
   
-          expect(spyCss).toHaveBeenCalledTimes(11);
+          expect(spyCss).toHaveBeenCalledTimes(12);
           expect(spyCss).toHaveBeenNthCalledWith(7, 'writing-mode', 'vertical-rl');
           expect(spyCss).toHaveBeenNthCalledWith(8, 'left', '0');
         });
@@ -306,7 +295,7 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
     
-            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenCalledTimes(12);
           });
 
           it('should set percentage line positioning', () => {
@@ -317,8 +306,8 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '50%');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '50%');
           });
 
           it('should set positive line positioning', () => {
@@ -329,8 +318,8 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '112px');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '112px');
           });
 
           it('should set negative line positioning', () => {
@@ -341,8 +330,8 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '112px');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'right', '112px');
           });
 
           describe('Line alignment', () => {
@@ -354,7 +343,7 @@ describe('Vtt Utils', () => {
       
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
               
-              expect(spyCss).toHaveBeenCalledTimes(12);
+              expect(spyCss).toHaveBeenCalledTimes(13);
             });
 
             it('should do center line alignment', () => {
@@ -365,8 +354,8 @@ describe('Vtt Utils', () => {
       
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
               
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-14px');
+              expect(spyCss).toHaveBeenCalledTimes(14);
+              expect(spyCss).toHaveBeenNthCalledWith(11, 'margin-left', '-14px');
             });
 
             it('should do end line alignment', () => {
@@ -377,8 +366,8 @@ describe('Vtt Utils', () => {
       
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
               
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-28px');
+              expect(spyCss).toHaveBeenCalledTimes(14);
+              expect(spyCss).toHaveBeenNthCalledWith(11, 'margin-left', '-28px');
             });
           })
         });
@@ -396,7 +385,7 @@ describe('Vtt Utils', () => {
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
           
           expect(spyCss).toHaveBeenCalledTimes(11);
-          expect(spyCss).toHaveBeenNthCalledWith(9, 'width', '100%');
+          expect(spyCss).toHaveBeenNthCalledWith(10, 'width', '100%');
         });
 
         describe('Position Align', () => {
@@ -409,8 +398,19 @@ describe('Vtt Utils', () => {
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
             expect(spyCss).toHaveBeenCalledTimes(11);
-            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '0');
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'bottom', '0');
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'left', '0');
+          });
+          
+          it('should set position', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 50 } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'left', '50%');
           });
 
           it('should set left position align', () => {
@@ -421,9 +421,9 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(11);
-            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '30%');
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'right', 'auto');
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'left', '30%');
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'right', 'auto');
           });
 
           it('should set center position align', () => {
@@ -434,9 +434,9 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(11);
-            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '-70%');
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'right', 'auto');
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'left', '-70%');
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'right', 'auto');
           });
 
           it('should set right position align', () => {
@@ -447,9 +447,9 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(11);
-            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', 'auto');
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'right', '30%');
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'left', 'auto');
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'right', '30%');
           });
         });
       });
@@ -463,8 +463,8 @@ describe('Vtt Utils', () => {
   
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
           
-          expect(spyCss).toHaveBeenCalledTimes(11);
-          expect(spyCss).toHaveBeenNthCalledWith(10, 'height', '100%');
+          expect(spyCss).toHaveBeenCalledTimes(12);
+          expect(spyCss).toHaveBeenNthCalledWith(11, 'height', '100%');
         });
 
         describe('Position Align', () => {
@@ -476,8 +476,20 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(11);
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '0');
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'top', '0');
+          });
+
+          it('should set position', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', position: 50 } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'top', '50%');
           });
 
           it('should set left position align', () => {
@@ -488,9 +500,9 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '30%');
-            expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', 'auto');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'top', '30%');
+            expect(spyCss).toHaveBeenNthCalledWith(13, 'bottom', 'auto');
           });
 
           it('should set center position align', () => {
@@ -501,9 +513,9 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '-70%');
-            expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', 'auto');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'top', '-70%');
+            expect(spyCss).toHaveBeenNthCalledWith(13, 'bottom', 'auto');
           });
 
           it('should set right position align', () => {
@@ -514,9 +526,9 @@ describe('Vtt Utils', () => {
     
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
             
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'top', 'auto');
-            expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', '30%');
+            expect(spyCss).toHaveBeenCalledTimes(13);
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'top', 'auto');
+            expect(spyCss).toHaveBeenNthCalledWith(13, 'bottom', '30%');
           });
         });
       })

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -1,0 +1,576 @@
+import { SubtitleRegionContainer, SubtitleLabel } from '../src/ts/components/subtitleoverlay';
+import { VttUtils } from '../src/ts/vttutils';
+import { VTTRegionProperties, VTTProperties } from 'bitmovin-player';
+import { MockHelper } from './helper/MockHelper';
+
+describe('Vtt Utils', () => {
+  beforeEach(() => {
+    // Setup DOM Mock
+
+  });
+  describe('Vtt Region', () => {
+    it('should set region css properties', () => {
+        const mockRegionContainer = generateSubtitleRegionContainerMock();
+        const mockDomElement = MockHelper.generateDOMMock();
+        mockRegionContainer.getDomElement = () => mockDomElement;
+        const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+        VttUtils.setVttRegionStyles(mockRegionContainer, vttRegionProps, {width: 1000, height: 800});
+
+        expect(spyCss).toHaveBeenCalledTimes(8);
+        expect(spyCss).toHaveBeenNthCalledWith(1, 'position', 'absolute');
+        expect(spyCss).toHaveBeenNthCalledWith(2, 'overflow', 'hidden');
+        expect(spyCss).toHaveBeenNthCalledWith(3, 'width', `${vttRegionProps.width}%`);
+        expect(spyCss).toHaveBeenNthCalledWith(4, 'left', '75px');
+        expect(spyCss).toHaveBeenNthCalledWith(5, 'right', 'unset');
+        expect(spyCss).toHaveBeenNthCalledWith(6, 'top', '772px');
+        expect(spyCss).toHaveBeenNthCalledWith(7, 'bottom', 'unset');
+        expect(spyCss).toHaveBeenNthCalledWith(8, 'height', '28px');
+      });
+  });
+
+  describe('Vtt Cue Box', () => {
+    it('should set text align', () => {
+      const mockRegionContainer = generateSubtitleCueBoxMock(false, { align: 'left' } as VTTProperties);
+      const mockDomElement = MockHelper.generateDOMMock();
+      mockRegionContainer.getDomElement = () => mockDomElement;
+      const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+
+      VttUtils.setVttCueBoxStyles(mockRegionContainer);
+      
+      expect(spyCss).toHaveBeenCalledTimes(11);
+      expect(spyCss).toHaveBeenNthCalledWith(8, 'text-align', 'left');
+    });
+
+    it('should not set default position', () => {
+      const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 50 } as VTTProperties);
+      const mockDomElement = MockHelper.generateDOMMock();
+      mockRegionContainer.getDomElement = () => mockDomElement;
+      const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+
+      VttUtils.setVttCueBoxStyles(mockRegionContainer);
+      
+      expect(spyCss).toHaveBeenCalledTimes(9);
+    });
+
+    describe('Default Cue Box Styles', () => {
+      it('should set default cue box css properties without region', () => {
+        const mockRegionContainer = generateSubtitleCueBoxMock(false);
+        const mockDomElement = MockHelper.generateDOMMock();
+        mockRegionContainer.getDomElement = () => mockDomElement;
+        const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+
+        VttUtils.setVttCueBoxStyles(mockRegionContainer);
+
+        expect(spyCss).toHaveBeenCalledTimes(11);
+        expect(spyCss).toHaveBeenNthCalledWith(1, 'position', 'absolute');
+        expect(spyCss).toHaveBeenNthCalledWith(2, 'overflow-wrap', 'break-word');
+        expect(spyCss).toHaveBeenNthCalledWith(3, 'overflow', 'hidden');
+        expect(spyCss).toHaveBeenNthCalledWith(4, 'display', 'inline-flex');
+        expect(spyCss).toHaveBeenNthCalledWith(5, 'flex-flow', 'column');
+        expect(spyCss).toHaveBeenNthCalledWith(6, 'justify-content', 'flex-end');
+      });
+
+      it('should set default cue box css properties with region', () => {
+        const mockRegionContainer = generateSubtitleCueBoxMock(true);
+        const mockDomElement = MockHelper.generateDOMMock();
+        mockRegionContainer.getDomElement = () => mockDomElement;
+        const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+
+        VttUtils.setVttCueBoxStyles(mockRegionContainer);
+
+        expect(spyCss).toHaveBeenCalledTimes(7);
+        expect(spyCss).toHaveBeenNthCalledWith(1, 'position', 'relative');
+        expect(spyCss).toHaveBeenNthCalledWith(2, 'unicode-bidi', 'plaintext');
+      });
+    });
+
+    describe('Cue Box Writing Direction', () => {
+      describe('Horizontal Writing Direction', () => {
+        it('should set horizontal-tb writing mode', () => {
+          const mockRegionContainer = generateSubtitleCueBoxMock(false);
+          const mockDomElement = MockHelper.generateDOMMock();
+          mockRegionContainer.getDomElement = () => mockDomElement;
+          const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+  
+          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+  
+          expect(spyCss).toHaveBeenCalledTimes(11);
+          expect(spyCss).toHaveBeenNthCalledWith(7, 'writing-mode', 'horizontal-tb');
+        });
+
+        describe('Line Positioning', () => {
+          it('should skip line positioning with default values', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+    
+            expect(spyCss).toHaveBeenCalledTimes(11);
+          });
+
+          it('should set percentage line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: '50%', snapToLines: false } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '50%');
+          });
+
+          it('should set positive line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: 4, snapToLines: true } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '112px');
+          });
+
+          it('should set negative line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: -4, snapToLines: true } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'bottom', '112px');
+          });
+
+          describe('Line Alignment', () => {
+            it('should not do start line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: '50%', snapToLines: false, lineAlign: 'start' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(12);
+            });
+
+            it('should do center line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: '50%', snapToLines: false, lineAlign: 'center' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(13);
+              expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-14px');
+            });
+
+            it('should do end line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: '50%', snapToLines: false, lineAlign: 'end' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(13);
+              expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-28px');
+            });
+          })
+        });
+      });
+
+      describe('Vertical LR Writing Direction', () => {
+        it('should set vertical-lr writing mode', () => {
+          const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr' } as VTTProperties);
+          const mockDomElement = MockHelper.generateDOMMock();
+          mockRegionContainer.getDomElement = () => mockDomElement;
+          const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+  
+          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+          
+          expect(spyCss).toHaveBeenCalledTimes(11);
+          expect(spyCss).toHaveBeenNthCalledWith(7, 'writing-mode', 'vertical-lr');
+          expect(spyCss).toHaveBeenNthCalledWith(8, 'right', '0');
+        });
+
+        describe('Line positioning', () => {
+          it('should skip line positioning with default values', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(11);
+          });
+
+          it('should set percentage line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: '50%', snapToLines: false } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '50%');
+          });
+
+          it('should set positive line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: 4, snapToLines: true } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '112px');
+          });
+
+          it('should set negative line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: -4, snapToLines: true } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '112px');
+          });
+
+          describe('Line alignment', () => {
+            it('should not do start line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: '50%', snapToLines: false, lineAlign: 'start' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(12);
+            });
+
+            it('should do center line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: '50%', snapToLines: false, lineAlign: 'center' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(13);
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-14px');
+            });
+
+            it('should do end line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: '50%', snapToLines: false, lineAlign: 'end' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(13);
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-28px');
+            });
+          })
+        });
+      });
+
+      describe('Vertical RL Writing Direction', () => {
+        it('should set vertical-rl writing mode', () => {
+          const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl' } as VTTProperties);
+          const mockDomElement = MockHelper.generateDOMMock();
+          mockRegionContainer.getDomElement = () => mockDomElement;
+          const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+  
+          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+  
+          expect(spyCss).toHaveBeenCalledTimes(11);
+          expect(spyCss).toHaveBeenNthCalledWith(7, 'writing-mode', 'vertical-rl');
+          expect(spyCss).toHaveBeenNthCalledWith(8, 'left', '0');
+        });
+
+        describe('Line positioning', () => {
+          it('should skip line positioning with default values', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+    
+            expect(spyCss).toHaveBeenCalledTimes(11);
+          });
+
+          it('should set percentage line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: '50%', snapToLines: false } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '50%');
+          });
+
+          it('should set positive line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: 4, snapToLines: true } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '112px');
+          });
+
+          it('should set negative line positioning', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: -4, snapToLines: true } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '112px');
+          });
+
+          describe('Line alignment', () => {
+            it('should not do start line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: '50%', snapToLines: false, lineAlign: 'start' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(12);
+            });
+
+            it('should do center line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: '50%', snapToLines: false, lineAlign: 'center' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(13);
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-14px');
+            });
+
+            it('should do end line alignment', () => {
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: '50%', snapToLines: false, lineAlign: 'end' } as VTTProperties);
+              const mockDomElement = MockHelper.generateDOMMock();
+              mockRegionContainer.getDomElement = () => mockDomElement;
+              const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+      
+              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              
+              expect(spyCss).toHaveBeenCalledTimes(13);
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-28px');
+            });
+          })
+        });
+      });
+    });
+
+    describe('Cue Box Size', () => {
+      describe('Vertical', () => {
+        it('should set width', () => {
+          const mockRegionContainer = generateSubtitleCueBoxMock(false);
+          const mockDomElement = MockHelper.generateDOMMock();
+          mockRegionContainer.getDomElement = () => mockDomElement;
+          const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+  
+          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+          
+          expect(spyCss).toHaveBeenCalledTimes(11);
+          expect(spyCss).toHaveBeenNthCalledWith(9, 'width', '100%');
+        });
+
+        describe('Position Align', () => {
+          it('should set default position align', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '0');
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'bottom', '0');
+          });
+
+          it('should set left position align', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 30, positionAlign: 'line-left' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '30%');
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'right', 'auto');
+          });
+
+          it('should set center position align', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 30, positionAlign: 'center' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '-70%');
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'right', 'auto');
+          });
+
+          it('should set right position align', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 30, positionAlign: 'line-right' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(10, 'left', 'auto');
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'right', '30%');
+          });
+        });
+      });
+      
+      describe('Horizontal', () => {
+        it('should set height', () => {
+          const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr' } as VTTProperties);
+          const mockDomElement = MockHelper.generateDOMMock();
+          mockRegionContainer.getDomElement = () => mockDomElement;
+          const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+  
+          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+          
+          expect(spyCss).toHaveBeenCalledTimes(11);
+          expect(spyCss).toHaveBeenNthCalledWith(10, 'height', '100%');
+        });
+
+        describe('Position Align', () => {
+          it('should set default position align', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '0');
+          });
+
+          it('should set left position align', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', position: 30, positionAlign: 'line-left' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '30%');
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', 'auto');
+          });
+
+          it('should set center position align', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', position: 30, positionAlign: 'center' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '-70%');
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', 'auto');
+          });
+
+          it('should set right position align', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', position: 30, positionAlign: 'line-right' } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+    
+            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            
+            expect(spyCss).toHaveBeenCalledTimes(12);
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'top', 'auto');
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', '30%');
+          });
+        });
+      })
+    });
+  });
+});
+
+function generateSubtitleRegionContainerMock(): SubtitleRegionContainer {
+    const SubtitleRegionContainerClass: jest.Mock<SubtitleRegionContainer> = jest.fn().mockImplementation();
+    return new SubtitleRegionContainerClass();
+}
+
+function generateSubtitleCueBoxMock(hasRegion: boolean, vttProps?: VTTProperties): SubtitleLabel {
+    const region = hasRegion ? vttRegionProps : null;
+    const SubtitleCueBoxClass: jest.Mock<SubtitleLabel> = jest.fn().mockImplementation(() => (
+        {
+            vtt: {
+                ...generateVttProps(vttProps),
+                region
+            }
+        }
+    ));
+    return new SubtitleCueBoxClass();
+}
+
+const vttRegionProps: VTTRegionProperties = {
+    id: 'regionId',
+    lines: 1,
+    width: 70,
+    regionAnchorX: 25,
+    regionAnchorY: 100,
+    viewportAnchorX: 25,
+    viewportAnchorY: 100,
+    scroll: ''
+}
+
+const generateVttProps = (props?: VTTProperties): VTTProperties => {
+  const defaultProps = {
+    vertical: '',
+    align: 'center',
+    size: 100,
+    line: 'auto',
+    lineAlign: 'start',
+    position: 'auto',
+    positionAlign: 'auto',
+    snapToLines: false,
+  }
+
+  return {
+    ...defaultProps,
+    ...props
+  }
+}

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -1,10 +1,10 @@
-import {Container, ContainerConfig} from './container';
-import {UIInstanceManager} from '../uimanager';
-import {Label, LabelConfig} from './label';
-import {ComponentConfig, Component} from './component';
-import {ControlBar} from './controlbar';
+import { Container, ContainerConfig } from './container';
+import { UIInstanceManager } from '../uimanager';
+import { Label, LabelConfig } from './label';
+import { ComponentConfig, Component } from './component';
+import { ControlBar } from './controlbar';
 import { EventDispatcher } from '../eventdispatcher';
-import {DOM} from '../dom';
+import { DOM } from '../dom';
 import { PlayerAPI, SubtitleCueEvent } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
 import { setVttCueBoxStyles, setVttRegionStyles } from './subtitlevtt';
@@ -494,7 +494,7 @@ export class SubtitleRegionContainerManager {
    * Removes a subtitle label from a container.
    */
   removeLabel(label: SubtitleLabel): void {
-    const regionName = label.vtt && label.vtt.region ? label.vtt.region.id : label.region || 'default';
+    const regionName = (label.vtt && label.vtt.region && label.vtt.region.id) ? label.vtt.region.id : label.region || 'default';
     this.subtitleRegionContainers[regionName].removeLabel(label);
 
     // Remove container if no more labels are displayed
@@ -536,7 +536,7 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
     this.addComponent(this.cueBoxContainers[id]);
     this.updateComponents();
 
-    if (labelToAdd.vtt.region && labelToAdd.vtt.region.scroll) {
+    if (labelToAdd.vtt.region && labelToAdd.vtt.region.scroll === 'up') {
       this.getDomElement().scrollTo(0, 9999);
     }
   }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -485,7 +485,7 @@ export class SubtitleRegionContainerManager {
 
     if (!this.subtitleRegionContainers[regionContainerId]) {
       const regionContainer = new SubtitleRegionContainer({
-        cssClasses
+        cssClasses,
       });
 
       this.subtitleRegionContainers[regionContainerId] = regionContainer;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -7,7 +7,7 @@ import { EventDispatcher } from '../eventdispatcher';
 import { DOM } from '../dom';
 import { PlayerAPI, SubtitleCueEvent } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
-import { setVttCueBoxStyles, setVttRegionStyles } from './subtitlevtt';
+import { VttUtils } from '../vttutils';
 import { VTTProperties } from 'bitmovin-player/types/subtitles/vtt/API';
 
 /**
@@ -466,7 +466,7 @@ export class SubtitleRegionContainerManager {
    * If the subtitle has positioning information it is added to the container.
    * @param label The subtitle label to wrap
    */
-  addLabel(label: SubtitleLabel, overlaySize?: {width: number, height: number}): void {
+  addLabel(label: SubtitleLabel, overlaySize?: { width: number, height: number }): void {
     let regionContainerId;
     let regionName;
 
@@ -493,6 +493,10 @@ export class SubtitleRegionContainerManager {
       if (label.regionStyle) {
         regionContainer.getDomElement().attr('style', label.regionStyle);
       } else if (label.vtt && !label.vtt.region) {
+        /**
+         * If there is no region present to wrap the Cue Box, the Cue box becomes the
+         * region itself. Therefore the positioning values have to come from the box.
+         */
         regionContainer.getDomElement().css('position', 'unset');
       } else {
         // getDomElement needs to be called at least once to ensure the component exists
@@ -551,16 +555,15 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
     }, this.config);
   }
 
-  addLabel(labelToAdd: SubtitleLabel, overlaySize?: {width: number, height: number}) {
+  addLabel(labelToAdd: SubtitleLabel, overlaySize?: { width: number, height: number }) {
     this.labelCount++;
 
     if (labelToAdd.vtt) {
-      debugger;
       if (labelToAdd.vtt.region && overlaySize) {
-        setVttRegionStyles(this, labelToAdd.vtt.region, overlaySize);
+        VttUtils.setVttRegionStyles(this, labelToAdd.vtt.region, overlaySize);
       }
 
-      setVttCueBoxStyles(labelToAdd, labelToAdd.vtt);
+      VttUtils.setVttCueBoxStyles(labelToAdd, labelToAdd.vtt);
     }
 
     this.addComponent(labelToAdd);

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -563,7 +563,7 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
         VttUtils.setVttRegionStyles(this, labelToAdd.vtt.region, overlaySize);
       }
 
-      VttUtils.setVttCueBoxStyles(labelToAdd, labelToAdd.vtt);
+      VttUtils.setVttCueBoxStyles(labelToAdd);
     }
 
     this.addComponent(labelToAdd);

--- a/src/ts/components/subtitlevtt.ts
+++ b/src/ts/components/subtitlevtt.ts
@@ -1,0 +1,142 @@
+import {SubtitleRegionContainer, SubtitleCueBoxContainer} from './subtitleoverlay';
+import { VTTProperties, VTTRegionProperties } from 'bitmovin-player/types/subtitles/vtt/API';
+
+type Direction = 'top' | 'bottom' | 'left' | 'right';
+
+const lineHeight = 28;
+
+const DirectionPair = new Map<Direction, Direction>([
+  ['top', 'bottom'],
+  ['left', 'right'],
+  ['right', 'left'],
+]);
+
+/**
+ * Sets the default standardized styles for the Cue Box
+ * https://w3.org/TR/webvtt1/#applying-css-properties
+ */
+const setDefaultVttStyles = (cueContainer: SubtitleCueBoxContainer | SubtitleRegionContainer) => {
+  cueContainer.getDomElement().css('unicode-bidi', 'plaintext');
+  cueContainer.getDomElement().css('overflow-wrap', 'break-word');
+  cueContainer.getDomElement().css('text-wrap', 'balance');
+  cueContainer.getDomElement().css('white-space', 'pre-line');
+};
+
+/**
+ * Align the Cue Box's line
+ * https://w3.org/TR/webvtt1/#webvtt-cue-line-alignment
+ */
+const setVttLineAlign = (cueContainer: SubtitleCueBoxContainer | SubtitleRegionContainer, {lineAlign}: VTTProperties, direction: Direction) => {
+  if (lineAlign != null && lineAlign === 'center') {
+    cueContainer.getDomElement().css(`margin-${direction}`, `${-lineHeight / 2}px`);
+  } else if (lineAlign != null && lineAlign === 'end') {
+    cueContainer.getDomElement().css(`margin-${direction}`, `${-lineHeight}px`);
+  }
+};
+
+/**
+ * Defines the positioning of the Cue Box
+ * https://w3.org/TR/webvtt1/#webvtt-cue-line
+ */
+const setVttLine = (cueContainer: SubtitleCueBoxContainer | SubtitleRegionContainer, vtt: VTTProperties, direction: Direction) => {
+  if (vtt.line != null && typeof vtt.line === 'number' && !vtt.snapToLines) {
+    cueContainer.getDomElement().css(direction, `${vtt.line}%`);
+    cueContainer.getDomElement().css(DirectionPair.get(direction), 'unset');
+
+    setVttLineAlign(cueContainer, vtt, direction);
+  } else if (vtt.line != null && typeof vtt.line === 'number' && vtt.snapToLines && vtt.line > 0) {
+    cueContainer.getDomElement().css(direction, `${vtt.line * lineHeight}px`);
+    cueContainer.getDomElement().css(DirectionPair.get(direction), 'unset');
+
+    setVttLineAlign(cueContainer, vtt, direction);
+  } else if (vtt.line != null && typeof vtt.line === 'number' && vtt.snapToLines && vtt.line < 0) {
+    cueContainer.getDomElement().css(DirectionPair.get(direction), `${vtt.line * -lineHeight}px`);
+    cueContainer.getDomElement().css(direction, 'unset');
+
+    setVttLineAlign(cueContainer, vtt, DirectionPair.get(direction));
+  }
+};
+
+/**
+ * Defines the writing direction of the Cue Box
+ * https://w3.org/TR/webvtt1/#webvtt-cue-writing-direction
+ */
+const setVttWritingDirection = (cueContainer: SubtitleCueBoxContainer | SubtitleRegionContainer, vtt: VTTProperties) => {
+  if (vtt.vertical === '') {
+    cueContainer.getDomElement().css('writing-mode', 'horizontal-tb');
+    setVttLine(cueContainer, vtt, 'top');
+  } else if (vtt.vertical === 'lr') {
+    cueContainer.getDomElement().css('writing-mode', 'vertical-lr');
+    cueContainer.getDomElement().css('left', 'unset');
+    cueContainer.getDomElement().css('right', '0');
+
+    setVttLine(cueContainer, vtt, 'right');
+  } else if (vtt.vertical === 'rl') {
+    cueContainer.getDomElement().css('writing-mode', 'vertical-rl');
+    cueContainer.getDomElement().css('left', '0');
+    cueContainer.getDomElement().css('right', 'unset');
+
+    setVttLine(cueContainer, vtt, 'left');
+  }
+};
+
+/**
+ * Defines the Cue position alignment
+ * https://w3.org/TR/webvtt1/#webvtt-cue-position-alignment
+ */
+const setVttPositionAlign = (cueContainer: SubtitleCueBoxContainer | SubtitleRegionContainer, vtt: VTTProperties, direction: Direction) => {
+  switch (vtt.positionAlign) {
+    case 'line-left':
+      cueContainer.getDomElement().css(direction, `${vtt.position}%`);
+      cueContainer.getDomElement().css(DirectionPair.get(direction), 'auto');
+      break;
+    case 'center':
+      cueContainer.getDomElement().css(direction, `${vtt.position as number - (vtt.size || 100)}%`);
+      cueContainer.getDomElement().css(DirectionPair.get(direction), 'auto');
+      break;
+    case 'line-right':
+      cueContainer.getDomElement().css(direction, 'auto');
+      cueContainer.getDomElement().css(DirectionPair.get(direction), `${vtt.position}%`);
+      break;
+    default:
+      cueContainer.getDomElement().css(direction, `${vtt.position}%`);
+      cueContainer.getDomElement().css(DirectionPair.get(direction), 'auto');
+      break;
+  }
+};
+
+export const setVttCueBoxStyles = (cueContainer: SubtitleCueBoxContainer | SubtitleRegionContainer, vtt: VTTProperties) => {
+  setDefaultVttStyles(cueContainer);
+
+  setVttWritingDirection(cueContainer, vtt);
+
+  // https://w3.org/TR/webvtt1/#webvtt-cue-text-alignment
+  const textAlign = vtt.align === 'middle' ? 'center' : vtt.align;
+  cueContainer.getDomElement().css('text-align', textAlign);
+
+  // https://w3.org/TR/webvtt1/#webvtt-cue-size
+  const containerSize = vtt.size;
+  if (vtt.position !== 'auto' && vtt.vertical == null) {
+    cueContainer.getDomElement().css('width', `${containerSize}%`);
+    cueContainer.getDomElement().css('left', 'unset');
+    cueContainer.getDomElement().css('right', 'unset');
+    setVttPositionAlign(cueContainer, vtt, 'left');
+  } else if (vtt.position !== 'auto' && vtt.vertical != null) {
+    cueContainer.getDomElement().css('height', `${containerSize}%`);
+    setVttPositionAlign(cueContainer, vtt, 'top');
+  }
+};
+
+// https://www.w3.org/TR/webvtt1/#regions
+export const setVttRegionStyles = (regionContainer: SubtitleRegionContainer | SubtitleRegionContainer, region: VTTRegionProperties, overlaySize: {width: number, height: number}) => {
+  const regionPositionX = overlaySize.width * region.viewportAnchorX / 100 - ((overlaySize.width * region.width / 100) * region.regionAnchorX / 100);
+  const regionPositionY = overlaySize.height * region.viewportAnchorY / 100 - ((region.lines * lineHeight) * region.regionAnchorY / 100);
+  regionContainer.getDomElement().css('position', 'absolute');
+  regionContainer.getDomElement().css('overflow', 'hidden');
+  regionContainer.getDomElement().css('width', `${region && region.width ? region.width : 100}%`);
+  regionContainer.getDomElement().css('left', `${regionPositionX}px`);
+  regionContainer.getDomElement().css('right', 'unset');
+  regionContainer.getDomElement().css('top', `${regionPositionY}px`);
+  regionContainer.getDomElement().css('bottom', 'unset');
+  regionContainer.getDomElement().css('height', `${region && region.lines ? region.lines * lineHeight : 3 * lineHeight}px`);
+};

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -181,6 +181,13 @@ export class DOM {
   }
 
   /**
+   * Focuses to the first input element
+   */
+  scrollTo(x: number, y: number) {
+    this.elements[0].scrollTo(x, y);
+  }
+
+  /**
    * Returns a string of the inner HTML content of the first element.
    */
   html(): string;

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -76,14 +76,17 @@ const setVttLine = (cueContainerDom: DOM, vtt: VTTProperties, direction: Directi
 const setVttWritingDirection = (cueContainerDom: DOM, vtt: VTTProperties) => {
   if (vtt.vertical === '') {
     cueContainerDom.css('writing-mode', 'horizontal-tb');
+    cueContainerDom.css(Direction.Bottom, '0');
     setVttLine(cueContainerDom, vtt, Direction.Top);
   } else if (vtt.vertical === 'lr') {
     cueContainerDom.css('writing-mode', 'vertical-lr');
     cueContainerDom.css(Direction.Right, '0');
+    cueContainerDom.css(Direction.Top, '0');
     setVttLine(cueContainerDom, vtt, Direction.Right);
   } else if (vtt.vertical === 'rl') {
     cueContainerDom.css('writing-mode', 'vertical-rl');
     cueContainerDom.css(Direction.Left, '0');
+    cueContainerDom.css(Direction.Top, '0');
     setVttLine(cueContainerDom, vtt, Direction.Left);
   }
 };
@@ -96,10 +99,6 @@ const setVttPositionAlign = (cueContainerDom: DOM, vtt: VTTProperties, direction
   // https://www.w3.org/TR/webvtt1/#webvtt-cue-position
   if (vtt.position === 'auto') {
     cueContainerDom.css(direction, '0');
-
-    if (vtt.vertical === '') {
-      cueContainerDom.css(Direction.Bottom, '0');
-    }
   } else {
     switch (vtt.positionAlign) {
       case 'line-left':
@@ -113,6 +112,9 @@ const setVttPositionAlign = (cueContainerDom: DOM, vtt: VTTProperties, direction
       case 'line-right':
         cueContainerDom.css(direction, 'auto');
         cueContainerDom.css(DirectionPair.get(direction), `${vtt.position}%`);
+        break;
+      default:
+        cueContainerDom.css(direction, `${vtt.position}%`);
     }
   }
 };

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -8,8 +8,8 @@ enum Direction {
   Top = 'top',
   Bottom = 'bottom',
   Left = 'left',
-  Right = 'right'
-};
+  Right = 'right',
+}
 
 const DirectionPair = new Map<Direction, Direction>([
   [Direction.Top, Direction.Bottom],
@@ -54,7 +54,7 @@ const setVttLineAlign = (cueContainer: SubtitleLabel, { lineAlign }: VTTProperti
  * https://w3.org/TR/webvtt1/#webvtt-cue-line
  */
 const setVttLine = (cueContainer: SubtitleLabel, vtt: VTTProperties, direction: Direction) => {
-  if (vtt.line != 'auto') {
+  if (vtt.line !== 'auto') {
     if (!vtt.snapToLines) {
       cueContainer.getDomElement().css(direction, vtt.line as string);
       cueContainer.getDomElement().css(DirectionPair.get(direction), 'unset');

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -1,5 +1,6 @@
 import { SubtitleRegionContainer, SubtitleLabel } from './components/subtitleoverlay';
 import { VTTProperties, VTTRegionProperties } from 'bitmovin-player/types/subtitles/vtt/API';
+import { DOM } from './dom';
 
 // Our default height of a line
 const lineHeight = 28;
@@ -21,17 +22,17 @@ const DirectionPair = new Map<Direction, Direction>([
  * Sets the default standardized styles for the Cue Box
  * https://w3.org/TR/webvtt1/#applying-css-properties
  */
-const setDefaultVttStyles = (cueContainer: SubtitleLabel) => {
-  if (cueContainer.vtt.region) {
-    cueContainer.getDomElement().css('position', 'relative');
-    cueContainer.getDomElement().css('unicode-bidi', 'plaintext');
+const setDefaultVttStyles = (cueContainerDom: DOM, vtt: VTTProperties) => {
+  if (vtt.region) {
+    cueContainerDom.css('position', 'relative');
+    cueContainerDom.css('unicode-bidi', 'plaintext');
   } else {
-    cueContainer.getDomElement().css('position', 'absolute');
-    cueContainer.getDomElement().css('overflow-wrap', 'break-word');
-    cueContainer.getDomElement().css('overflow', 'hidden');
-    cueContainer.getDomElement().css('display', 'inline-flex');
-    cueContainer.getDomElement().css('flex-flow', 'column');
-    cueContainer.getDomElement().css('justify-content', 'flex-end');
+    cueContainerDom.css('position', 'absolute');
+    cueContainerDom.css('overflow-wrap', 'break-word');
+    cueContainerDom.css('overflow', 'hidden');
+    cueContainerDom.css('display', 'inline-flex');
+    cueContainerDom.css('flex-flow', 'column');
+    cueContainerDom.css('justify-content', 'flex-end');
   }
 };
 
@@ -39,13 +40,13 @@ const setDefaultVttStyles = (cueContainer: SubtitleLabel) => {
  * Align the Cue Box's line
  * https://w3.org/TR/webvtt1/#webvtt-cue-line-alignment
  */
-const setVttLineAlign = (cueContainer: SubtitleLabel, { lineAlign }: VTTProperties, direction: Direction) => {
+const setVttLineAlign = (cueContainerDom: DOM, { lineAlign }: VTTProperties, direction: Direction) => {
   switch (lineAlign) {
     case 'center':
-      cueContainer.getDomElement().css(`margin-${direction}`, `${-lineHeight / 2}px`);
+      cueContainerDom.css(`margin-${direction}`, `${-lineHeight / 2}px`);
       break;
     case 'end':
-      cueContainer.getDomElement().css(`margin-${direction}`, `${-lineHeight}px`);
+      cueContainerDom.css(`margin-${direction}`, `${-lineHeight}px`);
   }
 };
 
@@ -53,23 +54,20 @@ const setVttLineAlign = (cueContainer: SubtitleLabel, { lineAlign }: VTTProperti
  * Defines the line positioning of the Cue Box
  * https://w3.org/TR/webvtt1/#webvtt-cue-line
  */
-const setVttLine = (cueContainer: SubtitleLabel, vtt: VTTProperties, direction: Direction) => {
+const setVttLine = (cueContainerDom: DOM, vtt: VTTProperties, direction: Direction) => {
   if (vtt.line !== 'auto') {
     if (!vtt.snapToLines) {
-      cueContainer.getDomElement().css(direction, vtt.line as string);
-      cueContainer.getDomElement().css(DirectionPair.get(direction), 'unset');
-
-      setVttLineAlign(cueContainer, vtt, direction);
+      cueContainerDom.css(direction, vtt.line as string);
+      cueContainerDom.css(DirectionPair.get(direction), 'unset');
+      setVttLineAlign(cueContainerDom, vtt, direction);
     } else if (vtt.snapToLines && vtt.line > 0) {
-      cueContainer.getDomElement().css(direction, `${vtt.line as number * lineHeight}px`);
-      cueContainer.getDomElement().css(DirectionPair.get(direction), 'unset');
-
-      setVttLineAlign(cueContainer, vtt, direction);
+      cueContainerDom.css(direction, `${vtt.line as number * lineHeight}px`);
+      cueContainerDom.css(DirectionPair.get(direction), 'unset');
+      setVttLineAlign(cueContainerDom, vtt, direction);
     } else if (vtt.snapToLines && vtt.line < 0) {
-      cueContainer.getDomElement().css(DirectionPair.get(direction), `${vtt.line as number * -lineHeight}px`);
-      cueContainer.getDomElement().css(direction, 'unset');
-
-      setVttLineAlign(cueContainer, vtt, DirectionPair.get(direction));
+      cueContainerDom.css(DirectionPair.get(direction), `${vtt.line as number * -lineHeight}px`);
+      cueContainerDom.css(direction, 'unset');
+      setVttLineAlign(cueContainerDom, vtt, DirectionPair.get(direction));
     }
   }
 };
@@ -78,20 +76,20 @@ const setVttLine = (cueContainer: SubtitleLabel, vtt: VTTProperties, direction: 
  * Defines the writing direction of the Cue Box
  * https://w3.org/TR/webvtt1/#webvtt-cue-writing-direction
  */
-const setVttWritingDirection = (cueContainer: SubtitleLabel, vtt: VTTProperties) => {
+const setVttWritingDirection = (cueContainerDom: DOM, vtt: VTTProperties) => {
   if (vtt.vertical === '') {
-    cueContainer.getDomElement().css('writing-mode', 'horizontal-tb');
-    setVttLine(cueContainer, vtt, Direction.Top);
+    cueContainerDom.css('writing-mode', 'horizontal-tb');
+    setVttLine(cueContainerDom, vtt, Direction.Top);
   } else if (vtt.vertical === 'lr') {
-    cueContainer.getDomElement().css('writing-mode', 'vertical-lr');
-    cueContainer.getDomElement().css('left', 'unset');
-    cueContainer.getDomElement().css('right', '0');
-    setVttLine(cueContainer, vtt, Direction.Right);
+    cueContainerDom.css('writing-mode', 'vertical-lr');
+    cueContainerDom.css('left', 'unset');
+    cueContainerDom.css('right', '0');
+    setVttLine(cueContainerDom, vtt, Direction.Right);
   } else if (vtt.vertical === 'rl') {
-    cueContainer.getDomElement().css('writing-mode', 'vertical-rl');
-    cueContainer.getDomElement().css('left', '0');
-    cueContainer.getDomElement().css('right', 'unset');
-    setVttLine(cueContainer, vtt, Direction.Left);
+    cueContainerDom.css('writing-mode', 'vertical-rl');
+    cueContainerDom.css('left', '0');
+    cueContainerDom.css('right', 'unset');
+    setVttLine(cueContainerDom, vtt, Direction.Left);
   }
 };
 
@@ -99,31 +97,33 @@ const setVttWritingDirection = (cueContainer: SubtitleLabel, vtt: VTTProperties)
  * Defines the Cue position alignment
  * https://w3.org/TR/webvtt1/#webvtt-cue-position-alignment
  */
-const setVttPositionAlign = (cueContainer: SubtitleLabel, vtt: VTTProperties, direction: Direction) => {
+const setVttPositionAlign = (cueContainerDom: DOM, vtt: VTTProperties, direction: Direction) => {
   switch (vtt.positionAlign) {
     case 'line-left':
-      cueContainer.getDomElement().css(direction, `${vtt.position}%`);
-      cueContainer.getDomElement().css(DirectionPair.get(direction), 'auto');
+      cueContainerDom.css(direction, `${vtt.position}%`);
+      cueContainerDom.css(DirectionPair.get(direction), 'auto');
       break;
     case 'center':
-      cueContainer.getDomElement().css(direction, `${vtt.position as number - (vtt.size || 100)}%`);
-      cueContainer.getDomElement().css(DirectionPair.get(direction), 'auto');
+      cueContainerDom.css(direction, `${vtt.position as number - (vtt.size || 100)}%`);
+      cueContainerDom.css(DirectionPair.get(direction), 'auto');
       break;
     case 'line-right':
-      cueContainer.getDomElement().css(direction, 'auto');
-      cueContainer.getDomElement().css(DirectionPair.get(direction), `${vtt.position}%`);
+      cueContainerDom.css(direction, 'auto');
+      cueContainerDom.css(DirectionPair.get(direction), `${vtt.position}%`);
       break;
     default:
-      cueContainer.getDomElement().css(direction, `${vtt.position}%`);
-      cueContainer.getDomElement().css(DirectionPair.get(direction), 'auto');
+      cueContainerDom.css(direction, `${vtt.position}%`);
+      cueContainerDom.css(DirectionPair.get(direction), 'auto');
   }
 };
 
 export namespace VttUtils {
-  export const setVttCueBoxStyles = (cueContainer: SubtitleLabel, vtt: VTTProperties) => {
-    setDefaultVttStyles(cueContainer);
+  export const setVttCueBoxStyles = (cueContainer: SubtitleLabel) => {
+    const vtt = cueContainer.vtt;
+    const cueContainerDom = cueContainer.getDomElement();
 
-    setVttWritingDirection(cueContainer, vtt);
+    setDefaultVttStyles(cueContainerDom, vtt);
+    setVttWritingDirection(cueContainerDom, vtt);
 
     // https://w3.org/TR/webvtt1/#webvtt-cue-text-alignment
     const textAlign = vtt.align === 'middle' ? 'center' : vtt.align;
@@ -139,10 +139,10 @@ export namespace VttUtils {
     const containerSize = vtt.size;
     if (vtt.vertical === '') {
       cueContainer.getDomElement().css('width', `${containerSize}%`);
-      setVttPositionAlign(cueContainer, vtt, Direction.Left);
+      setVttPositionAlign(cueContainerDom, vtt, Direction.Left);
     } else {
       cueContainer.getDomElement().css('height', `${containerSize}%`);
-      setVttPositionAlign(cueContainer, vtt, Direction.Top);
+      setVttPositionAlign(cueContainerDom, vtt, Direction.Top);
     }
   };
 
@@ -150,15 +150,16 @@ export namespace VttUtils {
    *  https://www.speechpad.com/captions/webvtt#toc_16
    */
   export const setVttRegionStyles = (regionContainer: SubtitleRegionContainer, region: VTTRegionProperties, overlaySize: { width: number, height: number }) => {
+    const regionContainerDom = regionContainer.getDomElement();
     const regionPositionX = overlaySize.width * region.viewportAnchorX / 100 - ((overlaySize.width * region.width / 100) * region.regionAnchorX / 100);
     const regionPositionY = overlaySize.height * region.viewportAnchorY / 100 - ((region.lines * lineHeight) * region.regionAnchorY / 100);
-    regionContainer.getDomElement().css('position', 'absolute');
-    regionContainer.getDomElement().css('overflow', 'hidden');
-    regionContainer.getDomElement().css('width', `${region && region.width ? region.width : 100}%`);
-    regionContainer.getDomElement().css('left', `${regionPositionX}px`);
-    regionContainer.getDomElement().css('right', 'unset');
-    regionContainer.getDomElement().css('top', `${regionPositionY}px`);
-    regionContainer.getDomElement().css('bottom', 'unset');
-    regionContainer.getDomElement().css('height', `${region && region.lines ? region.lines * lineHeight : 3 * lineHeight}px`);
+    regionContainerDom.css('position', 'absolute');
+    regionContainerDom.css('overflow', 'hidden');
+    regionContainerDom.css('width', `${region && region.width ? region.width : 100}%`);
+    regionContainerDom.css('left', `${regionPositionX}px`);
+    regionContainerDom.css('right', 'unset');
+    regionContainerDom.css('top', `${regionPositionY}px`);
+    regionContainerDom.css('bottom', 'unset');
+    regionContainerDom.css('height', `${region && region.lines ? region.lines * lineHeight : 3 * lineHeight}px`);
   };
 }

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -1,4 +1,4 @@
-import { SubtitleRegionContainer, SubtitleLabel } from './subtitleoverlay';
+import { SubtitleRegionContainer, SubtitleLabel } from './components/subtitleoverlay';
 import { VTTProperties, VTTRegionProperties } from 'bitmovin-player/types/subtitles/vtt/API';
 
 // Our default height of a line
@@ -39,7 +39,7 @@ const setDefaultVttStyles = (cueContainer: SubtitleLabel) => {
  * Align the Cue Box's line
  * https://w3.org/TR/webvtt1/#webvtt-cue-line-alignment
  */
-const setVttLineAlign = (cueContainer: SubtitleLabel, {lineAlign}: VTTProperties, direction: Direction) => {
+const setVttLineAlign = (cueContainer: SubtitleLabel, { lineAlign }: VTTProperties, direction: Direction) => {
   switch (lineAlign) {
     case 'center':
       cueContainer.getDomElement().css(`margin-${direction}`, `${-lineHeight / 2}px`);
@@ -50,7 +50,7 @@ const setVttLineAlign = (cueContainer: SubtitleLabel, {lineAlign}: VTTProperties
 };
 
 /**
- * Defines the positioning of the Cue Box
+ * Defines the line positioning of the Cue Box
  * https://w3.org/TR/webvtt1/#webvtt-cue-line
  */
 const setVttLine = (cueContainer: SubtitleLabel, vtt: VTTProperties, direction: Direction) => {
@@ -58,17 +58,17 @@ const setVttLine = (cueContainer: SubtitleLabel, vtt: VTTProperties, direction: 
     if (!vtt.snapToLines) {
       cueContainer.getDomElement().css(direction, vtt.line as string);
       cueContainer.getDomElement().css(DirectionPair.get(direction), 'unset');
-  
+
       setVttLineAlign(cueContainer, vtt, direction);
     } else if (vtt.snapToLines && vtt.line > 0) {
       cueContainer.getDomElement().css(direction, `${vtt.line as number * lineHeight}px`);
       cueContainer.getDomElement().css(DirectionPair.get(direction), 'unset');
-  
+
       setVttLineAlign(cueContainer, vtt, direction);
     } else if (vtt.snapToLines && vtt.line < 0) {
       cueContainer.getDomElement().css(DirectionPair.get(direction), `${vtt.line as number * -lineHeight}px`);
       cueContainer.getDomElement().css(direction, 'unset');
-  
+
       setVttLineAlign(cueContainer, vtt, DirectionPair.get(direction));
     }
   }
@@ -81,8 +81,6 @@ const setVttLine = (cueContainer: SubtitleLabel, vtt: VTTProperties, direction: 
 const setVttWritingDirection = (cueContainer: SubtitleLabel, vtt: VTTProperties) => {
   if (vtt.vertical === '') {
     cueContainer.getDomElement().css('writing-mode', 'horizontal-tb');
-    cueContainer.getDomElement().css('left', '0');
-    cueContainer.getDomElement().css('bottom', '0');
     setVttLine(cueContainer, vtt, Direction.Top);
   } else if (vtt.vertical === 'lr') {
     cueContainer.getDomElement().css('writing-mode', 'vertical-lr');
@@ -121,37 +119,46 @@ const setVttPositionAlign = (cueContainer: SubtitleLabel, vtt: VTTProperties, di
   }
 };
 
-export const setVttCueBoxStyles = (cueContainer: SubtitleLabel, vtt: VTTProperties) => {
-  console.warn(vtt);
-  setDefaultVttStyles(cueContainer);
+export namespace VttUtils {
+  export const setVttCueBoxStyles = (cueContainer: SubtitleLabel, vtt: VTTProperties) => {
+    setDefaultVttStyles(cueContainer);
 
-  setVttWritingDirection(cueContainer, vtt);
+    setVttWritingDirection(cueContainer, vtt);
 
-  // https://w3.org/TR/webvtt1/#webvtt-cue-text-alignment
-  const textAlign = vtt.align === 'middle' ? 'center' : vtt.align;
-  cueContainer.getDomElement().css('text-align', textAlign);
+    // https://w3.org/TR/webvtt1/#webvtt-cue-text-alignment
+    const textAlign = vtt.align === 'middle' ? 'center' : vtt.align;
+    cueContainer.getDomElement().css('text-align', textAlign);
 
-  const containerSize = vtt.size;
-  // https://w3.org/TR/webvtt1/#webvtt-cue-size
-  if (vtt.vertical === '') {
-    cueContainer.getDomElement().css('width', `${containerSize}%`);
-    setVttPositionAlign(cueContainer, vtt, Direction.Left);
-  } else {
-    cueContainer.getDomElement().css('height', `${containerSize}%`);
-    setVttPositionAlign(cueContainer, vtt, Direction.Top);
-  }
-};
+    // https://www.w3.org/TR/webvtt1/#webvtt-cue-position
+    if (vtt.position === 'auto') {
+      cueContainer.getDomElement().css('left', '0');
+      cueContainer.getDomElement().css('bottom', '0');
+    }
 
-// https://www.w3.org/TR/webvtt1/#regions
-export const setVttRegionStyles = (regionContainer: SubtitleRegionContainer, region: VTTRegionProperties, overlaySize: {width: number, height: number}) => {
-  const regionPositionX = overlaySize.width * region.viewportAnchorX / 100 - ((overlaySize.width * region.width / 100) * region.regionAnchorX / 100);
-  const regionPositionY = overlaySize.height * region.viewportAnchorY / 100 - ((region.lines * lineHeight) * region.regionAnchorY / 100);
-  regionContainer.getDomElement().css('position', 'absolute');
-  regionContainer.getDomElement().css('overflow', 'hidden');
-  regionContainer.getDomElement().css('width', `${region && region.width ? region.width : 100}%`);
-  regionContainer.getDomElement().css('left', `${regionPositionX}px`);
-  regionContainer.getDomElement().css('right', 'unset');
-  regionContainer.getDomElement().css('top', `${regionPositionY}px`);
-  regionContainer.getDomElement().css('bottom', 'unset');
-  regionContainer.getDomElement().css('height', `${region && region.lines ? region.lines * lineHeight : 3 * lineHeight}px`);
-};
+    // https://w3.org/TR/webvtt1/#webvtt-cue-size
+    const containerSize = vtt.size;
+    if (vtt.vertical === '') {
+      cueContainer.getDomElement().css('width', `${containerSize}%`);
+      setVttPositionAlign(cueContainer, vtt, Direction.Left);
+    } else {
+      cueContainer.getDomElement().css('height', `${containerSize}%`);
+      setVttPositionAlign(cueContainer, vtt, Direction.Top);
+    }
+  };
+
+  /** https://www.w3.org/TR/webvtt1/#regions
+   *  https://www.speechpad.com/captions/webvtt#toc_16
+   */
+  export const setVttRegionStyles = (regionContainer: SubtitleRegionContainer, region: VTTRegionProperties, overlaySize: { width: number, height: number }) => {
+    const regionPositionX = overlaySize.width * region.viewportAnchorX / 100 - ((overlaySize.width * region.width / 100) * region.regionAnchorX / 100);
+    const regionPositionY = overlaySize.height * region.viewportAnchorY / 100 - ((region.lines * lineHeight) * region.regionAnchorY / 100);
+    regionContainer.getDomElement().css('position', 'absolute');
+    regionContainer.getDomElement().css('overflow', 'hidden');
+    regionContainer.getDomElement().css('width', `${region && region.width ? region.width : 100}%`);
+    regionContainer.getDomElement().css('left', `${regionPositionX}px`);
+    regionContainer.getDomElement().css('right', 'unset');
+    regionContainer.getDomElement().css('top', `${regionPositionY}px`);
+    regionContainer.getDomElement().css('bottom', 'unset');
+    regionContainer.getDomElement().css('height', `${region && region.lines ? region.lines * lineHeight : 3 * lineHeight}px`);
+  };
+}

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -99,7 +99,7 @@ const setVttPositionAlign = (cueContainerDom: DOM, vtt: VTTProperties, direction
 
     if (vtt.vertical === '') {
       cueContainerDom.css(Direction.Bottom, '0');
-    } 
+    }
   } else {
     switch (vtt.positionAlign) {
       case 'line-left':


### PR DESCRIPTION
Added styling of new VTT properties and regions.

VTT subtitles now have supported styling that comes from the `.vtt` file.
Reference:
 - https://www.w3.org/TR/webvtt1/
 - https://www.speechpad.com/captions/webvtt