### PR TITLE
add npx build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/js/framework/main.d.ts",
   "scripts": {
     "test": "npx jest",
-    "prepublish": "gulp npm-prepare"
+    "prepublish": "npx gulp npm-prepare"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The build fails because the gulp is not up-to-date.

If we add NPX it installs needed dependencies. 