### PR TITLE
React to viewModeAvailabilityChanged event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
+
+### Added
+- Listen to `ViewModeAvailabilityChanged` event and toggle visibility of `FullscreenToggleButton` and `PictureInPictureToggleButton` accordingly
+
 ### Fixed
 - Dead documentation link in README.md
 - `FullscreenToggleButton` being visible although `ViewMode.Fullscreen` is not available
 
 ## [3.14.0]
+
 ### Added
 - Seekbar snapping range is now configurable
 

--- a/spec/components/fullscreentogglebutton.spec.ts
+++ b/spec/components/fullscreentogglebutton.spec.ts
@@ -1,6 +1,7 @@
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 import { UIInstanceManager } from '../../src/ts/uimanager';
 import { FullscreenToggleButton } from '../../src/ts/components/fullscreentogglebutton';
+import { PlayerEvent, ViewMode } from 'bitmovin-player';
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;
@@ -37,6 +38,48 @@ describe('FullscreenToggleButton', () => {
       fullscreenToggleButton.configure(playerMock, uiInstanceManagerMock);
 
       expect(fullscreenToggleButton.isHidden()).toBe(true);
+    });
+  });
+
+  describe('a change of fullscreen availability', () => {
+    beforeEach(() => {
+      // This is needed as the event is not yet part of the PlayerAPI
+      // @ts-ignore
+      playerMock.exports = {
+        PlayerEvent: {
+          ViewModeChanged: 'viewmodechanged',
+          ViewModeAvailabilityChanged: 'viewmodeavailabilitychanged',
+        },
+        ViewMode: {
+          Fullscreen: 'fullscreen',
+        },
+      } as any;
+    });
+
+    describe('when it becomes unavailable', () => {
+      it('hides the button', () => {
+        jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(true);
+
+        fullscreenToggleButton.configure(playerMock, uiInstanceManagerMock);
+
+        jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(false);
+        playerMock.eventEmitter.fireViewModeAvailabilityChangedEvent(ViewMode.Fullscreen, false);
+
+        expect(fullscreenToggleButton.isHidden()).toBe(true);
+      });
+    });
+
+    describe('when it becomes available', () => {
+      it('shows the button', () => {
+        jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(false);
+
+        fullscreenToggleButton.configure(playerMock, uiInstanceManagerMock);
+
+        jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(true);
+        playerMock.eventEmitter.fireViewModeAvailabilityChangedEvent(ViewMode.Fullscreen, true);
+
+        expect(fullscreenToggleButton.isHidden()).toBe(false);
+      });
     });
   });
 });

--- a/spec/components/fullscreentogglebutton.spec.ts
+++ b/spec/components/fullscreentogglebutton.spec.ts
@@ -1,7 +1,7 @@
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 import { UIInstanceManager } from '../../src/ts/uimanager';
 import { FullscreenToggleButton } from '../../src/ts/components/fullscreentogglebutton';
-import { PlayerEvent, ViewMode } from 'bitmovin-player';
+import { ViewMode } from 'bitmovin-player';
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;

