### PR TITLE
Handle PlaylistTransition event for Mobile v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## develop
+
+### Added
+- Support for `PlaylistTransition` event which is only present on Mobile V3
+
 ## [3.23.0] - 2021-01-14
 
 ### Changed

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -364,4 +364,11 @@ export class PlayerEventEmitter {
       type: 'viewmodeavailabilitychanged' as any,
     });
   }
+
+  firePlaylistTransitionEvent(): void {
+    this.fireEvent<any>({
+      timestamp: Date.now(),
+      type: 'playlisttransition',
+    });
+  }
 }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -184,11 +184,22 @@ export class UIManager {
 
     updateConfig();
 
-    // Update the configuration when a new source is loaded
-    this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.SourceLoaded, () => {
+    // Update the source configuration when a new source is loaded and dispatch onUpdated
+    const updateSource = () => {
       updateConfig();
       this.config.events.onUpdated.dispatch(this);
-    });
+    };
+
+    this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.SourceLoaded, updateSource);
+
+    // The PlaylistTransition event is only available on Mobile v3 for now.
+    // This event is fired when a new source becomes active in the player.
+    if ((this.player.exports.PlayerEvent as any).PlaylistTransition) {
+      this.managerPlayerWrapper.getPlayer().on(
+        (this.player.exports.PlayerEvent as any).PlaylistTransition,
+        updateSource,
+      );
+    }
 
     if (uiconfig.container) {
       // Unfortunately "uiContainerElement = new DOM(config.container)" will not accept the container with


### PR DESCRIPTION
## Description
As the Mobile SDKs introduce a new major version that supports playlists we need to add support for this in the UI as well.

### Problem
The UI doesn't know about the playlist context for now and does not update the components.

### Solution
Listen to the `PlaylistTransition` event (introduced with mobile v3) which indicates that the playlist transitioned to a new source. When this event occurs we need to update the UI accordingly to display the data from the new source. 
To achieve this we reuse the `onUpdated` event of the `UIManager` which is already in place and dispatched in the UI when a `SourceLoaded` event occurs. We can't reuse the `SourceLoaded` event for this as this event got a new behaviour in v3 and is fired for each source individually.