### PR TITLE
Timeline marker image support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Added
+- Support for `images` on `TimelineMarkers`
+
 ## [3.15.0] - 2020-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for `images` on `TimelineMarkers`
 
 ### Changed
-- CSS for positioning of the `TimelineMarkers`
+- Changed `TimelineMarkers` rendering from using no `offset` and `css-border` to `width` and `translateX` properties.
 
 ## [3.15.0] - 2020-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for `images` on `TimelineMarkers`
 
 ### Changed
-- The css for positioning of the `TimelineMarkers`
+- CSS for positioning of the `TimelineMarkers`
 
 ## [3.15.0] - 2020-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for `images` on `TimelineMarkers`
 
+### Changed
+- The way `TimelineMarkers` are rendered.
+
 ## [3.15.0] - 2020-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for `images` on `TimelineMarkers`
 
 ### Changed
-- The way `TimelineMarkers` are rendered.
+- The css for positioning of the `TimelineMarkers`
 
 ## [3.15.0] - 2020-07-23
 

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -94,11 +94,10 @@ $seekbar-height: .3125em;
 
         > .#{$prefix}-seekbar-marker-image {
           position: absolute;
-          top: -1em;
-          height: 1em;
+          height: $seekbar-height * 4;
           left: 50%;
-          -webkit-transform: translateX(-50%);
-          transform: translateX(-50%);
+          -webkit-transform: translate(-50%, calc(-100% - .2em));
+          transform: translate(-50%, calc(-100% - .2em));
         }
       }
     }

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -87,6 +87,8 @@ $seekbar-height: .3125em;
         height: 100%;
         width: $marker-width;
         text-align: center;
+        transition-property: all;
+        transition-duration: 1s;
 
         > .#{$prefix}-seekbar-marker-image {
           position: absolute;

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -94,7 +94,11 @@ $seekbar-height: .3125em;
 
         > .#{$prefix}-seekbar-marker-image {
           position: absolute;
-          top: -$seekbar-height - .375em;
+          top: -1em;
+          height: 1em;
+          left: 50%;
+          -webkit-transform: translateX(-50%);
+          transform: translateX(-50%);
         }
       }
     }

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -87,10 +87,6 @@ $seekbar-height: .3125em;
         height: 100%;
         width: $marker-width;
         text-align: center;
-        -webkit-transition-property: -webkit-transform;
-        -moz-transition-property: -moz-transform;
-        -ms-transition-property: -ms-transform;
-        -o-transition-property: -o-transform;
         transition-property: transform;
         transition-duration: 1s;
         transition-timing-function: linear;
@@ -98,10 +94,6 @@ $seekbar-height: .3125em;
         > .#{$prefix}-seekbar-marker-image {
           position: absolute;
           height: $seekbar-height * 4;
-          -webkit-transform: translate(-50%, calc(-100% - .2em));
-          -moz-transform: translate(-50%, calc(-100% - .2em));
-          -ms-transform: translate(-50%, calc(-100% - .2em));
-          -o-transform: translate(-50%, calc(-100% - .2em));
           transform: translate(-50%, calc(-100% - .2em));
         }
       }

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -84,11 +84,7 @@ $seekbar-height: .3125em;
         @extend %bar;
 
         background-color: $color-primary;
-        // don't consider the border for width, else it does not overlap at edges
-        box-sizing: content-box;
         height: 100%;
-        // offset position marker to center it on its actual position
-        margin-left: -$marker-width / 2;
         width: $marker-width;
         text-align: center;
 

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -96,6 +96,7 @@ $seekbar-height: .3125em;
           position: absolute;
           height: $seekbar-height * 4;
           left: 50%;
+          -ms-transform: translate(-50%, calc(-100% - .2em));
           -webkit-transform: translate(-50%, calc(-100% - .2em));
           transform: translate(-50%, calc(-100% - .2em));
         }

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -91,6 +91,11 @@ $seekbar-height: .3125em;
         margin-left: -$marker-width / 2;
         width: $marker-width;
         text-align: center;
+
+        > .#{$prefix}-seekbar-marker-image {
+          position: absolute;
+          top: -$seekbar-height - .375em;
+        }
       }
     }
   }

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -87,14 +87,21 @@ $seekbar-height: .3125em;
         height: 100%;
         width: $marker-width;
         text-align: center;
