### PR TITLE
Remove blacklist/whitelist terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## develop
+
+### Changed
+- Replace "whitelist" terminology with "allowlist"
 
 ## [3.22.0] - 2020-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## develop
 
 ### Changed
-- Default error message for code `1105` uses the term "allowlist" instead of "whitelist"
+- Default error message for code `1105` now uses the term "allowlist"
 
 ## [3.22.0] - 2020-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## develop
 
 ### Changed
-- Replace "whitelist" terminology with "allowlist"
+- Default error message for code `1105` uses the term "allowlist" instead of "whitelist"
 
 ## [3.22.0] - 2020-12-22
 

--- a/src/ts/errorutils.ts
+++ b/src/ts/errorutils.ts
@@ -11,7 +11,7 @@ export namespace ErrorUtils {
     1102: 'No configuration was provided',
     1103: 'The license is not valid',
     1104: 'The the domain-locked player is not authorized to playback on this domain',
-    1105: 'The domain is not whitelisted',
+    1105: 'The domain is not allowlisted',
     1106: 'The license server URL is invalid',
     1107: 'The impression server URL is invalid',
     1108: 'Could not initialize a rendering engine',


### PR DESCRIPTION
Replace "whitelist" terminology with "allowlist" in error message.
There were no "blacklist" or similar terms.