### PR TITLE
Fix CI build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Wrapping possibly not enumerable poperties of player object, like getters and setters
+
 ## [3.19.0] - 2020-11-10
 
 ### Fixed

--- a/spec/components/pictureinpicturetogglebutton.spec.ts
+++ b/spec/components/pictureinpicturetogglebutton.spec.ts
@@ -1,6 +1,6 @@
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 import { UIInstanceManager } from '../../src/ts/uimanager';
-import { PictureInPictureToggleButton } from '../../src/ts/components/pictureInPicturetogglebutton';
+import { PictureInPictureToggleButton } from '../../src/ts/components/pictureinpicturetogglebutton';
 import { ViewMode } from 'bitmovin-player';
 
 let playerMock: TestingPlayerAPI;

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -771,19 +771,7 @@ export class PlayerWrapper {
     // Collect all members of the player (public API methods and properties of the player)
     const objectProtoPropertyNames = Object.getOwnPropertyNames(Object.getPrototypeOf({}));
     const namesToIgnore = ['constructor', ...objectProtoPropertyNames];
-    const getAllPropertyNames = ((target: PlayerAPI) => {
-      let names: string[] = [];
-
-      while (target) {
-        names = names.concat(Object.getOwnPropertyNames(target).filter(name => namesToIgnore.indexOf(name) === -1));
-        // go up prototype chain
-        target = Object.getPrototypeOf(target);
-      }
-
-      return names;
-    });
-
-    const members = getAllPropertyNames(player);
+    const members = getAllPropertyNames(player).filter(name => namesToIgnore.indexOf(name) === -1);
     // Split the members into methods and properties
     let methods = <any[]>[];
     let properties = <any[]>[];
@@ -911,3 +899,14 @@ export class PlayerWrapper {
   }
 }
 
+function getAllPropertyNames(target: PlayerAPI): string[] {
+  let names: string[] = [];
+
+  while (target) {
+    names = names.concat(Object.getOwnPropertyNames(target));
+    // go up prototype chain
+    target = Object.getPrototypeOf(target);
+  }
+
+  return names;
+}

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -769,12 +769,21 @@ export class PlayerWrapper {
     this.player = player;
 
     // Collect all members of the player (public API methods and properties of the player)
-    // (Object.getOwnPropertyNames(player) does not work with the player TypeScript class starting in 7.2)
-    let members: string[] = [];
-    for (let member in player) {
-      members.push(member);
-    }
+    const objectProtoPropertyNames = Object.getOwnPropertyNames(Object.getPrototypeOf({}));
+    const namesToIgnore = ['constructor', ...objectProtoPropertyNames];
+    const getAllPropertyNames = ((target: PlayerAPI) => {
+      let names: string[] = [];
 
+      while (target) {
+        names = names.concat(Object.getOwnPropertyNames(target).filter(name => namesToIgnore.indexOf(name) === -1));
+        // go up prototype chain
+        target = Object.getPrototypeOf(target);
+      }
+
+      return names;
+    });
+
+    const members = getAllPropertyNames(player);
     // Split the members into methods and properties
     let methods = <any[]>[];
     let properties = <any[]>[];

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -903,7 +903,8 @@ function getAllPropertyNames(target: PlayerAPI): string[] {
   let names: string[] = [];
 
   while (target) {
-    names = names.concat(Object.getOwnPropertyNames(target));
+    const newNames = Object.getOwnPropertyNames(target).filter(name => names.indexOf(name) === -1);
+    names = names.concat(newNames);
     // go up prototype chain
     target = Object.getPrototypeOf(target);
   }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -899,7 +899,7 @@ export class PlayerWrapper {
   }
 }
 
-function getAllPropertyNames(target: PlayerAPI): string[] {
+function getAllPropertyNames(target: Object): string[] {
   let names: string[] = [];
 
   while (target) {


### PR DESCRIPTION
Fixing two build-breaking errors:

1. https://github.com/bitmovin/bitmovin-player-ui/pull/312 broke wrapping getters and setters in `uimanager.ts` and made the corresponding unit tests fail.
  The reason is that since TypeScript 3.9 getters and setters are no longer enumerable properties and thus the `for...in` loop we are using does not iterate over such properties anymore.
  https://github.com/bitmovin/bitmovin-player-ui/blob/f7847b64f6323a8a027cf7f998bf3c116857ace8/src/ts/uimanager.ts#L771-L776
  Side note: Currently all getters/setters on the player object are actually defined as enumerable properties which means the cases that the broken unit tests are covering are currently not relevant, they might have been in the past or become in the future.

2. https://github.com/bitmovin/bitmovin-player-ui/pull/307 had an [import error](https://travis-ci.org/github/bitmovin/bitmovin-player-ui/builds/743004941) in a spec file

