### PR TITLE
Fix subtitle positioning not respecting container size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Subtitle positioning when small screen UI is used and vtt properties are present
+
 ## [3.16.0] - 2020-07-30
 
 ### Added

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -51,6 +51,7 @@ export namespace MockHelper {
       css: jest.fn(),
       width: jest.fn(),
       height: jest.fn(),
+      size: jest.fn(),
       empty: jest.fn(),
       append: jest.fn(),
     }));

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -6,23 +6,23 @@ import { MockHelper } from './helper/MockHelper';
 describe('Vtt Utils', () => {
   describe('Vtt Region', () => {
     it('should set region css properties', () => {
-        const mockRegionContainer = generateSubtitleRegionContainerMock();
-        const mockDomElement = MockHelper.generateDOMMock();
-        mockRegionContainer.getDomElement = () => mockDomElement;
-        const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
-        VttUtils.setVttRegionStyles(mockRegionContainer, vttRegionProps, { width: 1000, height: 800 });
+      const mockRegionContainer = generateSubtitleRegionContainerMock();
+      const mockDomElement = MockHelper.generateDOMMock();
+      mockRegionContainer.getDomElement = () => mockDomElement;
+      const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-        expect(spyCss).toHaveBeenCalledTimes(8);
-        expect(spyCss).toHaveBeenNthCalledWith(1, 'position', 'absolute');
-        expect(spyCss).toHaveBeenNthCalledWith(2, 'overflow', 'hidden');
-        expect(spyCss).toHaveBeenNthCalledWith(3, 'width', `${vttRegionProps.width}%`);
-        expect(spyCss).toHaveBeenNthCalledWith(4, 'left', '75px');
-        expect(spyCss).toHaveBeenNthCalledWith(5, 'right', 'unset');
-        expect(spyCss).toHaveBeenNthCalledWith(6, 'top', '772px');
-        expect(spyCss).toHaveBeenNthCalledWith(7, 'bottom', 'unset');
-        expect(spyCss).toHaveBeenNthCalledWith(8, 'height', '28px');
-      });
+      VttUtils.setVttRegionStyles(mockRegionContainer, vttRegionProps, { width: 1000, height: 800 });
+
+      expect(spyCss).toHaveBeenCalledTimes(8);
+      expect(spyCss).toHaveBeenNthCalledWith(1, 'position', 'absolute');
+      expect(spyCss).toHaveBeenNthCalledWith(2, 'overflow', 'hidden');
+      expect(spyCss).toHaveBeenNthCalledWith(3, 'width', `${vttRegionProps.width}%`);
+      expect(spyCss).toHaveBeenNthCalledWith(4, 'left', '75px');
+      expect(spyCss).toHaveBeenNthCalledWith(5, 'right', 'unset');
+      expect(spyCss).toHaveBeenNthCalledWith(6, 'top', '772px');
+      expect(spyCss).toHaveBeenNthCalledWith(7, 'bottom', 'unset');
+      expect(spyCss).toHaveBeenNthCalledWith(8, 'height', '28px');
+    });
   });
 
   describe('Vtt Cue Box', () => {
@@ -33,7 +33,7 @@ describe('Vtt Utils', () => {
       const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
       VttUtils.setVttCueBoxStyles(mockRegionContainer);
-      
+
       expect(spyCss).toHaveBeenCalledTimes(10);
       expect(spyCss).toHaveBeenNthCalledWith(8, 'text-align', 'left');
     });
@@ -77,9 +77,9 @@ describe('Vtt Utils', () => {
           const mockDomElement = MockHelper.generateDOMMock();
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-  
+
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
-  
+
           expect(spyCss).toHaveBeenCalledTimes(10);
           expect(spyCss).toHaveBeenNthCalledWith(6, 'writing-mode', 'horizontal-tb');
         });
@@ -90,84 +90,105 @@ describe('Vtt Utils', () => {
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-    
+
             expect(spyCss).toHaveBeenCalledTimes(10);
           });
 
           it('should set percentage line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: '50%', snapToLines: false } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              line: '50%',
+              snapToLines: false,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(11);
             expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '50%');
           });
 
           it('should set positive line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: 4, snapToLines: true } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              line: 4,
+              snapToLines: true,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(11);
             expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '112px');
           });
 
           it('should set negative line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: -4, snapToLines: true } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              line: -4,
+              snapToLines: true,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(11);
             expect(spyCss).toHaveBeenNthCalledWith(8, 'bottom', '112px');
           });
 
           describe('Line Alignment', () => {
             it('should not do start line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: '50%', snapToLines: false, lineAlign: 'start' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'start',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(11);
             });
 
             it('should do center line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: '50%', snapToLines: false, lineAlign: 'center' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'center',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(12);
               expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-14px');
             });
 
             it('should do end line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { line: '50%', snapToLines: false, lineAlign: 'end' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'end',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(12);
               expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-28px');
             });
