### PR TITLE
Fix TTML region class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [development]
 
+### Added
+- TTML `displayAlign = after` styling case
+
 ### Fixed
-- TTML subtitles region alignment
+- TTML subtitles region alignmeng
 
 ## [3.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Fixed
+- TTML subtitles region alignment
+
 ## [3.11.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - TTML `displayAlign = after` styling case
 
 ### Fixed
-- TTML subtitles region alignmeng
+- TTML subtitles region alignment
 
 ## [3.11.0]
 

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -25,6 +25,12 @@
       left: 3em;
       right: 3em;
     }
+
+    &.#{$prefix}-subtitle-position-bottom>div {
+      position: absolute;
+      bottom: 0;
+      width: 100%;
+    }
   }
 
   .#{$prefix}-ui-subtitle-label {

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -26,10 +26,12 @@
       right: 3em;
     }
 
-    &.#{$prefix}-subtitle-position-bottom>div {
-      position: absolute;
-      bottom: 0;
-      width: 100%;
+    &.#{$prefix}-subtitle-position-bottom {
+      & div {
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+      }
     }
   }
 

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -13,25 +13,23 @@
   position: absolute;
   right: 0;
   text-align: center;
-  transition: bottom $animation-duration-short ease-out;
   top: 0;
+  transition: bottom $animation-duration-short ease-out;
 
   .#{$prefix}-subtitle-region-container {
     position: absolute;
 
     &.#{$prefix}-subtitle-position-default {
       bottom: 2em;
-      top: initial;
       left: 3em;
       right: 3em;
+      top: initial;
     }
 
-    &.#{$prefix}-subtitle-position-bottom {
-      & div {
-        position: absolute;
-        bottom: 0;
-        width: 100%;
-      }
+    &.#{$prefix}-subtitle-position-bottom > div {
+      bottom: 0;
+      position: absolute;
+      width: 100%;
     }
   }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -551,7 +551,7 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClass: 'subtitle-region-container'
+      cssClass: 'subtitle-region-container',
     }, this.config);
   }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -485,7 +485,7 @@ export class SubtitleRegionContainerManager {
 
     if (!this.subtitleRegionContainers[regionContainerId]) {
       const regionContainer = new SubtitleRegionContainer({
-        cssClasses,
+        cssClasses: [...cssClasses, 'subtitle-region-container'],
       });
 
       this.subtitleRegionContainers[regionContainerId] = regionContainer;
@@ -549,10 +549,6 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
 
   constructor(config: ContainerConfig = {}) {
     super(config);
-
-    this.config = this.mergeConfig(config, {
-      cssClasses: ['subtitle-region-container'],
-    }, this.config);
   }
 
   addLabel(labelToAdd: SubtitleLabel, overlaySize?: { width: number, height: number }) {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -485,7 +485,7 @@ export class SubtitleRegionContainerManager {
 
     if (!this.subtitleRegionContainers[regionContainerId]) {
       const regionContainer = new SubtitleRegionContainer({
-        cssClasses: [...cssClasses, 'subtitle-region-container'],
+        cssClasses,
       });
 
       this.subtitleRegionContainers[regionContainerId] = regionContainer;
@@ -549,6 +549,10 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
 
   constructor(config: ContainerConfig = {}) {
     super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClass: 'subtitle-region-container'
+    }, this.config);
   }
 
   addLabel(labelToAdd: SubtitleLabel, overlaySize?: { width: number, height: number }) {


### PR DESCRIPTION
Issue: TTML region subtitles were missing region class names. TTML `displayAlign = after` case styling was missing as well.

Solution: Fixed CSS configuration of the container adding the class name on subtitle region.
Added CSS case for TTML `displayAlign = after`