### PR TITLE
Add CI step for publishing to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
 script:
   - npm test
   - gulp build-prod
+  - bash publish.sh
 cache:
   yarn: true
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Added
+- Build step to publish releases to npm via CI
+
 ## [3.24.0] - 2021-02-16
 
 ### Added
@@ -707,6 +712,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[develop]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.24.0...HEAD
 [3.24.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.23.0...v3.24.0
 [3.23.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.22.0...v3.23.0
 [3.22.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.21.0...v3.22.0

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -e
+
+PACKAGE_NAME="bitmovin-player-ui"
+CI_BRANCH=$TRAVIS_BRANCH
+
+if ! [[ "${CI_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+  echo "INFO ${CI_BRANCH} is not a valid version to be published, skipping"
+  exit 0
+fi
+
+CHANNEL=-1
+NPM_TAG=-1
+MAJOR=-1
+MINOR=-1
+POSTIFX=-1
+VERSION=-1
+
+DRY_RUN_CMD=
+if ($DRY_RUN); then
+    DRY_RUN_CMD="--dry-run"
+    echo "INFO performing a dry run"
+fi
+
+if [[ "${CI_BRANCH}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-?([a-z]*) ]]; then
+    MAJOR=${BASH_REMATCH[1]}
+    MINOR=${BASH_REMATCH[2]}
+    HOTFIX=${BASH_REMATCH[3]}
+    POSTFIX=${BASH_REMATCH[4]}
+    VERSION=${CI_BRANCH:1}
+    case ${POSTFIX} in
+        "b")
+            CHANNEL="beta"
+            NPM_TAG="beta"
+            ;;
+        "rc")
+            CHANNEL="staging"
+            NPM_TAG="staging"
+            ;;
+        "")
+            CHANNEL="stable"
+            NPM_TAG="latest"
+            ;;
+        *)
+            echo "ERROR postfix ${POSTFIX} not supported"
+            exit 1
+            ;;
+    esac
+elif [[ "${CI_BRANCH}" =~ ^nightly\/([0-9]{4})\/([0-9]{2})\/([0-9]{2}) ]]; then
+    CHANNEL="nightly"
+    YEAR=${BASH_REMATCH[1]}
+    MONTH=${BASH_REMATCH[2]}
+    DAY=${BASH_REMATCH[3]}
+    VERSION="${YEAR}.${MONTH}.${DAY}"
+    MAJOR=${YEAR}
+    MINOR=${MONTH}
+else
+    CHANNEL="dev"
+fi
+
+echo "INFO npm tag set to ${NPM_TAG}"
+if [[ ${NPM_TAG}  == -1 ]]; then
+    echo "ERROR npm tag ${NPM_TAG} not valid"
+    exit 1
+fi
+
+## Check if this version was already published.
+## If something went wrong during a later build step and we re-run the release
+## after fixing the problem, the npm publish would fail the build.
+IS_PUBLISHED=$(npm view ${PACKAGE_NAME}@${VERSION} dist-tags)
+
+if [[ ${IS_PUBLISHED} ]]; then
+    echo "WARNING ${VERSION} is already published, skipping."
+    exit 0
+else
+    echo "INFO ${VERSION} not published yet, publishing now"
+fi
+
+echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+chmod 0600 ~/.npmrc
+
+NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".${NPM_TAG}")
+echo "INFO latest npm version is $NPM_LATEST"
+
+# We always publish the package with the channel/latest tag because there is no way to publish a package without
+# a tag (the default tag is always "latest"). If the published version is older that the currently tagged version,
+# we have to revert the tag afterwards to avoid version regressions.
+echo "INFO publishing ${VERSION} to npm with tag "${NPM_TAG}" (current tagged version is ${NPM_LATEST})"
+npm publish --tag ${NPM_TAG} ${DRY_RUN_CMD}
+
+# Checks if one version is greater than the other
+# https://stackoverflow.com/a/24067243/370252
+# Edge cases:
+#  - if version_gt "7.3.2" "7.3.2" evaluates to false
+#    so this can't be used to overwrite an existing version
+#  - if version_gt "7.3.2" "7.3.2-0" evaluates to false
+#    prerelease versions are considered greater than the final release,
+#    but since we're splitting the versions into channels that is not important right now
+#    (as a workaround we could suffix "-zzzzz" to versions without a suffix)
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+
+if !$DRY_RUN && version_gt ${NPM_LATEST} ${VERSION}; then
+    # The version we just published is lower than the previously tagged version on npm, so we need to revert the
+    # tag to the previous version to avoid version downgrades (this e.g. avoids that a 7.2.5 hotfix release overwrites
+    # the latest-tagged 7.3.2)
+    echo "INFO reverting "${NPM_TAG}" tag from the just published version ${VERSION} to the greater ${NPM_LATEST}"
+    # It takes a while until the metadata after npm publish is updated so we need to wait to avoid a failed tag update
+    # "npm WARN dist-tag add latest is already set to version ${VERSION}"
+    sleep 10
+    npm dist-tag add ${PACKAGE_NAME}@${NPM_LATEST} ${NPM_TAG}
+fi


### PR DESCRIPTION
Publishes releases to npm, e.g.:

git branch/tag            | npm channel
---------------------|---------------
`v3.25.0`                    | `latest`
`v3.25.1`                    | `latest`
`v3.25.0-b.1`             | `beta`
`v3.25.0-rc.1`            | `staging`
`nightly/2021/02/15` | `nightly`