-          })
+          });
         });
       });
 
@@ -177,9 +198,9 @@ describe('Vtt Utils', () => {
           const mockDomElement = MockHelper.generateDOMMock();
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-  
+
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
-          
+
           expect(spyCss).toHaveBeenCalledTimes(11);
           expect(spyCss).toHaveBeenNthCalledWith(6, 'writing-mode', 'vertical-lr');
           expect(spyCss).toHaveBeenNthCalledWith(7, 'right', '0');
@@ -191,84 +212,111 @@ describe('Vtt Utils', () => {
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(11);
           });
 
           it('should set percentage line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: '50%', snapToLines: false } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'lr',
+              line: '50%',
+              snapToLines: false,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '50%');
           });
 
           it('should set positive line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: 4, snapToLines: true } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'lr',
+              line: 4,
+              snapToLines: true,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '112px');
           });
 
           it('should set negative line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: -4, snapToLines: true } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'lr',
+              line: -4,
+              snapToLines: true,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '112px');
           });
 
           describe('Line alignment', () => {
             it('should not do start line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: '50%', snapToLines: false, lineAlign: 'start' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                vertical: 'lr',
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'start',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(12);
             });
 
             it('should do center line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: '50%', snapToLines: false, lineAlign: 'center' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                vertical: 'lr',
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'center',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(13);
               expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-14px');
             });
 
             it('should do end line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', line: '50%', snapToLines: false, lineAlign: 'end' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                vertical: 'lr',
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'end',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(13);
               expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-28px');
             });
-          })
+          });
         });
       });
 
@@ -278,9 +326,9 @@ describe('Vtt Utils', () => {
           const mockDomElement = MockHelper.generateDOMMock();
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-  
+
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
-  
+
           expect(spyCss).toHaveBeenCalledTimes(11);
           expect(spyCss).toHaveBeenNthCalledWith(6, 'writing-mode', 'vertical-rl');
           expect(spyCss).toHaveBeenNthCalledWith(7, 'left', '0');
@@ -292,84 +340,111 @@ describe('Vtt Utils', () => {
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-    
+
             expect(spyCss).toHaveBeenCalledTimes(11);
           });
 
           it('should set percentage line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: '50%', snapToLines: false } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'rl',
+              line: '50%',
+              snapToLines: false,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '50%');
           });
 
           it('should set positive line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: 4, snapToLines: true } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'rl',
+              line: 4,
+              snapToLines: true,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '112px');
           });
 
           it('should set negative line positioning', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: -4, snapToLines: true } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'rl',
+              line: -4,
+              snapToLines: true,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '112px');
           });
 
           describe('Line alignment', () => {
             it('should not do start line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: '50%', snapToLines: false, lineAlign: 'start' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                vertical: 'rl',
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'start',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(12);
             });
 
             it('should do center line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: '50%', snapToLines: false, lineAlign: 'center' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                vertical: 'rl',
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'center',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(13);
               expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-14px');
             });
 
             it('should do end line alignment', () => {
-              const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'rl', line: '50%', snapToLines: false, lineAlign: 'end' } as VTTProperties);
+              const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+                vertical: 'rl',
+                line: '50%',
+                snapToLines: false,
+                lineAlign: 'end',
+              } as VTTProperties);
               const mockDomElement = MockHelper.generateDOMMock();
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-      
+
               VttUtils.setVttCueBoxStyles(mockRegionContainer);
