### PR TITLE
Fix unreachable link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v3.14.0]
+## [3.14.0]
 ### Added
 - Seekbar snapping range is now configurable
 
-## [v3.13.0]
+## [3.13.0]
 
 ### Fixed
 - Subtitles partially hidden by player controls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+### Fixed
+- Dead documentation link in README.md
+
 ## [3.14.0]
 ### Added
 - Seekbar snapping range is now configurable

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ There are three approaches to customize the UI:
 
 ### Styling the built-in UI
 
-When using the built-in UI, you can style it to your linking with CSS by overwriting our default styles, as documented in our [CSS Class Reference](https://bitmovin.com/player-documentation/css-class-reference/).
+When using the built-in UI, you can style it to your linking with CSS by overwriting our default styles, as documented in our [CSS Class Reference](https://bitmovin.com/docs/player/articles/player-ui-css-class-reference/).
 
 ### Replacing the built-in UI
 


### PR DESCRIPTION
### Description

We had a link in our `README.md` which was pointing to the old documentation.

### Fix

- Replaced outdated with up to date link.
- Fixed wrong markdown links in CHANGELOG