-        transition-property: all;
+        -webkit-transition-property: -webkit-transform;
+        -moz-transition-property: -moz-transform;
+        -ms-transition-property: -ms-transform;
+        -o-transition-property: -o-transform;
+        transition-property: transform;
         transition-duration: 1s;
+        transition-timing-function: linear;
 
         > .#{$prefix}-seekbar-marker-image {
           position: absolute;
           height: $seekbar-height * 4;
-          -ms-transform: translate(-50%, calc(-100% - .2em));
           -webkit-transform: translate(-50%, calc(-100% - .2em));
+          -moz-transform: translate(-50%, calc(-100% - .2em));
+          -ms-transform: translate(-50%, calc(-100% - .2em));
+          -o-transform: translate(-50%, calc(-100% - .2em));
           transform: translate(-50%, calc(-100% - .2em));
         }
       }

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -95,7 +95,6 @@ $seekbar-height: .3125em;
         > .#{$prefix}-seekbar-marker-image {
           position: absolute;
           height: $seekbar-height * 4;
-          left: 50%;
           -ms-transform: translate(-50%, calc(-100% - .2em));
           -webkit-transform: translate(-50%, calc(-100% - .2em));
           transform: translate(-50%, calc(-100% - .2em));

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -83,13 +83,14 @@ $seekbar-height: .3125em;
       > .#{$prefix}-seekbar-marker {
         @extend %bar;
 
-        border-right: $marker-width solid $color-primary;
+        background-color: $color-primary;
         // don't consider the border for width, else it does not overlap at edges
         box-sizing: content-box;
         height: 100%;
         // offset position marker to center it on its actual position
         margin-left: -$marker-width / 2;