-              
+
               expect(spyCss).toHaveBeenCalledTimes(13);
               expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-28px');
             });
-          })
+          });
         });
       });
     });
@@ -381,9 +456,9 @@ describe('Vtt Utils', () => {
           const mockDomElement = MockHelper.generateDOMMock();
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-  
+
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
-          
+
           expect(spyCss).toHaveBeenCalledTimes(10);
           expect(spyCss).toHaveBeenNthCalledWith(9, 'width', '100%');
         });
@@ -394,75 +469,84 @@ describe('Vtt Utils', () => {
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(10);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '0');
           });
-          
+
           it('should set position', () => {
             const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 50 } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(11);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '50%');
           });
 
           it('should set left position align', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 30, positionAlign: 'line-left' } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              position: 30,
+              positionAlign: 'line-left',
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '30%');
             expect(spyCss).toHaveBeenNthCalledWith(11, 'right', 'auto');
           });
 
           it('should set center position align', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 30, positionAlign: 'center' } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              position: 30,
+              positionAlign: 'center',
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '-20%');
             expect(spyCss).toHaveBeenNthCalledWith(11, 'right', 'auto');
           });
 
           it('should set right position align', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { position: 30, positionAlign: 'line-right' } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              position: 30,
+              positionAlign: 'line-right',
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', 'auto');
             expect(spyCss).toHaveBeenNthCalledWith(11, 'right', '30%');
           });
         });
       });
-      
+
       describe('Horizontal', () => {
         it('should set height', () => {
           const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr' } as VTTProperties);
           const mockDomElement = MockHelper.generateDOMMock();
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-  
+
           VttUtils.setVttCueBoxStyles(mockRegionContainer);
-          
+
           expect(spyCss).toHaveBeenCalledTimes(11);
           expect(spyCss).toHaveBeenNthCalledWith(10, 'height', '100%');
         });
@@ -473,97 +557,112 @@ describe('Vtt Utils', () => {
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(11);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '0');
           });
 
           it('should set position', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', position: 50 } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'lr',
+              position: 50,
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '50%');
           });
 
           it('should set left position align', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', position: 30, positionAlign: 'line-left' } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'lr',
+              position: 30,
+              positionAlign: 'line-left',
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(13);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '30%');
             expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', 'auto');
           });
 
           it('should set center position align', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', position: 30, positionAlign: 'center' } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'lr',
+              position: 30,
+              positionAlign: 'center',
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(13);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '-20%');
             expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', 'auto');
           });
 
           it('should set right position align', () => {
-            const mockRegionContainer = generateSubtitleCueBoxMock(false, { vertical: 'lr', position: 30, positionAlign: 'line-right' } as VTTProperties);
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              vertical: 'lr',
+              position: 30,
+              positionAlign: 'line-right',
+            } as VTTProperties);
             const mockDomElement = MockHelper.generateDOMMock();
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
-    
+
             VttUtils.setVttCueBoxStyles(mockRegionContainer);
-            
+
             expect(spyCss).toHaveBeenCalledTimes(13);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', 'auto');
             expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', '30%');
           });
         });
