### PR TITLE
fix partial cues when controls are visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Fixed
+- Subtitles partially hidden by player controls
+
 ## [3.12.0]
 
 ### Added

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -37,6 +37,7 @@
     @include text-border($subtitle-text-border-color);
 
     color: $subtitle-text-color;
+    height: fit-content;
 
     // Break labels into separate lines
     // sass-lint:disable force-pseudo-nesting


### PR DESCRIPTION
Fixes the height of subtitle labels.
Mainly affects multi-line subtitles that were "cut off" by the player controls:
The subtitles get offset upwards when the player controls are shown, but if the height of the subtitles is set to auto, this causes multi-line subtitles to get "cut off" (see screenshot). Setting the height of the subtitle label fixes that.
![image](https://user-images.githubusercontent.com/8625026/79330362-ab1dfa80-7f19-11ea-8d97-87e858bc92b9.png)
