### PR TITLE
Add missing comparison link to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[3.23.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.22.0...v3.23.0
 [3.22.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.21.0...v3.22.0
 [3.21.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.20.0...v3.21.0
 [3.20.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.19.0...v3.20.0


### PR DESCRIPTION
During the last UI release, I forgot to add the comparison link to the CHANGELOG. This PR adds the missing comparison link.