### PR TITLE
Fixing issue with settings panel going blank on switching tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -668,6 +668,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.16.0...HEAD
 [3.16.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.15.0...v3.16.0
 [3.15.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.14.0...v3.15.0
 [3.14.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.13.0...v3.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.17.0] - 2020-08-03
+
+### Fixed
+- `SettingsPanel` goes blank sometimes when switching browser tab/window
+
 ## [3.16.0] - 2020-07-30
 
 ### Added

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -367,17 +367,23 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
       if (item.isActive() && (item as any).setting instanceof SelectBox) {
         const selectBox = (item as any).setting as SelectBox;
         const oldDisplay = selectBox.getDomElement().css('display');
-        // updating the display to none marks the select-box as inactive, so it will be hidden with the rest
-        // we just have to make sure to reset this as soon as possible
-        selectBox.getDomElement().css('display', 'none');
-        if (window.requestAnimationFrame) {
-          requestAnimationFrame(() => {
+        if (oldDisplay !== 'none') {
+          // updating the display to none marks the select-box as inactive, so it will be hidden with the rest
+          // we just have to make sure to reset this as soon as possible
+          // if oldDisplay is already 'none', no need to redo it as it could lead to race condition
+          // wherein the display is irreversibly set to 'none' when browser tab/window is not active because
+          // requestAnimationFrame is either delayed or paused in some browsers in inactive state
+          selectBox.getDomElement().css('display', 'none');
+          // console.log('Before: Setting display:none');
+          if (window.requestAnimationFrame) {
+            requestAnimationFrame(() => {
+              selectBox.getDomElement().css('display', oldDisplay);
+            });
+          } else {
+            // IE9 has no requestAnimationFrame, set the value directly. It has no optimization about ignoring DOM-changes
+            // between animationFrames
             selectBox.getDomElement().css('display', oldDisplay);
-          });
-        } else {
-          // IE9 has no requestAnimationFrame, set the value directly. It has no optimization about ignoring DOM-changes
-          // between animationFrames
-          selectBox.getDomElement().css('display', oldDisplay);
+          }
         }
       }
     });

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -367,23 +367,24 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
       if (item.isActive() && (item as any).setting instanceof SelectBox) {
         const selectBox = (item as any).setting as SelectBox;
         const oldDisplay = selectBox.getDomElement().css('display');
-        if (oldDisplay !== 'none') {
-          // updating the display to none marks the select-box as inactive, so it will be hidden with the rest
-          // we just have to make sure to reset this as soon as possible
-          // if oldDisplay is already 'none', no need to redo it as it could lead to race condition
+        if (oldDisplay === 'none') {
+          // if oldDisplay is already 'none', no need to set to 'none' again. It could lead to race condition
           // wherein the display is irreversibly set to 'none' when browser tab/window is not active because
           // requestAnimationFrame is either delayed or paused in some browsers in inactive state
-          selectBox.getDomElement().css('display', 'none');
-          // console.log('Before: Setting display:none');
-          if (window.requestAnimationFrame) {
-            requestAnimationFrame(() => {
-              selectBox.getDomElement().css('display', oldDisplay);
-            });
-          } else {
-            // IE9 has no requestAnimationFrame, set the value directly. It has no optimization about ignoring DOM-changes
-            // between animationFrames
+          return;
+        }
+
+        // updating the display to none marks the select-box as inactive, so it will be hidden with the rest
+        // we just have to make sure to reset this as soon as possible
+        selectBox.getDomElement().css('display', 'none');
+        if (window.requestAnimationFrame) {
+          requestAnimationFrame(() => {
             selectBox.getDomElement().css('display', oldDisplay);
-          }
+          });
+        } else {
+          // IE9 has no requestAnimationFrame, set the value directly. It has no optimization about ignoring DOM-changes
+          // between animationFrames
+          selectBox.getDomElement().css('display', oldDisplay);
         }
       }
     });


### PR DESCRIPTION
Putting a check to prevent a race conditions causing display to be set to 'none' when the browser tab/window is inactive.

**Issue :** 
- The method 'hideHoveredSelectBoxes' is called twice(back to back), once with timeout of settings panel and then for main controls hiding. In the method, the display of panel is set to 'none' to mark select box as inactive so that it is hidden with rest of control UI and then immediately reset back to original value so that it retains the correct value next time. 
- 'requestAnimationFrame' method is used for setting it back to original value. This works fine when window/tab is active.
- But when Tab/Window is inactive when this method is executed,
  - The display is set to 'none' in the first call. 
  - Since some browsers(Chromium/Edge) delay/pause execution of 'requestAnimationFrame' in inactive tabs/window so 
     display is not set back to original value until tab/window is active again.
  - Now, with second invocation of 'requestAnimationFrame', the display is found to be 'none' and the variable 'oldDisplay' is 
     saved as 'none' and 'requestAnimationFrame' is called with this value pf display as 'none' instead of the original value.
  - When  tab/window is active again, 'requestAnimationFrame' gets executed setting the display as 'none' instead of restoring 
     the original value. And the correct value cannot be restored after this point.

**Fix :** 
- If the display is already 'none', then the setting it to 'none' again and resetting back to original value is not required. This also 
   prevents the race condition from happening.



