### PR TITLE
Export the method to create modernUI container object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## develop
+
+### Changed
+- Exported builder method for `modernUI`
+
 ## [3.21.0] - 2020-12-03
 
 ### Added
@@ -13,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.20.0] - 2020-11-25
 
 ### Fixed
-- Wrapping possibly not enumerable poperties of player object, like getters and setters
+- Wrapping possibly not enumerable properties of player object, like getters and setters
 
 ## [3.19.0] - 2020-11-10
 

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -60,7 +60,7 @@ export namespace UIFactory {
     return UIFactory.buildModernCastReceiverUI(player, config);
   }
 
-  function modernUI() {
+  export function modernUI() {
     let subtitleOverlay = new SubtitleOverlay();
 
     let mainSettingsPanelPage = new SettingsPanelPage({


### PR DESCRIPTION
Exporting `bitmovin.playerui.UIFactory.modernUI()` method to allow application to create and use the UIContainer for a easy customization without needing to build and deploy the player UI JS.

For example hideDelay parameter can be easily customized using below code if `bitmovin.playerui.UIFactory.modernUI()` is exported as public. So if there is no side effect of making it public, it will allow for easy customizations for some cases like below.

  ```
var modernUI = new bitmovin.playerui.UIFactory.modernUI();
  modernUI.config.hideDelay = 5000;
  var modernSmallScreenUI = new bitmovin.playerui.UIFactory.modernSmallScreenUI();
  modernSmallScreenUI.config.hideDelay = 10000;

  var mainUIManager = new bitmovin.playerui.UIManager(player, [{
      ui: modernSmallScreenUI,
      condition: (context) => {
        return !context.isAd && !context.adRequiresUi && context.isMobile
          && context.documentWidth < smallScreenSwitchWidth;
      },
    }, {
      ui: modernUI,
      condition: (context) => {
        return !context.isAd && !context.adRequiresUi;
      },
    }], config);
```