### PR TITLE
Make seekbar snapping range configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+### Added
+- Seekbar snapping range is now configurable
+
 ## [v3.13.0]
 
 ### Fixed

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -249,6 +249,7 @@
 //      {title: 'Recommendation 11', url: 'http://bitmovin.com', thumbnail: 'http://placehold.it/300x300', duration: 435},
 //      {title: 'Recommendation 12: Ain\'t no better video than this', url: 'http://bitmovin.com', thumbnail: 'http://placehold.it/300x300', duration: 34}
 //    ],
+//      seekbarSnappingRange: 0,
   };
 
   var player;

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -39,6 +39,11 @@ export interface SeekBarConfig extends ComponentConfig {
    * Used for seekBar control increments and decrements
    */
   keyStepIncrements?: { leftRight: number, upDown: number };
+
+  /**
+   * Used for seekBar marker snapping range percentage
+   */
+  snappingRange?: number;
 }
 
 /**
@@ -133,6 +138,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       keyStepIncrements,
       ariaLabel: i18n.getLocalizer('seekBar'),
       tabIndex: 0,
+      snappingRange: 1,
     }, this.config);
 
     this.label = this.config.label;
@@ -389,6 +395,11 @@ export class SeekBar extends Component<SeekBarConfig> {
     uimanager.getConfig().events.onUpdated.subscribe(() => {
       playbackPositionHandler();
     });
+
+    // Set the snappingRange if set in the uimanager config
+    if (typeof uimanager.getConfig().seekbarSnappingRange === 'number') {
+      this.config.snappingRange = uimanager.getConfig().seekbarSnappingRange;
+    }
 
     // Initialize seekbar
     playbackPositionHandler(); // Set the playback position
@@ -753,7 +764,7 @@ export class SeekBar extends Component<SeekBarConfig> {
   }
 
   protected getMarkerAtPosition(percentage: number): SeekBarMarker | null {
-    const snappingRange = 1;
+    const snappingRange = this.config.snappingRange;
 
     if (this.timelineMarkers.length > 0) {
       for (let marker of this.timelineMarkers) {

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -63,6 +63,11 @@ export interface UIConfig {
    */
   playbackSpeedSelectionEnabled?: boolean;
   /**
+   * Specifies the seekbar snapping range in percentage
+   * Default: 1
+   */
+  seekbarSnappingRange?: number;
+  /**
    * Provide customized errorMessages
    * For an example have a look at {@link ErrorMessageOverlayConfig.messages}
    */


### PR DESCRIPTION
I would like to be able to control the snapping range, rather than the preset 1%. In my use case, I would like to disable it by setting it to 0.