### PR TITLE
Respect isViewModeAvailable in FullscreenToggleButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 ### Fixed
 - Dead documentation link in README.md
+- `FullscreenToggleButton` is no longer visible if `ViewMode.Fullscreen` is not available
 
 ## [3.14.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 ### Fixed
 - Dead documentation link in README.md
-- `FullscreenToggleButton` is no longer visible if `ViewMode.Fullscreen` is not available
+- `FullscreenToggleButton` being visible although `ViewMode.Fullscreen` is not available
 
 ## [3.14.0]
 ### Added

--- a/spec/components/fullscreentogglebutton.spec.ts
+++ b/spec/components/fullscreentogglebutton.spec.ts
@@ -1,0 +1,42 @@
+import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
+import { UIInstanceManager } from '../../src/ts/uimanager';
+import { FullscreenToggleButton } from '../../src/ts/components/fullscreentogglebutton';
+
+let playerMock: TestingPlayerAPI;
+let uiInstanceManagerMock: UIInstanceManager;
+
+let fullscreenToggleButton: FullscreenToggleButton;
+
+describe('FullscreenToggleButton', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+
+    fullscreenToggleButton = new FullscreenToggleButton();
+    fullscreenToggleButton.initialize();
+
+    // Setup DOM Mock
+    const mockDomElement = MockHelper.generateDOMMock();
+    jest.spyOn(fullscreenToggleButton, 'getDomElement').mockReturnValue(mockDomElement);
+  });
+
+  describe('is visible', () => {
+    it('when fullscreen is available', () => {
+      jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(true);
+
+      fullscreenToggleButton.configure(playerMock, uiInstanceManagerMock);
+
+      expect(fullscreenToggleButton.isHidden()).toBe(false);
+    });
+  });
+
+  describe('is hidden', () => {
+    it('when fullscreen is not available', () => {
+      jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(false);
+
+      fullscreenToggleButton.configure(playerMock, uiInstanceManagerMock);
+
+      expect(fullscreenToggleButton.isHidden()).toBe(true);
+    });
+  });
+});

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -100,6 +100,7 @@ export namespace MockHelper {
         hasEnded: jest.fn(),
         isStalled: jest.fn(),
         isCasting: jest.fn(),
+        isViewModeAvailable: jest.fn(),
 
         // Event faker
         eventEmitter: eventHelper,

--- a/src/ts/components/fullscreentogglebutton.ts
+++ b/src/ts/components/fullscreentogglebutton.ts
@@ -49,7 +49,7 @@ export class FullscreenToggleButton extends ToggleButton<ToggleButtonConfig> {
         }
       } else {
         if (console) {
-          console.log('PIP unavailable');
+          console.log('Fullscreen unavailable');
         }
       }
     });

--- a/src/ts/components/fullscreentogglebutton.ts
+++ b/src/ts/components/fullscreentogglebutton.ts
@@ -41,17 +41,19 @@ export class FullscreenToggleButton extends ToggleButton<ToggleButtonConfig> {
     player.on(player.exports.PlayerEvent.ViewModeChanged, fullscreenStateHandler);
 
     this.onClick.subscribe(() => {
-      if (player.isViewModeAvailable(player.exports.ViewMode.Fullscreen)) {
-        if (player.getViewMode() === player.exports.ViewMode.Fullscreen) {
-          player.setViewMode(player.exports.ViewMode.Inline);
-        } else {
-          player.setViewMode(player.exports.ViewMode.Fullscreen);
-        }
-      } else {
+      if (!player.isViewModeAvailable(player.exports.ViewMode.Fullscreen)) {
         if (console) {
           console.log('Fullscreen unavailable');
         }
+        return;
       }
+
+      const targetViewMode =
+        player.getViewMode() === player.exports.ViewMode.Fullscreen
+          ? player.exports.ViewMode.Inline
+          : player.exports.ViewMode.Fullscreen;
+
+      player.setViewMode(targetViewMode);
     });
 
     // Startup init

--- a/src/ts/components/fullscreentogglebutton.ts
+++ b/src/ts/components/fullscreentogglebutton.ts
@@ -28,17 +28,34 @@ export class FullscreenToggleButton extends ToggleButton<ToggleButtonConfig> {
       }
     };
 
+    let fullscreenAvailableHandler = () => {
+      if (player.isViewModeAvailable(player.exports.ViewMode.Fullscreen)) {
+        this.show();
+      } else {
+        this.hide();
+      }
+    };
+
+    uimanager.getConfig().events.onUpdated.subscribe(fullscreenAvailableHandler);
+
     player.on(player.exports.PlayerEvent.ViewModeChanged, fullscreenStateHandler);
 
     this.onClick.subscribe(() => {
-      if (player.getViewMode() === player.exports.ViewMode.Fullscreen) {
-        player.setViewMode(player.exports.ViewMode.Inline);
+      if (player.isViewModeAvailable(player.exports.ViewMode.Fullscreen)) {
+        if (player.getViewMode() === player.exports.ViewMode.Fullscreen) {
+          player.setViewMode(player.exports.ViewMode.Inline);
+        } else {
+          player.setViewMode(player.exports.ViewMode.Fullscreen);
+        }
       } else {
-        player.setViewMode(player.exports.ViewMode.Fullscreen);
+        if (console) {
+          console.log('PIP unavailable');
+        }
       }
     });
 
     // Startup init
+    fullscreenAvailableHandler();
     fullscreenStateHandler();
   }
 }


### PR DESCRIPTION
## Description
On our mobile SDKs `ViewMode.Fullscreen` is not always available. We have an API to check if fullscreen is available but that was not used in the `FullscreenToggleButton`.

## Fix
Respect the return value of `isViewModeAvailable` for `ViewMode.Fullscreen` and hide / show the button accordingly.