--- a/spec/components/pictureinpicturetogglebutton.spec.ts
+++ b/spec/components/pictureinpicturetogglebutton.spec.ts
@@ -1,0 +1,85 @@
+import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
+import { UIInstanceManager } from '../../src/ts/uimanager';
+import { PictureInPictureToggleButton } from '../../src/ts/components/pictureInPicturetogglebutton';
+import { ViewMode } from 'bitmovin-player';
+
+let playerMock: TestingPlayerAPI;
+let uiInstanceManagerMock: UIInstanceManager;
+
+let pictureInPictureToggleButton: PictureInPictureToggleButton;
+
+describe('PictureInPictureToggleButton', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+
+    pictureInPictureToggleButton = new PictureInPictureToggleButton();
+    pictureInPictureToggleButton.initialize();
+
+    // Setup DOM Mock
+    const mockDomElement = MockHelper.generateDOMMock();
+    jest.spyOn(pictureInPictureToggleButton, 'getDomElement').mockReturnValue(mockDomElement);
+  });
+
+  describe('is visible', () => {
+    it('when pictureInPicture is available', () => {
+      jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(true);
+
+      pictureInPictureToggleButton.configure(playerMock, uiInstanceManagerMock);
+
+      expect(pictureInPictureToggleButton.isHidden()).toBe(false);
+    });
+  });
+
+  describe('is hidden', () => {
+    it('when pictureInPicture is not available', () => {
+      jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(false);
+
+      pictureInPictureToggleButton.configure(playerMock, uiInstanceManagerMock);
+
+      expect(pictureInPictureToggleButton.isHidden()).toBe(true);
+    });
+  });
+
+  describe('a change of pictureInPicture availability', () => {
+    beforeEach(() => {
+      // This is needed as the event is not yet part of the PlayerAPI
+      // @ts-ignore
+      playerMock.exports = {
+        PlayerEvent: {
+          ViewModeChanged: 'viewmodechanged',
+          ViewModeAvailabilityChanged: 'viewmodeavailabilitychanged',
+        },
+        ViewMode: {
+          PictureInPicture: 'pictureInPicture',
+        },
+      } as any;
+    });
+
+    describe('when it becomes unavailable', () => {
+      it('hides the button', () => {
+        jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(true);
+
+        pictureInPictureToggleButton.configure(playerMock, uiInstanceManagerMock);
+
+        jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(false);
+        playerMock.eventEmitter.fireViewModeAvailabilityChangedEvent(ViewMode.PictureInPicture, false);
+
+        expect(pictureInPictureToggleButton.isHidden()).toBe(true);
+      });
+    });
+
+    describe('when it becomes available', () => {
+      it('shows the button', () => {
+        jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(false);
+
+        pictureInPictureToggleButton.configure(playerMock, uiInstanceManagerMock);
+
+        jest.spyOn(playerMock, 'isViewModeAvailable').mockReturnValue(true);
+        playerMock.eventEmitter.fireViewModeAvailabilityChangedEvent(ViewMode.PictureInPicture, true);
+
+        expect(pictureInPictureToggleButton.isHidden()).toBe(false);
+      });
+    });
+  });
+});

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -68,6 +68,7 @@ export namespace MockHelper {
           PlayerEvent,
           ViewMode: {
             Fullscreen: 'fullscreen',
+            PictureInPicture: 'pictureinpicture',
           },
         },
         isLive: jest.fn(),

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -18,8 +18,14 @@ import {
   SubtitleTrack,
   TimeChangedEvent,
   TimeShiftEvent,
-  VideoPlaybackQualityChangedEvent
+  VideoPlaybackQualityChangedEvent, ViewMode,
 } from 'bitmovin-player';
+
+// TODO: remove once available in the type definitions of the player
+export interface ViewModeAvailabilityChangedEvent extends PlayerEventBase {
+  viewMode: ViewMode;
+  available: Boolean;
+}
 
 export class PlayerEventEmitter {
   private eventHandlers: { [eventType: string]: PlayerEventCallback[]; } = {};
@@ -347,5 +353,14 @@ export class PlayerEventEmitter {
       timestamp: Date.now(),
       type: PlayerEvent.AudioChanged,
     } as AudioChangedEvent);
+  }
+
+  fireViewModeAvailabilityChangedEvent(viewMode: ViewMode, available: boolean): void {
+    this.fireEvent<ViewModeAvailabilityChangedEvent>({
+      timestamp: Date.now(),
+      viewMode: viewMode,
+      available: available,
+      type: 'viewmodeavailabilitychanged' as any,
+    });
   }
 }

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -18,7 +18,8 @@ import {
   SubtitleTrack,
   TimeChangedEvent,
   TimeShiftEvent,
-  VideoPlaybackQualityChangedEvent, ViewMode,
+  VideoPlaybackQualityChangedEvent,
+  ViewMode,
 } from 'bitmovin-player';
 
 // TODO: remove once available in the type definitions of the player

--- a/src/ts/components/fullscreentogglebutton.ts
+++ b/src/ts/components/fullscreentogglebutton.ts
@@ -1,6 +1,6 @@
 import { ToggleButton, ToggleButtonConfig } from './togglebutton';
 import { UIInstanceManager } from '../uimanager';
