### PR TITLE
Fix Vast `unknown` AdError when UI is not present

### DIFF
--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -79,27 +79,3 @@ export { SettingsPanelPageBackButton } from './components/settingspanelpagebackb
 export { SettingsPanelPageOpenButton } from './components/settingspanelpageopenbutton';
 export { SubtitleSettingsPanelPage } from './components/subtitlesettings/subtitlesettingspanelpage';
 export { SettingsPanelItem } from './components/settingspanelitem';
-
-// Object.assign polyfill for ES5/IE9
-// https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-if (typeof Object.assign !== 'function') {
-  Object.assign = function(target: any) {
-    'use strict';
-    if (target == null) {
-      throw new TypeError('Cannot convert undefined or null to object');
-    }
-
-    target = Object(target);
-    for (let index = 1; index < arguments.length; index++) {
-      let source = arguments[index];
-      if (source != null) {
-        for (let key in source) {
-          if (Object.prototype.hasOwnProperty.call(source, key)) {
-            target[key] = source[key];
-          }
-        }
-      }
-    }
-    return target;
-  };
-}


### PR DESCRIPTION
Object.assign is removed and now present only in bitdash.