### PR TITLE
Add button type to button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## develop
+
 ### Added
-- Add `'type' : 'button'` to buttons
+- `'type' : 'button'` to buttons to prevent submitting forms
 
 ## [3.20.0] - 2020-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### Added
+- Add `'type' : 'button'` to buttons
+
 ## [3.20.0] - 2020-11-25
 
 ### Fixed

--- a/src/ts/components/button.ts
+++ b/src/ts/components/button.ts
@@ -37,6 +37,7 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
       'id': this.config.id,
       'aria-label': i18n.performLocalization(this.config.ariaLabel || this.config.text),
       'class': this.getCssClasses(),
+      'type' : 'button',
       /**
       * WCAG20 standard to display if a button is pressed or not
       */


### PR DESCRIPTION
Description: In most modern browsers (with the exception of IE), the default button type is submit this causes an issue when we embed our player in a form, on play button press the form is submitted.

Problem: button type needs to be defined, so that browser will not consider it as submit. 

Fix: Add  `'type' : 'button'` to button component