### PR TITLE
Restrict focus visibility of controls to keyboard interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for `PlaylistTransition` event which is only present on Mobile V3
 
+### Fixed
+- Controls' focus highlighting is shown in case of non-keyboard interaction on some browsers/platforms
+
 ## [3.23.0] - 2021-01-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## develop
+
+### Fixed
+- Controls' focus highlighting is shown in case of non-keyboard interaction on some browsers/platforms
+
 ## [3.24.0] - 2021-02-16
 
 ### Added
 - Support for `PlaylistTransition` event which is only present on Mobile V3
-
-### Fixed
-- Controls' focus highlighting is shown in case of non-keyboard interaction on some browsers/platforms
 
 ## [3.23.0] - 2021-01-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,10 +1351,33 @@
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
     },
+    "@types/jsdom": {
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-12.2.4.tgz",
+      "integrity": "sha512-q+De3S/Ri6U9uPx89YA1XuC+QIBgndIfvBaaJG0pRT8Oqa75k4Mr7G9CRZjIvlbLGIukO/31DFGFJYlQBmXf/A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^4.0.0"
+      }
+    },
+    "@types/node": {
+      "version": "14.14.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.26.tgz",
+      "integrity": "sha512-skWxepWOs+VArEBWd2S/VR3wUavioIIx9/HzW+UJiIjtwa6+kNXdsOeq7FfxDXf56hIcL0ieo2brwMgBJ1+lhw==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/bitmovin/bitmovin-player-ui#readme",
   "devDependencies": {
     "@types/jest": "^24.0.11",
+    "@types/jsdom": "^12.2.4",
     "autoprefixer": "^6.5.2",
     "bitmovin-player": "^8.28.0",
     "browser-sync": "^2.26.3",

--- a/spec/focusvisibilitytracker.spec.ts
+++ b/spec/focusvisibilitytracker.spec.ts
@@ -19,7 +19,7 @@ describe('FocusVisibilityTracker', () => {
   });
 
   it('should add the focus-visible class on a UI button that gets focus w/o initial interaction', () => {
-    // Tinitially , the last interaction is set to keyboard to cover case of htting TAB from the adress bar which would
+    // Initially, the last interaction is set to keyboard. To cover the case of hitting TAB from the address bar which would
     // not trigger a keydown event.
     uiButton.focus();
 

--- a/spec/focusvisibilitytracker.spec.ts
+++ b/spec/focusvisibilitytracker.spec.ts
@@ -1,0 +1,96 @@
+import { JSDOM } from 'jsdom';
+import { FocusVisibilityTracker } from '../src/ts/focusvisibilitytracker';
+
+describe('FocusVisibilityTracker', () => {
+  const bitmovinUIPrefix = 'bmpui';
+  const uiButtonId = `${bitmovinUIPrefix}-some-button`;
+  const nonUiButtonId = 'some-button';
+  const focusVisibileClassName = '{{PREFIX}}-focus-visible';
+  let document: Document;
+  let uiButton: HTMLElement;
+  let nonUiButton: HTMLElement;
+  let tracker: FocusVisibilityTracker;
+
+  beforeEach(() => {
+    const dom = new JSDOM();
+    document = dom.window.document;
+    uiButton = createAndAddButton(document, uiButtonId);
+    nonUiButton = createAndAddButton(document, nonUiButtonId);
+
+    // make x instance of Element/DOMTokenList checks work
+    global.Element = dom.window.Element;
+    global.DOMTokenList = dom.window.DOMTokenList;
+
+    tracker = new FocusVisibilityTracker(document, bitmovinUIPrefix);
+  });
+
+  it('should add the focus-visible class on a UI button that gets focus w/o initial interaction', () => {
+    // Tinitially , the last interaction is set to keyboard to cover case of htting TAB from the adress bar which would
+    // not trigger a keydown event.
+    uiButton.focus();
+
+    expect(uiButton.classList.contains(focusVisibileClassName)).toBe(true);
+    expect(nonUiButton.classList.contains(focusVisibileClassName)).toBe(false);
+  });
+
+  it('should add the focus-visible class on a UI button that gets focus after a keydown event', () => {
+    dispatchEvent(document, 'MouseEvent', 'mousedown');
+    dispatchEvent(document, 'KeyboardEvent', 'keydown');
+
+    uiButton.focus();
+
+    expect(uiButton.classList.contains(focusVisibileClassName)).toBe(true);
+    expect(nonUiButton.classList.contains(focusVisibileClassName)).toBe(false);
+  });
+
+  // TODO: Add '${'PointerEvent'} | ${'pointerdown'}' once fixed in jsdom, see
+  // https://github.com/jsdom/jsdom/issues/2527
+  test.each`
+    eventInterface  | eventType
+    ${'MouseEvent'} | ${'mousedown'}
+    ${'TouchEvent'} | ${'touchstart'}
+  `(
+    'should not add the focus-visible class on a UI button that gets focus after a $eventType event',
+    ({ eventInterface, eventType }) => {
+      dispatchEvent(document, eventInterface, eventType);
+
+      uiButton.focus();
+
+      expect(uiButton.classList.contains(focusVisibileClassName)).toBe(false);
+      expect(nonUiButton.classList.contains(focusVisibileClassName)).toBe(
+        false
+      );
+    }
+  );
+
+  it('should remove the focus-visible class on a UI button once it loses focus', () => {
+    uiButton.focus();
+
+    uiButton.blur();
+
+    expect(uiButton.classList.contains(focusVisibileClassName)).toBe(false);
+    expect(nonUiButton.classList.contains(focusVisibileClassName)).toBe(false);
+  });
+
+  it('should remove event listeners upon release', () => {
+    const spy = jest.spyOn(global.document, 'removeEventListener');
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    tracker.release();
+
+    expect(spy).toHaveBeenCalledTimes(6);
+  });
+});
+
+function createAndAddButton(document: Document, id: string): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.id = id;
+  document.body.appendChild(button);
+  return button;
+};
+
+function dispatchEvent(document: Document, eventInterface: string, eventType: string): void {
+  const event = document.createEvent(eventInterface);
+  event.initEvent(eventType);
+  document.dispatchEvent(event);
+}

--- a/spec/focusvisibilitytracker.spec.ts
+++ b/spec/focusvisibilitytracker.spec.ts
@@ -18,7 +18,7 @@ describe('FocusVisibilityTracker', () => {
     tracker = new FocusVisibilityTracker(bitmovinUIPrefix);
   });
 
-  it('should add the focus-visible class on a UI button that gets focus w/o initial interaction', () => {
+  it('adds the focus-visible class on a UI button that gets focus w/o initial interaction', () => {
     // Initially, the last interaction is set to keyboard. To cover the case of hitting TAB from the address bar which would
     // not trigger a keydown event.
     uiButton.focus();
@@ -27,7 +27,7 @@ describe('FocusVisibilityTracker', () => {
     expect(nonUiButton.classList.contains(focusVisibileClassName)).toBe(false);
   });
 
-  it('should add the focus-visible class on a UI button that gets focus after a keydown event', () => {
+  it('adds the focus-visible class on a UI button that gets focus after a keydown event', () => {
     dispatchEvent(document, 'MouseEvent', 'mousedown');
     dispatchEvent(document, 'KeyboardEvent', 'keydown');
 
@@ -44,7 +44,7 @@ describe('FocusVisibilityTracker', () => {
     ${'MouseEvent'} | ${'mousedown'}
     ${'TouchEvent'} | ${'touchstart'}
   `(
-    'should not add the focus-visible class on a UI button that gets focus after a $eventType event',
+    'does not add the focus-visible class on a UI button that gets focus after a $eventType event',
     ({ eventInterface, eventType }) => {
       dispatchEvent(document, eventInterface, eventType);
 
@@ -55,7 +55,7 @@ describe('FocusVisibilityTracker', () => {
     }
   );
 
-  it('should remove the focus-visible class on a UI button once it loses focus', () => {
+  it('removes the focus-visible class on a UI button once it loses focus', () => {
     uiButton.focus();
 
     uiButton.blur();
@@ -64,7 +64,7 @@ describe('FocusVisibilityTracker', () => {
     expect(nonUiButton.classList.contains(focusVisibileClassName)).toBe(false);
   });
 
-  it('should remove event listeners upon release', () => {
+  it('removes event listeners upon release', () => {
     const spy = jest.spyOn(global.document, 'removeEventListener');
     expect(spy).toHaveBeenCalledTimes(0);
 

--- a/spec/focusvisibilitytracker.spec.ts
+++ b/spec/focusvisibilitytracker.spec.ts
@@ -6,22 +6,16 @@ describe('FocusVisibilityTracker', () => {
   const uiButtonId = `${bitmovinUIPrefix}-some-button`;
   const nonUiButtonId = 'some-button';
   const focusVisibileClassName = '{{PREFIX}}-focus-visible';
-  let document: Document;
   let uiButton: HTMLElement;
   let nonUiButton: HTMLElement;
   let tracker: FocusVisibilityTracker;
 
   beforeEach(() => {
-    const dom = new JSDOM();
-    document = dom.window.document;
+    const { window } = new JSDOM();
+    global.document = window.document;
     uiButton = createAndAddButton(document, uiButtonId);
     nonUiButton = createAndAddButton(document, nonUiButtonId);
-
-    // make x instance of Element/DOMTokenList checks work
-    global.Element = dom.window.Element;
-    global.DOMTokenList = dom.window.DOMTokenList;
-
-    tracker = new FocusVisibilityTracker(document, bitmovinUIPrefix);
+    tracker = new FocusVisibilityTracker(bitmovinUIPrefix);
   });
 
   it('should add the focus-visible class on a UI button that gets focus w/o initial interaction', () => {

--- a/spec/focusvisibilitytracker.spec.ts
+++ b/spec/focusvisibilitytracker.spec.ts
@@ -51,9 +51,7 @@ describe('FocusVisibilityTracker', () => {
       uiButton.focus();
 
       expect(uiButton.classList.contains(focusVisibileClassName)).toBe(false);
-      expect(nonUiButton.classList.contains(focusVisibileClassName)).toBe(
-        false
-      );
+      expect(nonUiButton.classList.contains(focusVisibileClassName)).toBe(false);
     }
   );
 

--- a/src/scss/skin-modern/_mixins.scss
+++ b/src/scss/skin-modern/_mixins.scss
@@ -138,4 +138,9 @@
     box-shadow: $focus-element-box-shadow;
     outline: none;
   }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: none;
+    outline: none;
+  }
 }

--- a/src/scss/skin-modern/_mixins.scss
+++ b/src/scss/skin-modern/_mixins.scss
@@ -139,7 +139,7 @@
     outline: none;
   }
 
-  &:focus:not(:focus-visible) {
+  &:focus:not(.#{$prefix}-focus-visible) {
     box-shadow: none;
     outline: none;
   }

--- a/src/scss/skin-modern/components/_uicontainer.scss
+++ b/src/scss/skin-modern/components/_uicontainer.scss
@@ -35,7 +35,7 @@
         box-shadow: inset -4px -3px 2px 9px $color-focus;
       }
 
-      &:focus:not(:focus-visible) {
+      &:focus:not(.#{$prefix}-focus-visible) {
         box-shadow: none;
       }
     }

--- a/src/scss/skin-modern/components/_uicontainer.scss
+++ b/src/scss/skin-modern/components/_uicontainer.scss
@@ -30,8 +30,14 @@
   }
 
   &.#{$prefix}-controls-shown {
-    .#{$prefix}-ui-hugeplaybacktogglebutton:focus {
-      box-shadow: inset -4px -3px 2px 9px $color-focus;
+    .#{$prefix}-ui-hugeplaybacktogglebutton {
+      &:focus {
+        box-shadow: inset -4px -3px 2px 9px $color-focus;
+      }
+
+      &:focus:not(:focus-visible) {
+        box-shadow: none;
+      }
     }
   }
 

--- a/src/ts/components/tvnoisecanvas.ts
+++ b/src/ts/components/tvnoisecanvas.ts
@@ -97,7 +97,7 @@ export class TvNoiseCanvas extends Component<ComponentConfig> {
     if (this.useAnimationFrame) {
       this.frameUpdateHandlerId = window.requestAnimationFrame(this.renderFrame.bind(this));
     } else {
-      this.frameUpdateHandlerId = setTimeout(this.renderFrame.bind(this), this.frameInterval);
+      this.frameUpdateHandlerId = window.setTimeout(this.renderFrame.bind(this), this.frameInterval);
     }
   }
 }

--- a/src/ts/focusvisibilitytracker.ts
+++ b/src/ts/focusvisibilitytracker.ts
@@ -64,7 +64,7 @@ function isBitmovinUi(element: Element, bitmovinUiPrefix: string): boolean {
   return element.id.indexOf(bitmovinUiPrefix) === 0;
 }
 
-function isHtmlElement(element: unknown): element is Element & { classList: DOMTokenList } {
+function isHtmlElement(element: unknown): element is HTMLElement & { classList: DOMTokenList } {
   return (
     element instanceof HTMLElement && element.classList instanceof DOMTokenList
   );

--- a/src/ts/focusvisibilitytracker.ts
+++ b/src/ts/focusvisibilitytracker.ts
@@ -1,4 +1,4 @@
-const FocusVisibleClassName = '{{PREFIX}}-focus-visible';
+const FocusVisibleCssClassName = '{{PREFIX}}-focus-visible';
 
 export class FocusVisibilityTracker {
   private readonly eventHandlerMap: { [eventName: string]: EventListenerOrEventListenerObject };
@@ -31,15 +31,15 @@ export class FocusVisibilityTracker {
       this.lastInteractionWasKeyboard &&
       isHtmlElement(element) &&
       isBitmovinUi(element, this.bitmovinUiPrefix) &&
-      !element.classList.contains(FocusVisibleClassName)
+      !element.classList.contains(FocusVisibleCssClassName)
     ) {
-      element.classList.add(FocusVisibleClassName);
+      element.classList.add(FocusVisibleCssClassName);
     }
   };
 
   private onBlur = ({ target: element }: FocusEvent) => {
     if (isHtmlElement(element)) {
-      element.classList.remove(FocusVisibleClassName);
+      element.classList.remove(FocusVisibleCssClassName);
     }
   };
 

--- a/src/ts/focusvisibilitytracker.ts
+++ b/src/ts/focusvisibilitytracker.ts
@@ -4,7 +4,7 @@ export class FocusVisibilityTracker {
   private readonly eventHandlerMap: { [eventName: string]: EventListenerOrEventListenerObject };
   private lastInteractionWasKeyboard: boolean = true;
 
-  constructor(document: Document, private bitmovinUiPrefix: string) {
+  constructor(private bitmovinUiPrefix: string) {
     this.eventHandlerMap = {
       mousedown: this.onMouseOrPointerOrTouch,
       pointerdown: this.onMouseOrPointerOrTouch,
@@ -13,7 +13,7 @@ export class FocusVisibilityTracker {
       focus: this.onFocus,
       blur: this.onBlur,
     };
-    this.registerEventListeners(document);
+    this.registerEventListeners();
   }
 
   private onKeyDown = (e: KeyboardEvent) => {
@@ -43,7 +43,7 @@ export class FocusVisibilityTracker {
     }
   };
 
-  private registerEventListeners(document: Document): void {
+  private registerEventListeners(): void {
     for (const event in this.eventHandlerMap) {
       document.addEventListener(event, this.eventHandlerMap[event], true);
     }

--- a/src/ts/focusvisibilitytracker.ts
+++ b/src/ts/focusvisibilitytracker.ts
@@ -1,0 +1,71 @@
+const FocusVisibleClassName = '{{PREFIX}}-focus-visible';
+
+export class FocusVisibilityTracker {
+  private readonly eventHandlerMap: { [eventName: string]: EventListenerOrEventListenerObject };
+  private lastInteractionWasKeyboard: boolean = true;
+
+  constructor(document: Document, private bitmovinUiPrefix: string) {
+    this.eventHandlerMap = {
+      mousedown: this.onMouseOrPointerOrTouch,
+      pointerdown: this.onMouseOrPointerOrTouch,
+      touchstart: this.onMouseOrPointerOrTouch,
+      keydown: this.onKeyDown,
+      focus: this.onFocus,
+      blur: this.onBlur,
+    };
+    this.registerEventListeners(document);
+  }
+
+  private onKeyDown = (e: KeyboardEvent) => {
+    if (e.metaKey || e.altKey || e.ctrlKey) {
+      return;
+    }
+
+    this.lastInteractionWasKeyboard = true;
+  };
+
+  private onMouseOrPointerOrTouch = () => (this.lastInteractionWasKeyboard = false);
+
+  private onFocus = ({ target: element }: FocusEvent) => {
+    if (
+      this.lastInteractionWasKeyboard &&
+      isHtmlElement(element) &&
+      isBitmovinUi(element, this.bitmovinUiPrefix) &&
+      !element.classList.contains(FocusVisibleClassName)
+    ) {
+      element.classList.add(FocusVisibleClassName);
+    }
+  };
+
+  private onBlur = ({ target: element }: FocusEvent) => {
+    if (isHtmlElement(element)) {
+      element.classList.remove(FocusVisibleClassName);
+    }
+  };
+
+  private registerEventListeners(document: Document): void {
+    for (const event in this.eventHandlerMap) {
+      document.addEventListener(event, this.eventHandlerMap[event], true);
+    }
+  }
+
+  private unregisterEventListeners(): void {
+    for (const event in this.eventHandlerMap) {
+      document.removeEventListener(event, this.eventHandlerMap[event], true);
+    }
+  }
+
+  public release(): void {
+    this.unregisterEventListeners();
+  }
+}
+
+function isBitmovinUi(element: Element, bitmovinUiPrefix: string): boolean {
+  return element.id.indexOf(bitmovinUiPrefix) === 0;
+}
+
+function isHtmlElement(element: unknown): element is Element & { classList: DOMTokenList } {
+  return (
+    element instanceof HTMLElement && element.classList instanceof DOMTokenList
+  );
+}

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -333,7 +333,7 @@ export class UIManager {
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.ViewModeChanged, resolveUiVariant);
     }
 
-    this.focusVisibilityTracker = new FocusVisibilityTracker(document, '{{PREFIX}}');
+    this.focusVisibilityTracker = new FocusVisibilityTracker('{{PREFIX}}');
 
     // Initialize the UI
     resolveUiVariant(null);

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -11,6 +11,7 @@ import { TimelineMarker, UIConfig } from './uiconfig';
 import { PlayerAPI, PlayerEventCallback, PlayerEventBase, PlayerEvent, AdEvent, LinearAd } from 'bitmovin-player';
 import { VolumeController } from './volumecontroller';
 import { i18n, CustomVocabulary, Vocabularies } from './localization/i18n';
+import { FocusVisibilityTracker } from './focusvisibilitytracker';
 
 export interface LocalizationConfig {
   /**
@@ -95,6 +96,7 @@ export class UIManager {
   private currentUi: InternalUIInstanceManager;
   private config: InternalUIConfig; // Conjunction of provided uiConfig and sourceConfig from the player
   private managerPlayerWrapper: PlayerWrapper;
+  private focusVisibilityTracker: FocusVisibilityTracker;
 
   private events = {
     onUiVariantResolve: new EventDispatcher<UIManager, UIConditionContext>(),
@@ -331,6 +333,8 @@ export class UIManager {
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.ViewModeChanged, resolveUiVariant);
     }
 
+    this.focusVisibilityTracker = new FocusVisibilityTracker(document, '{{PREFIX}}');
+
     // Initialize the UI
     resolveUiVariant(null);
   }
@@ -489,6 +493,7 @@ export class UIManager {
       this.releaseUi(uiInstanceManager);
     }
     this.managerPlayerWrapper.clearEventHandlers();
+    this.focusVisibilityTracker.release();
   }
 
   /**


### PR DESCRIPTION
## Problem

There are inconsistencies across browsers on different platforms regarding if a button element receives focus upon click, see [here](https://zellwk.com/blog/inconsistent-button-behavior/#summary-of-the-results).

This causes UI controls to show a focus indicator upon clicking on certain platforms, like Chrome on Android. This is unintended behavior as the focus indicator should only be visible upon interaction via keyboard.

## Fix

There would be the CCS pseudo-class [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#selectively_showing_the_focus_indicator) that we could use and it applies only on elements where `:focus` applies and the focus should be indicated to the user e.g. caused by keyboard interaction [and similar](https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo).https://github.com/bitmovin/bitmovin-player-ui/commit/c83e95f5e925aae30d5aa150b44b4c0977a0b6cb demonstrates the usageof that. However, it is [not supported](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#browser_compatibility) on all browsers/platforms that we need to cover.

To cover old browsers/platforms like the WebView on Android KitKat we have now have a `FocusVisibilityTracker` that puts a `.bmpui-focus-visible` CCS class on the elements similarly as the native `:focus-visible` CCS pseudo-class would apply. 

### How it works
We're basically tracking `mousedown`, `pointerdown`, `touchstart`, and `keydown` events to determine which input method was last used. Once a UI element gets focus (`focus` event) and the last interaction was a keyboard we add the `.bmpui-focus-visible` class to that element to make the focus visible. Once it loses the focus again (`blur` event) we're removing that CCS class again.