-      })
+      });
     });
   });
 });
 
 function generateSubtitleRegionContainerMock(): SubtitleRegionContainer {
-    const SubtitleRegionContainerClass: jest.Mock<SubtitleRegionContainer> = jest.fn().mockImplementation();
-    return new SubtitleRegionContainerClass();
+  const SubtitleRegionContainerClass: jest.Mock<SubtitleRegionContainer> = jest.fn().mockImplementation();
+  return new SubtitleRegionContainerClass();
 }
 
 function generateSubtitleCueBoxMock(hasRegion: boolean, vttProps?: VTTProperties): SubtitleLabel {
-    const region = hasRegion ? vttRegionProps : null;
-    const SubtitleCueBoxClass: jest.Mock<SubtitleLabel> = jest.fn().mockImplementation(() => (
-        {
-            vtt: {
-                ...generateVttProps(vttProps),
-                region
-            }
-        }
-    ));
-    return new SubtitleCueBoxClass();
+  const region = hasRegion ? vttRegionProps : null;
+  const SubtitleCueBoxClass: jest.Mock<SubtitleLabel> = jest.fn().mockImplementation(() => (
+    {
+      vtt: {
+        ...generateVttProps(vttProps),
+        region,
+      },
+    }
+  ));
+  return new SubtitleCueBoxClass();
 }
 
 const vttRegionProps: VTTRegionProperties = {
-    id: 'regionId',
-    lines: 1,
-    width: 70,
-    regionAnchorX: 25,
-    regionAnchorY: 100,
-    viewportAnchorX: 25,
-    viewportAnchorY: 100,
-    scroll: ''
-}
+  id: 'regionId',
+  lines: 1,
+  width: 70,
+  regionAnchorX: 25,
+  regionAnchorY: 100,
+  viewportAnchorX: 25,
+  viewportAnchorY: 100,
+  scroll: '',
+};
 
 const generateVttProps = (props?: VTTProperties): VTTProperties => {
   const defaultProps = {
@@ -575,10 +674,10 @@ const generateVttProps = (props?: VTTProperties): VTTProperties => {
     position: 'auto',
     positionAlign: 'auto',
     snapToLines: false,
-  }
+  };
 
   return {
     ...defaultProps,
-    ...props
-  }
-}
+    ...props,
+  };
+};

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -114,6 +114,21 @@ describe('Vtt Utils', () => {
             expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '50%');
           });
 
+          it('should set percentage line positioning for absolute value', () => {
+            const mockRegionContainer = generateSubtitleCueBoxMock(false, {
+              line: 50,
+              snapToLines: false,
+            } as VTTProperties);
+            const mockDomElement = MockHelper.generateDOMMock();
+            mockRegionContainer.getDomElement = () => mockDomElement;
+            const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
+
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
+
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '50%');
+          });
+
           it('should set positive line positioning', () => {
             const mockRegionContainer = generateSubtitleCueBoxMock(false, {
               line: 4,

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -2,6 +2,7 @@ import { SubtitleRegionContainer, SubtitleLabel } from '../src/ts/components/sub
 import { VttUtils } from '../src/ts/vttutils';
 import { VTTRegionProperties, VTTProperties } from 'bitmovin-player';
 import { MockHelper } from './helper/MockHelper';
+import { Size } from '../src/ts/dom';
 
 describe('Vtt Utils', () => {
   describe('Vtt Region', () => {
@@ -26,13 +27,15 @@ describe('Vtt Utils', () => {
   });
 
   describe('Vtt Cue Box', () => {
+    const subtitleOverLaySize: Size = { width: 300, height: 168 };
+
     it('should set text align', () => {
       const mockRegionContainer = generateSubtitleCueBoxMock(false, { align: 'left' } as VTTProperties);
       const mockDomElement = MockHelper.generateDOMMock();
       mockRegionContainer.getDomElement = () => mockDomElement;
       const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-      VttUtils.setVttCueBoxStyles(mockRegionContainer);
+      VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
       expect(spyCss).toHaveBeenCalledTimes(10);
       expect(spyCss).toHaveBeenNthCalledWith(8, 'text-align', 'left');
@@ -45,7 +48,7 @@ describe('Vtt Utils', () => {
         mockRegionContainer.getDomElement = () => mockDomElement;
         const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-        VttUtils.setVttCueBoxStyles(mockRegionContainer);
+        VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
         expect(spyCss).toHaveBeenCalledTimes(10);
         expect(spyCss).toHaveBeenNthCalledWith(1, 'position', 'absolute');
@@ -61,7 +64,7 @@ describe('Vtt Utils', () => {
         mockRegionContainer.getDomElement = () => mockDomElement;
         const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-        VttUtils.setVttCueBoxStyles(mockRegionContainer);
+        VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
         expect(spyCss).toHaveBeenCalledTimes(8);
         expect(spyCss).toHaveBeenNthCalledWith(1, 'position', 'relative');
@@ -78,7 +81,7 @@ describe('Vtt Utils', () => {
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+          VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
           expect(spyCss).toHaveBeenCalledTimes(10);
           expect(spyCss).toHaveBeenNthCalledWith(6, 'writing-mode', 'horizontal-tb');
@@ -91,7 +94,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(10);
           });
@@ -105,7 +108,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(11);
             expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '50%');
@@ -120,10 +123,10 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(11);
-            expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '112px');
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '19.047619047619047%');
           });
 
           it('should set negative line positioning', () => {
@@ -135,10 +138,10 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(11);
-            expect(spyCss).toHaveBeenNthCalledWith(8, 'bottom', '112px');
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'top', '80.95238095238095%');
           });
 
           describe('Line Alignment', () => {
@@ -152,7 +155,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(11);
             });
@@ -167,7 +170,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(12);
               expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-14px');
@@ -183,7 +186,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(12);
               expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-28px');
@@ -199,7 +202,7 @@ describe('Vtt Utils', () => {
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+          VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
           expect(spyCss).toHaveBeenCalledTimes(11);
           expect(spyCss).toHaveBeenNthCalledWith(6, 'writing-mode', 'vertical-lr');
@@ -213,7 +216,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(11);
           });
@@ -228,7 +231,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '50%');
@@ -244,10 +247,10 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '112px');
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '19.047619047619047%');
           });
 
           it('should set negative line positioning', () => {
@@ -260,10 +263,10 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '112px');
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '80.95238095238095%');
           });
 
           describe('Line alignment', () => {
@@ -278,7 +281,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(12);
             });
@@ -294,7 +297,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(13);
               expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-14px');
@@ -311,7 +314,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(13);
               expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-28px');
@@ -327,7 +330,7 @@ describe('Vtt Utils', () => {
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+          VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
           expect(spyCss).toHaveBeenCalledTimes(11);
           expect(spyCss).toHaveBeenNthCalledWith(6, 'writing-mode', 'vertical-rl');
@@ -341,7 +344,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(11);
           });
@@ -356,7 +359,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '50%');
@@ -372,10 +375,10 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '112px');
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '19.047619047619047%');
           });
 
           it('should set negative line positioning', () => {
@@ -388,10 +391,10 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '112px');
+            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '80.95238095238095%');
           });
 
           describe('Line alignment', () => {
@@ -406,7 +409,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(12);
             });