-        width: 0;
+        width: $marker-width;
+        text-align: center;
       }
     }
   }

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -61,6 +61,7 @@ export interface SeekBarMarker {
   marker: TimelineMarker;
   position: number;
   duration?: number;
+  element?: DOM;
 }
 
 /**

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -120,6 +120,8 @@ export class TimelineMarkersHandler {
       const markerClasses = ['seekbar-marker'].concat(marker.marker.cssClasses || [])
         .map(cssClass => this.prefixCss(cssClass));
 
+      const markerImageClasses = ['seekbar-marker-image'].map(cssClass => this.prefixCss(cssClass));
+
       const cssProperties: { [propertyName: string]: string } = {
         'left': `${marker.position}%`,
       };
@@ -134,6 +136,14 @@ export class TimelineMarkersHandler {
         'data-marker-time': String(marker.marker.time),
         'data-marker-title': String(marker.marker.title),
       }).css(cssProperties);
+
+      const imageElement = new DOM('img', {
+        'class': markerImageClasses.join(' '),
+        'src': marker.marker.imageUrl,
+      });
+
+      markerElement.append(imageElement);
+
       this.markersContainer.append(markerElement);
     });
   }

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -99,8 +99,7 @@ export class TimelineMarkersHandler {
 
   private removeMarkerFromDOM(marker: SeekBarMarker): void {
     if (marker.element) {
-      const element = marker.element.get()[0];
-      element.parentElement.removeChild(element);
+      marker.element.remove();
     }
   }
 
@@ -171,8 +170,7 @@ export class TimelineMarkersHandler {
 
       if (marker.marker.imageUrl) {
         const removeImage = () => {
-          const toRemove = imageElement.get()[0];
-          toRemove.parentElement.removeChild(toRemove);
+        imageElement.remove();
         };
 
         const imageElement = new DOM('img', {

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -134,23 +134,8 @@ export class TimelineMarkersHandler {
     });
   }
 
-  private getMarkerCssProperties(marker: SeekBarMarker): { [propertyName: string]: string } {
-    const seekBarWidthPx = this.getSeekBarWidth();
-
-    const cssProperties: { [propertyName: string]: string } = {
-      'left': `${marker.position < 0 ? 0 : marker.position}%`,
-    };
-
-    if (marker.duration > 0) {
-      const markerWidthPx = Math.round(seekBarWidthPx / 100 * marker.duration);
-      cssProperties['width'] = `${markerWidthPx}px`;
-    }
-
-    return cssProperties;
-  }
-
   private updateMarkerDOM(marker: SeekBarMarker): void {
-    marker.element.css(this.getMarkerCssProperties(marker));
+    marker.element.css(getMarkerCssProperties(marker));
   }
 
   private createMarkerDOM(marker: SeekBarMarker): void {
@@ -161,7 +146,7 @@ export class TimelineMarkersHandler {
         'class': markerClasses.join(' '),
         'data-marker-time': String(marker.marker.time),
         'data-marker-title': String(marker.marker.title),
-      }).css(this.getMarkerCssProperties(marker));
+      }).css(getMarkerCssProperties(marker));
 
       if (marker.marker.imageUrl) {
         const removeImage = () => {
@@ -259,4 +244,19 @@ function shouldProcessMarkers(player: PlayerAPI, uimanager: UIInstanceManager): 
   const hasMarkers = uimanager.getConfig().metadata.markers.length > 0;
 
   return validToProcess && hasMarkers;
+}
+
+function getMarkerCssProperties(marker: SeekBarMarker): { [propertyName: string]: string } {
+  const seekBarWidthPx = this.getSeekBarWidth();
+
+  const cssProperties: { [propertyName: string]: string } = {
+    'left': `${marker.position < 0 ? 0 : marker.position}%`,
+  };
+
+  if (marker.duration > 0) {
+    const markerWidthPx = Math.round(seekBarWidthPx / 100 * marker.duration);
+    cssProperties['width'] = `${markerWidthPx}px`;
+  }
+
+  return cssProperties;
 }

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -139,10 +139,6 @@ export class TimelineMarkersHandler {
 
     const positionInPx = (seekBarWidthPx / 100) * (marker.position < 0 ? 0 : marker.position);
     const cssProperties: { [propertyName: string]: string } = {
-      '-webkit-transform': `translateX(${positionInPx}px)`,
-      '-moz-transform': `translateX(${positionInPx}px)`,
-      '-ms-transform': `translateX(${positionInPx}px)`,
-      '-o-transform': `translateX(${positionInPx}px)`,
       'transform': `translateX(${positionInPx}px)`,
     };
 

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -27,6 +27,7 @@ export class TimelineMarkersHandler {
     this.config = config;
     this.getSeekBarWidth = getSeekBarWidth;
     this.markersContainer = markersContainer;
+    this.timelineMarkers = [];
   }
 
   public initialize(player: PlayerAPI, uimanager: UIInstanceManager) {

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -138,8 +138,9 @@ export class TimelineMarkersHandler {
   private getMarkerCssProperties(marker: SeekBarMarker): { [propertyName: string]: string } {
     const seekBarWidthPx = this.getSeekBarWidth();
 
+    const positionInPx = (seekBarWidthPx / 100) * (marker.position < 0 ? 0 : marker.position);
     const cssProperties: { [propertyName: string]: string } = {
-      'left': `${marker.position < 0 ? 0 : marker.position}%`,
+      'transform': `translateX(${positionInPx}px)`,
     };
 
     if (marker.duration > 0) {

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -39,6 +39,8 @@ export class TimelineMarkersHandler {
   private configureMarkers(): void {
     // Remove markers when unloaded
     this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => this.clearMarkers());
+    this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, () => this.clearMarkers());
+    this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers());
     // Update markers when the size of the seekbar changes
     this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkersDOM());
 

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -136,10 +136,8 @@ export class TimelineMarkersHandler {
       }).css(cssProperties);
 
       if (marker.marker.imageUrl) {
-        const markerImageClasses = ['seekbar-marker-image'].map(cssClass => this.prefixCss(cssClass));
-
         const imageElement = new DOM('img', {
-          'class': markerImageClasses.join(' '),
+          'class': this.prefixCss('seekbar-marker-image'),
           'src': marker.marker.imageUrl,
         });
 

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -83,11 +83,11 @@ export class TimelineMarkersHandler {
     this.markersContainer.get()[0].innerHTML = '';
   }
 
-  private removeMarker(marker: TimelineMarker): void {
+  private removeMarkerFromConfig(marker: TimelineMarker): void {
     this.uimanager.getConfig().metadata.markers = this.uimanager.getConfig().metadata.markers.filter(_marker => marker !== _marker);
   }
 
-  private filterRemovedMarkers() {
+  private filterRemovedMarkers(): void {
     this.timelineMarkers = this.timelineMarkers.filter(seekbarMarker => {
       const matchingMarker = this.uimanager.getConfig().metadata.markers.find(_marker =>  seekbarMarker.marker === _marker);
       if (!matchingMarker) {
@@ -97,7 +97,7 @@ export class TimelineMarkersHandler {
     });
   }
 
-  private removeMarkerFromDOM(marker: SeekBarMarker) {
+  private removeMarkerFromDOM(marker: SeekBarMarker): void {
     if (marker.element) {
       const element = marker.element.get()[0];
       element.parentElement.removeChild(element);
@@ -116,7 +116,7 @@ export class TimelineMarkersHandler {
       const { markerPosition, markerDuration } = getMarkerPositions(this.player, marker);
 
       if (shouldRemoveMarker(markerPosition, markerDuration)) {
-        this.removeMarker(marker);
+        this.removeMarkerFromConfig(marker);
       } else if (markerPosition <= 100) {
         const matchingMarker = this.timelineMarkers.find(seekbarMarker => seekbarMarker.marker === marker);
         if (matchingMarker) {

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -140,8 +140,10 @@ export class TimelineMarkersHandler {
 
     const positionInPx = (seekBarWidthPx / 100) * (marker.position < 0 ? 0 : marker.position);
     const cssProperties: { [propertyName: string]: string } = {
-      '-ms-transform': `translateX(${positionInPx}px)`,
       '-webkit-transform': `translateX(${positionInPx}px)`,
+      '-moz-transform': `translateX(${positionInPx}px)`,
+      '-ms-transform': `translateX(${positionInPx}px)`,
+      '-o-transform': `translateX(${positionInPx}px)`,
       'transform': `translateX(${positionInPx}px)`,
     };
 

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -80,7 +80,7 @@ export class TimelineMarkersHandler {
 
   private clearMarkers(): void {
     this.timelineMarkers = [];
-    this.markersContainer.get()[0].innerHTML = '';
+    this.markersContainer.empty();
   }
 
   private removeMarkerFromConfig(marker: TimelineMarker): void {

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -217,7 +217,7 @@ export class TimelineMarkersHandler {
 function getMarkerPositions(player: PlayerAPI, marker: TimelineMarker) {
   const duration = getDuration(player);
 
-  let markerPosition = 100 / duration * getMarkerTime(marker, player, duration); // convert absolute time to percentage
+  const markerPosition = 100 / duration * getMarkerTime(marker, player, duration); // convert absolute time to percentage
   let markerDuration = 100 / duration * marker.duration;
 
   if (markerPosition < 0 && !isNaN(markerDuration)) {

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -137,12 +137,14 @@ export class TimelineMarkersHandler {
         'data-marker-title': String(marker.marker.title),
       }).css(cssProperties);
 
-      const imageElement = new DOM('img', {
-        'class': markerImageClasses.join(' '),
-        'src': marker.marker.imageUrl,
-      });
+      if (marker.marker.imageUrl) {
+        const imageElement = new DOM('img', {
+          'class': markerImageClasses.join(' '),
+          'src': marker.marker.imageUrl,
+        });
 
-      markerElement.append(imageElement);
+        markerElement.append(imageElement);
+      }
 
       this.markersContainer.append(markerElement);
     });

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -120,8 +120,6 @@ export class TimelineMarkersHandler {
       const markerClasses = ['seekbar-marker'].concat(marker.marker.cssClasses || [])
         .map(cssClass => this.prefixCss(cssClass));
 
-      const markerImageClasses = ['seekbar-marker-image'].map(cssClass => this.prefixCss(cssClass));
-
       const cssProperties: { [propertyName: string]: string } = {
         'left': `${marker.position}%`,
       };
@@ -138,6 +136,8 @@ export class TimelineMarkersHandler {
       }).css(cssProperties);
 
       if (marker.marker.imageUrl) {
+        const markerImageClasses = ['seekbar-marker-image'].map(cssClass => this.prefixCss(cssClass));
+
         const imageElement = new DOM('img', {
           'class': markerImageClasses.join(' '),
           'src': marker.marker.imageUrl,

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -179,9 +179,9 @@ export class TimelineMarkersHandler {
         }).on('error', removeImage);
 
         markerElement.append(imageElement);
-        marker.element = markerElement;
       }
 
+      marker.element = markerElement;
       this.markersContainer.append(markerElement);
   }
 

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -136,10 +136,15 @@ export class TimelineMarkersHandler {
       }).css(cssProperties);
 
       if (marker.marker.imageUrl) {
+        const removeImage = () => {
+          const toRemove = imageElement.get()[0];
+          toRemove.parentElement.removeChild(toRemove);
+        };
+
         const imageElement = new DOM('img', {
           'class': this.prefixCss('seekbar-marker-image'),
           'src': marker.marker.imageUrl,
-        });
+        }).on('error', removeImage);
 
         markerElement.append(imageElement);
       }

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -126,7 +126,7 @@ export class TimelineMarkersHandler {
 
           this.updateMarkerDOM(matchingMarker);
         } else {
-          const newMarker: SeekBarMarker = {marker, position: markerPosition, duration: markerDuration};
+          const newMarker: SeekBarMarker = { marker, position: markerPosition, duration: markerDuration };
           this.timelineMarkers.push(newMarker);
 
           this.createMarkerDOM(newMarker);

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -121,20 +121,20 @@ export class TimelineMarkersHandler {
         .map(cssClass => this.prefixCss(cssClass));
 
       const cssProperties: { [propertyName: string]: string } = {
-        'width': marker.position + '%',
+        'left': `${marker.position}%`,
       };
 
       if (marker.duration > 0) {
         const markerWidthPx = Math.round(seekBarWidthPx / 100 * marker.duration);
-        cssProperties['border-right-width'] = markerWidthPx + 'px';
-        cssProperties['margin-left'] = '0';
+        cssProperties['width'] = `${markerWidthPx}px`;
       }
 
-      this.markersContainer.append(new DOM('div', {
+      const markerElement = new DOM('div', {
         'class': markerClasses.join(' '),
         'data-marker-time': String(marker.marker.time),
         'data-marker-title': String(marker.marker.title),
-      }).css(cssProperties));
+      }).css(cssProperties);
+      this.markersContainer.append(markerElement);
     });
   }
 

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -89,7 +89,7 @@ export class TimelineMarkersHandler {
 
   private filterRemovedMarkers(): void {
     this.timelineMarkers = this.timelineMarkers.filter(seekbarMarker => {
-      const matchingMarker = this.uimanager.getConfig().metadata.markers.find(_marker =>  seekbarMarker.marker === _marker);
+      const matchingMarker = this.uimanager.getConfig().metadata.markers.find(_marker => seekbarMarker.marker === _marker);
       if (!matchingMarker) {
         this.removeMarkerFromDOM(seekbarMarker);
       }
@@ -159,30 +159,30 @@ export class TimelineMarkersHandler {
   }
 
   private createMarkerDOM(marker: SeekBarMarker): void {
-      const markerClasses = ['seekbar-marker'].concat(marker.marker.cssClasses || [])
-        .map(cssClass => this.prefixCss(cssClass));
+    const markerClasses = ['seekbar-marker'].concat(marker.marker.cssClasses || [])
+      .map(cssClass => this.prefixCss(cssClass));
 
-      const markerElement = new DOM('div', {
-        'class': markerClasses.join(' '),
-        'data-marker-time': String(marker.marker.time),
-        'data-marker-title': String(marker.marker.title),
-      }).css(this.getMarkerCssProperties(marker));
+    const markerElement = new DOM('div', {
+      'class': markerClasses.join(' '),
+      'data-marker-time': String(marker.marker.time),
+      'data-marker-title': String(marker.marker.title),
+    }).css(this.getMarkerCssProperties(marker));
 
-      if (marker.marker.imageUrl) {
-        const removeImage = () => {
+    if (marker.marker.imageUrl) {
+      const removeImage = () => {
         imageElement.remove();
-        };
+      };
 
-        const imageElement = new DOM('img', {
-          'class': this.prefixCss('seekbar-marker-image'),
-          'src': marker.marker.imageUrl,
-        }).on('error', removeImage);
+      const imageElement = new DOM('img', {
+        'class': this.prefixCss('seekbar-marker-image'),
+        'src': marker.marker.imageUrl,
+      }).on('error', removeImage);
 
-        markerElement.append(imageElement);
-      }
+      markerElement.append(imageElement);
+    }
 
-      marker.element = markerElement;
-      this.markersContainer.append(markerElement);
+    marker.element = markerElement;
+    this.markersContainer.append(markerElement);
   }
 
   private updateMarkersDOM(): void {

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -134,8 +134,23 @@ export class TimelineMarkersHandler {
     });
   }
 
+  private getMarkerCssProperties(marker: SeekBarMarker): { [propertyName: string]: string } {
+    const seekBarWidthPx = this.getSeekBarWidth();
+
+    const cssProperties: { [propertyName: string]: string } = {
+      'left': `${marker.position < 0 ? 0 : marker.position}%`,
+    };
+
+    if (marker.duration > 0) {
+      const markerWidthPx = Math.round(seekBarWidthPx / 100 * marker.duration);
+      cssProperties['width'] = `${markerWidthPx}px`;
+    }
+
+    return cssProperties;
+  }
+
   private updateMarkerDOM(marker: SeekBarMarker): void {
-    marker.element.css(getMarkerCssProperties(marker));
+    marker.element.css(this.getMarkerCssProperties(marker));
   }
 
   private createMarkerDOM(marker: SeekBarMarker): void {
@@ -146,7 +161,7 @@ export class TimelineMarkersHandler {
         'class': markerClasses.join(' '),
         'data-marker-time': String(marker.marker.time),
         'data-marker-title': String(marker.marker.title),
-      }).css(getMarkerCssProperties(marker));
+      }).css(this.getMarkerCssProperties(marker));
 
       if (marker.marker.imageUrl) {
         const removeImage = () => {
@@ -244,19 +259,4 @@ function shouldProcessMarkers(player: PlayerAPI, uimanager: UIInstanceManager): 
   const hasMarkers = uimanager.getConfig().metadata.markers.length > 0;
 
   return validToProcess && hasMarkers;
-}
-
-function getMarkerCssProperties(marker: SeekBarMarker): { [propertyName: string]: string } {
-  const seekBarWidthPx = this.getSeekBarWidth();
-
-  const cssProperties: { [propertyName: string]: string } = {
-    'left': `${marker.position < 0 ? 0 : marker.position}%`,
-  };
-
-  if (marker.duration > 0) {
-    const markerWidthPx = Math.round(seekBarWidthPx / 100 * marker.duration);
-    cssProperties['width'] = `${markerWidthPx}px`;
-  }
-
-  return cssProperties;
 }

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -119,6 +119,7 @@ export class TimelineMarkersHandler {
         this.removeMarkerFromConfig(marker);
       } else if (markerPosition <= 100) {
         const matchingMarker = this.timelineMarkers.find(seekbarMarker => seekbarMarker.marker === marker);
+
         if (matchingMarker) {
           matchingMarker.position = markerPosition;
           matchingMarker.duration = markerDuration;

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -140,6 +140,8 @@ export class TimelineMarkersHandler {
 
     const positionInPx = (seekBarWidthPx / 100) * (marker.position < 0 ? 0 : marker.position);
     const cssProperties: { [propertyName: string]: string } = {
+      '-ms-transform': `translateX(${positionInPx}px)`,
+      '-webkit-transform': `translateX(${positionInPx}px)`,
       'transform': `translateX(${positionInPx}px)`,
     };
 

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -26,6 +26,8 @@ export interface TimelineMarker {
   title?: string;
   /**
    * Url to timeline marker image
+   * Prefered small image sizes (~50px)
+   * Best performing with SVG format
    */
   imageUrl?: string;
   /**

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -25,6 +25,10 @@ export interface TimelineMarker {
    */
   title?: string;
   /**
+   * Url to timeline marker image
+   */
+  imageUrl?: string;
+  /**
    * Optional CSS classes that are applied to the marker on a {@link SeekBar} and can be used to
    * differentiate different types of markers by their style (e.g. different color of chapter markers
    * and ad break markers).

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -26,7 +26,7 @@ export interface TimelineMarker {
   title?: string;
   /**
    * Url to timeline marker image
-   * Prefered small image sizes (~50px)
+   * Prefered small image sizes (~50px) with aspect ratio of 1:1
    * Best performing with SVG format
    */
   imageUrl?: string;


### PR DESCRIPTION
Extending `timeline markers` interface to pass `imageUrl` for `timeline markers`. These images will be rendered above the marker on the seek bar.

Update the way we render `timeline markers` - for live streams we were removing and then adding markers as marker positions keep updating. This results in jittery updating in the UI - especially now that we are adding images. To avoid this, we are keeping track of elements and only update their positions when needed. This way we are able to animate marker position changes.

Example 
![image](https://user-images.githubusercontent.com/20220542/88774315-904b5b00-d183-11ea-92b7-d4bb0efa8503.png)
