### PR TITLE
Fix that the live indicator stays active after stalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## develop
+
+### Fixed
+- Live-indicator stays active after stalling in live streams
+
 ## [3.17.0] - 2020-08-18
 
 ### Fixed

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -139,6 +139,8 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     player.on(player.exports.PlayerEvent.TimeShifted, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.Playing, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.Paused, updateLiveTimeshiftState);
+    player.on(player.exports.PlayerEvent.StallStarted, updateLiveTimeshiftState);
+    player.on(player.exports.PlayerEvent.StallEnded, updateLiveTimeshiftState);
 
     let init = () => {
       // Reset min-width when a new source is ready (especially for switching VOD/Live modes where the label content


### PR DESCRIPTION
### Description
When a live-stream continues after stalling the live indicator within the UI stays active like we are on the live edge. 

![Screenshot 2020-10-12 at 16 54 35](https://user-images.githubusercontent.com/6216959/95763008-c7bfa300-0cae-11eb-8cf4-5fe62f2a789e.png)


### Solution
Update live time shift state when stalling events occur.