@@ -422,7 +425,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(13);
               expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-14px');
@@ -439,7 +442,7 @@ describe('Vtt Utils', () => {
               mockRegionContainer.getDomElement = () => mockDomElement;
               const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-              VttUtils.setVttCueBoxStyles(mockRegionContainer);
+              VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(13);
               expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-28px');
@@ -457,7 +460,7 @@ describe('Vtt Utils', () => {
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+          VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
           expect(spyCss).toHaveBeenCalledTimes(10);
           expect(spyCss).toHaveBeenNthCalledWith(9, 'width', '100%');
@@ -470,7 +473,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(10);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '0');
@@ -482,7 +485,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(11);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '50%');
@@ -497,7 +500,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '30%');
@@ -513,7 +516,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '-20%');
@@ -529,7 +532,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', 'auto');
@@ -545,7 +548,7 @@ describe('Vtt Utils', () => {
           mockRegionContainer.getDomElement = () => mockDomElement;
           const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-          VttUtils.setVttCueBoxStyles(mockRegionContainer);
+          VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
           expect(spyCss).toHaveBeenCalledTimes(11);
           expect(spyCss).toHaveBeenNthCalledWith(10, 'height', '100%');
@@ -558,7 +561,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(11);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '0');
@@ -573,7 +576,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '50%');
@@ -589,7 +592,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(13);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '30%');
@@ -606,7 +609,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(13);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', '-20%');
@@ -623,7 +626,7 @@ describe('Vtt Utils', () => {
             mockRegionContainer.getDomElement = () => mockDomElement;
             const spyCss = jest.spyOn(mockRegionContainer.getDomElement(), 'css');
 
-            VttUtils.setVttCueBoxStyles(mockRegionContainer);
+            VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
             expect(spyCss).toHaveBeenCalledTimes(13);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', 'auto');

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -4,7 +4,7 @@ import { Label, LabelConfig } from './label';
 import { ComponentConfig, Component } from './component';
 import { ControlBar } from './controlbar';
 import { EventDispatcher } from '../eventdispatcher';
-import { DOM } from '../dom';
+import { DOM, Size } from '../dom';
 import { PlayerAPI, SubtitleCueEvent } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
 import { VttUtils } from '../vttutils';
@@ -71,11 +71,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       this.show();
 
-      const overlaySize = {
-        width: this.getDomElement().width(),
-        height: this.getDomElement().height(),
-      };
-      this.subtitleContainerManager.addLabel(labelToAdd, overlaySize);
+      this.subtitleContainerManager.addLabel(labelToAdd, this.getDomElement().size());
       this.updateComponents();
     });
 
