### PR TITLE
forced a state update if the adBreak requires UI

### DIFF
--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -281,6 +281,13 @@ export class UIManager {
         }
       }
 
+      if (adRequiresUi) {
+        // we dispatch onUpdated event because if there are multiple adBreaks for same position
+        // `Play` and `Playing` events will not be dispatched which will cause `PlaybackButton` state
+        // to be out of sync
+        this.config.events.onUpdated.dispatch(this);
+      }
+
       this.resolveUiVariant({
         isAd: isAd,
         adRequiresUi: adRequiresUi,


### PR DESCRIPTION
**problem:** When there are multiple `adBreaks` for the same position, default-ui and adbreak-ui will be toggled between the ads.
Since there are not `Play` or `Playing` events after the second adBreak start `playbackToggleButton` will not be updated and as a result it'll have `onState: true`.
 
**fix:** manually trigger `onUpdated` event if the `adBreak` requires UI.

**PS:** a better fix would be _"don't switch UI while transitioning between adBreaks for same position"_ unfortunately that is currently not possible considering that we do not have a way to figure out if we do/not have queued ads on the player. Applying that fix would require a change in the public api...