### PR TITLE
fix selection of audiotrack in trackutils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - UI hiding when actively using seek or volume slider
 - Empty background boxes with TTML subtitles on Chromecast
-- Default audio track not highlighted in AudioTrackListBox
+- Default selection not highlighted in AudioTrackListBox and SubtitleListBox
 
 ## [3.9.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - UI hiding when actively using seek or volume slider
 - Empty background boxes with TTML subtitles on Chromecast
+- Default audio track not highlighted in AudioTrackListBox
 
 ## [3.9.2]
 

--- a/src/ts/audiotrackutils.ts
+++ b/src/ts/audiotrackutils.ts
@@ -22,7 +22,6 @@ export class AudioTrackSwitchHandler {
     this.bindSelectionEvent();
     this.bindPlayerEvents();
     this.refreshAudioTracks();
-    this.selectCurrentAudioTrack();
   }
 
   private bindSelectionEvent(): void {
@@ -74,5 +73,6 @@ export class AudioTrackSwitchHandler {
     };
 
     this.listElement.synchronizeItems(audioTracks.map(audioTrackToListItem));
+    this.selectCurrentAudioTrack();
   };
 }

--- a/src/ts/subtitleutils.ts
+++ b/src/ts/subtitleutils.ts
@@ -24,7 +24,6 @@ export class SubtitleSwitchHandler {
     this.bindSelectionEvent();
     this.bindPlayerEvents();
     this.refreshSubtitles();
-    this.selectCurrentSubtitle();
   }
 
   private bindSelectionEvent(): void {
@@ -96,5 +95,6 @@ export class SubtitleSwitchHandler {
     this.listElement.synchronizeItems([
       offListItem, ...subtitles.map(subtitleToListItem),
     ]);
+    this.selectCurrentSubtitle();
   };
 }


### PR DESCRIPTION
Moved `selectCurrentAudioTrack()` call to the end of `refreshAudioTracks`, so the selection gets updated as well
Applied same fix to the `subtitleutils`