### PR TITLE
Improve title alignment in SmallScreenUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Dead documentation link in README.md
 - `FullscreenToggleButton` being visible although `ViewMode.Fullscreen` is not available
+- Vertical text alignment in the `MetadataLabel` for the `MetadataLabelContent.Title` in the `SmallScreenUI`
 
 ## [3.14.0]
 ### Added

--- a/src/scss/skin-modern/_skin-smallscreen.scss
+++ b/src/scss/skin-modern/_skin-smallscreen.scss
@@ -40,7 +40,8 @@
       display: flex;
 
       .#{$prefix}-ui-label {
-        display: inline;
+        align-items: center;
+        display: inline-flex;
         font-size: 1em;
       }
 


### PR DESCRIPTION
## Description
Currently when using the small-screen-ui, the title is not aligned vertically centred / middle. This is really noticeable on mobile phones where the title is closer to the buttons on the right.

## Fix
As the Title bar is displayed as `flex` we just needed to align it `center` and change the `display` to `inline-flex`

| Before | After |
| -------|------|
| ![Screenshot 2020-07-09 at 16 53 44](https://user-images.githubusercontent.com/6216959/87055827-20415900-c205-11ea-8c1e-645beae0e6ac.png)|![Screenshot 2020-07-09 at 16 53 23](https://user-images.githubusercontent.com/6216959/87055855-27686700-c205-11ea-8501-ebcf1c405867.png)|

