### PR TITLE
Fix subtitle display issue for IE/tizen 2016 when no regions are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Live-indicator stays active after stalling in live streams
+- Subtitles not displayed in IE/tizen 2016 when no regions are present
 
 ## [3.17.0] - 2020-08-18
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -493,7 +493,7 @@ export class SubtitleRegionContainerManager {
          * If there is no region present to wrap the Cue Box, the Cue box becomes the
          * region itself. Therefore the positioning values have to come from the box.
          */
-        regionContainer.getDomElement().css('position', 'unset');
+        regionContainer.getDomElement().css('position', 'static');
       } else {
         // getDomElement needs to be called at least once to ensure the component exists
         regionContainer.getDomElement();


### PR DESCRIPTION
**Description**: Captions are not displayed in IE 11/tizen 2016 when there are no regions present in WebVTT.

**Problem**: When region labels are not present for the subtitle we are removing the absolute position set to the region container using CSS `position: unset` which is not supported in IE11 and also Tizen 2016.

**Fix**: Use CSS position property `'static'` to remove the position style.