@@ -466,7 +462,7 @@ export class SubtitleRegionContainerManager {
    * If the subtitle has positioning information it is added to the container.
    * @param label The subtitle label to wrap
    */
-  addLabel(label: SubtitleLabel, overlaySize?: { width: number, height: number }): void {
+  addLabel(label: SubtitleLabel, overlaySize?: Size): void {
     let regionContainerId;
     let regionName;
 
@@ -555,7 +551,7 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
     }, this.config);
   }
 
-  addLabel(labelToAdd: SubtitleLabel, overlaySize?: { width: number, height: number }) {
+  addLabel(labelToAdd: SubtitleLabel, overlaySize?: Size) {
     this.labelCount++;
 
     if (labelToAdd.vtt) {
@@ -563,7 +559,7 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
         VttUtils.setVttRegionStyles(this, labelToAdd.vtt.region, overlaySize);
       }
 
-      VttUtils.setVttCueBoxStyles(labelToAdd);
+      VttUtils.setVttCueBoxStyles(labelToAdd, overlaySize);
     }
 
     this.addComponent(labelToAdd);

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -3,6 +3,11 @@ export interface Offset {
   top: number;
 }
 
+export interface Size {
+  width: number;
+  height: number;
+}
+
 export interface CssProperties {
   [propertyName: string]: string;
 }
@@ -394,6 +399,14 @@ export class DOM {
   height(): number {
     // TODO check if this is the same as jQuery's height() (probably not)
     return this.elements[0].offsetHeight;
+  }
+
+  /**
+   * Returns the size of the first element.
+   * @return {Size} the size of the first element
+   */
+  size(): Size {
+    return { width: this.width(), height: this.height() };
   }
 
   /**

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -64,7 +64,7 @@ const setVttLine = (
     return;
   }
 
-  let relativeLinePosition = vtt.line;
+  let relativeLinePosition = parseFloat(vtt.line as string);
 
   if (vtt.snapToLines) {
     let targetLine = Number(vtt.line);
@@ -75,10 +75,9 @@ const setVttLine = (
     const lineHeight = subtitleOverLaySize.height / defaultLineNumber;
     const absoluteLinePosition = lineHeight * targetLine;
     relativeLinePosition = (100 * absoluteLinePosition) / subtitleOverLaySize.height;
-    relativeLinePosition = `${relativeLinePosition}%`;
   }
 
-  cueContainerDom.css(direction, relativeLinePosition as string);
+  cueContainerDom.css(direction, `${relativeLinePosition}%`);
   setVttLineAlign(cueContainerDom, vtt, direction);
 };
 


### PR DESCRIPTION
### Description
When there is a subtitle with `vtt` positioning information which has an absolute value for the `line` property, the size of the container was not respected.

![Hnet com-image-2](https://user-images.githubusercontent.com/6216959/88808333-09ae7200-d1b3-11ea-8308-5a8db6f211e6.gif)

## Problem
The position is calculated based on our default line-height and the absolute `line` property. When you resize the player this value does not change and therefore it could happen that it was rendered out of the screen.

## Fix
Calculating a relative value for the CSS property based on our default line number and the `vtt.line` property.

## Review
@ reviewers: You can skip e18e05f (autoformatting using IDE)
