### PR TITLE
Clear selected CC/Subtitles on source unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - UI hiding when actively using seek or volume slider
 - Empty background boxes with TTML subtitles on Chromecast
+- Clear subtitles list when source is unloaded
 
 ## [3.9.2]
 

--- a/spec/subtitleutils.spec.ts
+++ b/spec/subtitleutils.spec.ts
@@ -15,6 +15,7 @@ let ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.fn
   getItems: jest.fn().mockReturnValue([]),
   synchronizeItems: jest.fn(),
   selectItem: jest.fn(),
+  clearItems: jest.fn(),
 }));
 
 let listSelectorMock: ListSelector<ListSelectorConfig>;
@@ -138,6 +139,14 @@ describe('SubtitleUtils', () => {
       );
       playerMock.eventEmitter.fireSubtitleDisabled();
       expect(listSelectorMock.selectItem).toHaveBeenCalledWith('null');
+    });
+  });
+
+  describe('clears subtitle list', () => {
+    it('on sourceUnloaded event', () => {
+      playerMock.eventEmitter.fireSourceUnloadedEvent();
+
+      expect(listSelectorMock.clearItems).toHaveBeenCalled();
     });
   });
 

--- a/src/ts/subtitleutils.ts
+++ b/src/ts/subtitleutils.ts
@@ -47,7 +47,7 @@ export class SubtitleSwitchHandler {
     this.player.on(this.player.exports.PlayerEvent.SubtitleDisabled, this.selectCurrentSubtitle);
     this.player.on(this.player.exports.PlayerEvent.SubtitleRemoved, this.removeSubtitle);
     // Update subtitles when source goes away
-    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, this.refreshSubtitles);
+    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, this.clearSubtitles);
     // Update subtitles when the period within a source changes
     this.player.on(this.player.exports.PlayerEvent.PeriodSwitched, this.refreshSubtitles);
     this.uimanager.getConfig().events.onUpdated.subscribe(this.refreshSubtitles);
@@ -76,6 +76,10 @@ export class SubtitleSwitchHandler {
     let currentSubtitle = this.player.subtitles.list().filter((subtitle) => subtitle.enabled).pop();
     this.listElement.selectItem(currentSubtitle ? currentSubtitle.id : SubtitleSwitchHandler.SUBTITLES_OFF_KEY);
   };
+
+  private clearSubtitles = () => {
+    this.listElement.clearItems();
+  }
 
   private refreshSubtitles = () => {
     if (!this.player.subtitles) {


### PR DESCRIPTION
If we playback an HLS stream twice. Notice that on the second playback, CC is not rendered although it shows as enabled in the Bitmovin UI.

The current implementation of `refreshSubtitles` that is called on `SourceUnloaded` does clear/sync `listElements`. But it does not clear `selectedItem`. Doing load or unload will constantly persist this `selectedItem`, and if we have the same subtitle `identifier` between sources, it will be rendered as `selected` in the UI. 

We are now adding `clearSubtitles()` which is being run on `PlayerEvent.SourceUnloaded`, and it will clear `listElements` and `selectedItem`.