-import { PlayerAPI, ViewMode } from 'bitmovin-player';
+import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
 
 /**
@@ -21,7 +21,7 @@ export class FullscreenToggleButton extends ToggleButton<ToggleButtonConfig> {
     super.configure(player, uimanager);
 
     let isFullScreenAvailable = () => {
-      return player.isViewModeAvailable(ViewMode.Fullscreen);
+      return player.isViewModeAvailable(player.exports.ViewMode.Fullscreen);
     };
 
     let fullscreenStateHandler = () => {

--- a/src/ts/components/fullscreentogglebutton.ts
+++ b/src/ts/components/fullscreentogglebutton.ts
@@ -20,15 +20,15 @@ export class FullscreenToggleButton extends ToggleButton<ToggleButtonConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let isFullScreenAvailable = () => {
+    const isFullScreenAvailable = () => {
       return player.isViewModeAvailable(player.exports.ViewMode.Fullscreen);
     };
 
-    let fullscreenStateHandler = () => {
+    const fullscreenStateHandler = () => {
       player.getViewMode() === player.exports.ViewMode.Fullscreen ? this.on() : this.off();
     };
 
-    let fullscreenAvailabilityChangedHandler = () => {
+    const fullscreenAvailabilityChangedHandler = () => {
       isFullScreenAvailable() ? this.show() : this.hide();
     };
 

--- a/src/ts/components/fullscreentogglebutton.ts
+++ b/src/ts/components/fullscreentogglebutton.ts
@@ -1,6 +1,6 @@
-import {ToggleButton, ToggleButtonConfig} from './togglebutton';
-import {UIInstanceManager} from '../uimanager';
-import { PlayerAPI } from 'bitmovin-player';
+import { ToggleButton, ToggleButtonConfig } from './togglebutton';
+import { UIInstanceManager } from '../uimanager';
+import { PlayerAPI, ViewMode } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
 
 /**
@@ -20,28 +20,32 @@ export class FullscreenToggleButton extends ToggleButton<ToggleButtonConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
+    let isFullScreenAvailable = () => {
+      return player.isViewModeAvailable(ViewMode.Fullscreen);
+    };
+
     let fullscreenStateHandler = () => {
-      if (player.getViewMode() === player.exports.ViewMode.Fullscreen) {
-        this.on();
-      } else {
-        this.off();
-      }
+      player.getViewMode() === player.exports.ViewMode.Fullscreen ? this.on() : this.off();
     };
 
-    let fullscreenAvailableHandler = () => {
-      if (player.isViewModeAvailable(player.exports.ViewMode.Fullscreen)) {
-        this.show();
-      } else {
-        this.hide();
-      }
+    let fullscreenAvailabilityChangedHandler = () => {
+      isFullScreenAvailable() ? this.show() : this.hide();
     };
-
-    uimanager.getConfig().events.onUpdated.subscribe(fullscreenAvailableHandler);
 
     player.on(player.exports.PlayerEvent.ViewModeChanged, fullscreenStateHandler);
 
+    // Available only in our native SDKs for now
+    if ((player.exports.PlayerEvent as any).ViewModeAvailabilityChanged) {
+      player.on(
+        (player.exports.PlayerEvent as any).ViewModeAvailabilityChanged,
+        fullscreenAvailabilityChangedHandler,
+      );
+    }
+
+    uimanager.getConfig().events.onUpdated.subscribe(fullscreenAvailabilityChangedHandler);
+
     this.onClick.subscribe(() => {
-      if (!player.isViewModeAvailable(player.exports.ViewMode.Fullscreen)) {
+      if (!isFullScreenAvailable()) {
         if (console) {
           console.log('Fullscreen unavailable');
         }
@@ -57,7 +61,7 @@ export class FullscreenToggleButton extends ToggleButton<ToggleButtonConfig> {
     });
 
     // Startup init
-    fullscreenAvailableHandler();
+    fullscreenAvailabilityChangedHandler();
     fullscreenStateHandler();
   }
 }

--- a/src/ts/components/pictureinpicturetogglebutton.ts
+++ b/src/ts/components/pictureinpicturetogglebutton.ts
@@ -20,15 +20,15 @@ export class PictureInPictureToggleButton extends ToggleButton<ToggleButtonConfi
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let isPictureInPictureAvailable = () => {
+    const isPictureInPictureAvailable = () => {
       return player.isViewModeAvailable(player.exports.ViewMode.PictureInPicture);
     };
 
-    let pictureInPictureStateHandler = () => {
+    const pictureInPictureStateHandler = () => {
       player.getViewMode() === player.exports.ViewMode.PictureInPicture ? this.on() : this.off();
     };
 
-    let pictureInPictureAvailabilityChangedHandler = () => {
+    const pictureInPictureAvailabilityChangedHandler = () => {
       isPictureInPictureAvailable() ? this.show() : this.hide();
     };
 


### PR DESCRIPTION
## Description
In our native SDKs the availability of a `ViewMode` can change after initialization of the player / UI. Therefore we introduced the `ViewModeAvailabilityChanged` event.

## Changes
Listen to the new event and change the visibility accordingly.
To enable backwards compatibility there is a check added if the event is available.