### PR TITLE
Change default keyStepIncrements to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Seekbar snapping range is now configurable
 
+### Changed
+- default key increment value for seekbar/volumeslidebar to 5
+
 ## [v3.13.0]
 
 ### Fixed

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -127,7 +127,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     super(config);
 
     const keyStepIncrements = this.config.keyStepIncrements || {
-      leftRight: 1,
+      leftRight: 5,
       upDown: 5,
     };
 


### PR DESCRIPTION
Changed the default keyStepIncrements to 5
  - When the keyStepIncrements:leftRight value was 1, the volume slidebar couldn't be increased due to a floating point error (over 28). 
  - Setting the value to >1 solved the issue. Although the value can be customized on the app UI, I'd like to suggest to change the default value.