### PR TITLE
Configurable hide UI when hovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## develop
 
 ### Added
-- Add `UIConfig#disableAutoHideWhenHovered` config property to disable auto hiding of UI when an element in `ControlBar` is currently hovered
+- `UIConfig#disableAutoHideWhenHovered` config property to disable auto hiding of UI when an element in `ControlBar` is currently hovered
 
 ### Changed
 - Exported builder method for `modernUI`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## develop
 
+### Added
+- Add `UIConfig#disableAutoHideWhenHovered` config property to disable auto hiding of UI when an element in `ControlBar` is currently hovered
+
 ### Changed
 - Exported builder method for `modernUI`
 

--- a/src/ts/components/controlbar.ts
+++ b/src/ts/components/controlbar.ts
@@ -72,7 +72,5 @@ export class ControlBar extends Container<ControlBarConfig> {
     uimanager.onControlsHide.subscribe(() => {
       this.hide();
     });
-
-
   }
 }

--- a/src/ts/components/controlbar.ts
+++ b/src/ts/components/controlbar.ts
@@ -36,28 +36,26 @@ export class ControlBar extends Container<ControlBarConfig> {
     // Counts how many components are hovered and block hiding of the control bar
     let hoverStackCount = 0;
 
-    if (uimanager.getConfig().disableAutoHideWhenHovered) {
-      // only enabling this for non-mobile platforms without touch input. enabling this
-      // for touch devices causes the UI to not disappear after the standard few seconds.
-      // Instead, it will stay visible until another manual action is performed.
-      if (!BrowserUtils.isMobile) {
-        // Track hover status of child components
-        UIUtils.traverseTree(this, (component) => {
-          // Do not track hover status of child containers or spacers, only of 'real' controls
-          if (component instanceof Container || component instanceof Spacer) {
-            return;
-          }
+    // only enabling this for non-mobile platforms without touch input. enabling this
+    // for touch devices causes the UI to not disappear after hideDelay seconds.
+    // Instead, it will stay visible until another manual interaction is performed.
+    if (uimanager.getConfig().disableAutoHideWhenHovered && !BrowserUtils.isMobile) {
+      // Track hover status of child components
+      UIUtils.traverseTree(this, (component) => {
+        // Do not track hover status of child containers or spacers, only of 'real' controls
+        if (component instanceof Container || component instanceof Spacer) {
+          return;
+        }
 
-          // Subscribe hover event and keep a count of the number of hovered children
-          component.onHoverChanged.subscribe((sender, args) => {
-            if (args.hovered) {
-              hoverStackCount++;
-            } else {
-              hoverStackCount--;
-            }
-          });
+        // Subscribe hover event and keep a count of the number of hovered children
+        component.onHoverChanged.subscribe((_, args) => {
+          if (args.hovered) {
+            hoverStackCount++;
+          } else {
+            hoverStackCount--;
+          }
         });
-      }
+      });
     }
 
     uimanager.onControlsShow.subscribe(() => {

--- a/src/ts/components/controlbar.ts
+++ b/src/ts/components/controlbar.ts
@@ -4,6 +4,7 @@ import {UIUtils} from '../uiutils';
 import {Spacer} from './spacer';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
+import { BrowserUtils } from '../browserutils';
 
 /**
  * Configuration interface for the {@link ControlBar}.
@@ -32,12 +33,46 @@ export class ControlBar extends Container<ControlBarConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
+    // Counts how many components are hovered and block hiding of the control bar
+    let hoverStackCount = 0;
+
+    if (uimanager.getConfig().disableAutoHideWhenHovered) {
+      // only enabling this for non-mobile platforms without touch input. enabling this
+      // for touch devices causes the UI to not disappear after the standard few seconds.
+      // Instead, it will stay visible until another manual action is performed.
+      if (!BrowserUtils.isMobile) {
+        // Track hover status of child components
+        UIUtils.traverseTree(this, (component) => {
+          // Do not track hover status of child containers or spacers, only of 'real' controls
+          if (component instanceof Container || component instanceof Spacer) {
+            return;
+          }
+
+          // Subscribe hover event and keep a count of the number of hovered children
+          component.onHoverChanged.subscribe((sender, args) => {
+            if (args.hovered) {
+              hoverStackCount++;
+            } else {
+              hoverStackCount--;
+            }
+          });
+        });
+      }
+    }
+
     uimanager.onControlsShow.subscribe(() => {
       this.show();
+    });
+
+    uimanager.onPreviewControlsHide.subscribe((sender, args) => {
+      // Cancel the hide event if hovered child components block hiding
+      args.cancel = (hoverStackCount > 0);
     });
 
     uimanager.onControlsHide.subscribe(() => {
       this.hide();
     });
+
+
   }
 }

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -69,7 +69,9 @@ export interface UIConfig {
    */
   playbackSpeedSelectionEnabled?: boolean;
   /**
-   * Specifies if the player controls including `SettingsPanel` should auto hide when still hovered
+   * Specifies if the player controls including `SettingsPanel` should auto hide when still hovered. This
+   * configuration does not apply to mobile platforms. On mobile platforms the `SettingsPanel` is by default
+   * configured to not auto-hide and the behaviour cannot be changed using this configuration.
    * Default: false
    */
   disableAutoHideWhenHovered?: boolean;

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -69,6 +69,11 @@ export interface UIConfig {
    */
   playbackSpeedSelectionEnabled?: boolean;
   /**
+   * Specifies if the player controls including `SettingsPanel` should auto hide when still hovered
+   * Default: false
+   */
+  disableAutoHideWhenHovered?: boolean;
+  /**
    * Specifies the seekbar snapping range in percentage
    * Default: 1
    */

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -146,6 +146,7 @@ export class UIManager {
     this.config = {
       playbackSpeedSelectionEnabled: true, // Switch on speed selector by default
       autoUiVariantResolve: true, // Switch on auto UI resolving by default
+      disableAutoHideWhenHovered: false, // Disable auto hide when UI is hovered
       ...uiconfig,
       events: {
         onUpdated: new EventDispatcher<UIManager, void>(),


### PR DESCRIPTION
**Issue**
Currently controls bar auto hides in hide delay seconds even if user is hovering over any of the elements like settings panel etc. There is no configuration option to disable auto hiding in this case. 

For a little background, the default behaviour was disabling auto hide when hovered but this was changed with #272 

The reason for this change was behaviour on touch devices(Android, iOS) where tapping on an element in control bar would make it stay forever until user again taps to dismiss it. But at the same time the behaviour changed for non-touch devices like Desktop causing controls to auto hide.

**Fix**
- Bring in changes removed in #272 + additionally limit the change to non-mobile devices
- Add a configuration option to allow disabling auto hiding on hover instead of making it default behaviour. Default 
   behaviour still remains to auto hide.
- The mobile devices are already good with default behaviour as some of important elements like SettingsPanel 
   that would benefit with this configuration are configured to not auto-hide by default.

