### PR TITLE
[PW-4666] Support mobile v3 error events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## develop
 
+### Added
+- Support for Mobile V3 `PlayerError` and `SourceError` events
+
 ### Fixed
 - Controls' focus highlighting is shown in case of non-keyboard interaction on some browsers/platforms
 

--- a/spec/components/errormessageoverlay.spec.ts
+++ b/spec/components/errormessageoverlay.spec.ts
@@ -15,14 +15,14 @@ describe('ErrorMessageOverlay', () => {
       uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
     });
   
-    it('should add event listener for source loaded event', () => {
+    it('adds an event listener for source loaded event', () => {
       const onSpy = jest.spyOn(playerMock, 'on');
       errorMessageOverlay.configure(playerMock, uiInstanceManagerMock);
 
       expect(onSpy).toHaveBeenCalledWith(playerMock.exports.PlayerEvent.SourceLoaded, expect.any(Function));
     });
 
-    it('should add event listener for error event when not mobile v3', () => {
+    it('adds an event listener for error event when not mobile v3', () => {
       const onSpy = jest.spyOn(playerMock, 'on');
       errorMessageOverlay.configure(playerMock, uiInstanceManagerMock);
 
@@ -40,14 +40,14 @@ describe('ErrorMessageOverlay', () => {
         (playerMock.exports.PlayerEvent as any).PlaylistTransition = MobileV3PlayerEvent.PlaylistTransition;
       });
 
-      it('should add event listener for sourceerror and playererror when mobile v3', () => {
+      it('adds an event listener for sourceerror and playererror when mobile v3', () => {
         errorMessageOverlay.configure(playerMock, uiInstanceManagerMock);
   
         expect(onSpy).toHaveBeenCalledWith(MobileV3PlayerEvent.PlayerError, expect.any(Function));
         expect(onSpy).toHaveBeenCalledWith(MobileV3PlayerEvent.SourceError, expect.any(Function));
       });
   
-      it('should use message from the error event when mobile v3', () => {  
+      it('uses message from the error event when mobile v3', () => {  
         const setTextSpy = jest.spyOn(errorMessageOverlay['errorLabel'], 'setText');
   
         errorMessageOverlay['tvNoiseBackground'] = { start: () => {} } as any;

--- a/spec/components/errormessageoverlay.spec.ts
+++ b/spec/components/errormessageoverlay.spec.ts
@@ -1,0 +1,69 @@
+import { UIInstanceManager } from './../../src/ts/uimanager';
+import { ErrorMessageOverlay } from '../../src/ts/components/errormessageoverlay';
+import { MobileV3PlayerEvent } from '../../src/ts/mobilev3playerapi';
+import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
+
+describe('ErrorMessageOverlay', () => {
+  describe('configure', () => {
+    let errorMessageOverlay: ErrorMessageOverlay;
+    let playerMock: TestingPlayerAPI;
+    let uiInstanceManagerMock: UIInstanceManager;
+  
+    beforeEach(() => {
+      errorMessageOverlay = new ErrorMessageOverlay({});
+      playerMock = MockHelper.getPlayerMock();
+      uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+    });
+  
+    it('should add event listener for source loaded event', () => {
+      const onSpy = jest.spyOn(playerMock, 'on');
+      errorMessageOverlay.configure(playerMock, uiInstanceManagerMock);
+
+      expect(onSpy).toHaveBeenCalledWith(playerMock.exports.PlayerEvent.SourceLoaded, expect.any(Function));
+    });
+
+    it('should add event listener for error event when not mobile v3', () => {
+      const onSpy = jest.spyOn(playerMock, 'on');
+      errorMessageOverlay.configure(playerMock, uiInstanceManagerMock);
+
+      expect(onSpy).toHaveBeenCalledWith(playerMock.exports.PlayerEvent.Error, expect.any(Function));
+    });
+
+    describe('mobile v3 handling', () => {
+      let onSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        onSpy = jest.spyOn(playerMock, 'on');
+
+        (playerMock.exports.PlayerEvent as any).SourceError = MobileV3PlayerEvent.SourceError;
+        (playerMock.exports.PlayerEvent as any).PlayerError = MobileV3PlayerEvent.PlayerError;
+        (playerMock.exports.PlayerEvent as any).PlaylistTransition = MobileV3PlayerEvent.PlaylistTransition;
+      });
+
+      it('should add event listener for sourceerror and playererror when mobile v3', () => {
+        errorMessageOverlay.configure(playerMock, uiInstanceManagerMock);
+  
+        expect(onSpy).toHaveBeenCalledWith(MobileV3PlayerEvent.PlayerError, expect.any(Function));
+        expect(onSpy).toHaveBeenCalledWith(MobileV3PlayerEvent.SourceError, expect.any(Function));
+      });
+  
+      it('should use message from the error event when mobile v3', () => {  
+        const setTextSpy = jest.spyOn(errorMessageOverlay['errorLabel'], 'setText');
+  
+        errorMessageOverlay['tvNoiseBackground'] = { start: () => {} } as any;
+  
+        errorMessageOverlay.configure(playerMock, uiInstanceManagerMock);
+  
+        const playerErrorEvent = {
+          type: MobileV3PlayerEvent.PlayerError,
+          message: 'this is a player error',
+          name: 'playererror',
+        };
+        playerMock.eventEmitter.fireEvent<any>(playerErrorEvent);
+  
+        expect(onSpy).toHaveBeenCalledWith(MobileV3PlayerEvent.PlayerError, expect.any(Function));
+        expect(setTextSpy).toHaveBeenCalledWith(`${playerErrorEvent.message}\n(${playerErrorEvent.name})`);
+      });
+    });
+  });
+});

--- a/spec/components/errormessageoverlay.spec.ts
+++ b/spec/components/errormessageoverlay.spec.ts
@@ -57,12 +57,11 @@ describe('ErrorMessageOverlay', () => {
         const playerErrorEvent = {
           type: MobileV3PlayerEvent.PlayerError,
           message: 'this is a player error',
-          name: 'playererror',
         };
         playerMock.eventEmitter.fireEvent<any>(playerErrorEvent);
   
         expect(onSpy).toHaveBeenCalledWith(MobileV3PlayerEvent.PlayerError, expect.any(Function));
-        expect(setTextSpy).toHaveBeenCalledWith(`${playerErrorEvent.message}\n(${playerErrorEvent.name})`);
+        expect(setTextSpy).toHaveBeenCalledWith(playerErrorEvent.message);
       });
     });
   });

--- a/spec/errorutils.spec.ts
+++ b/spec/errorutils.spec.ts
@@ -1,0 +1,36 @@
+import { MobileV3PlayerErrorEvent } from '../src/ts/mobilev3playerapi';
+import { ErrorUtils } from '../src/ts/errorutils';
+import defaultMobileV3ErrorMessageTranslator = ErrorUtils.defaultMobileV3ErrorMessageTranslator;
+import { ErrorEvent } from 'bitmovin-player';
+import defaultWebErrorMessageTranslator = ErrorUtils.defaultWebErrorMessageTranslator;
+
+describe('ErrorUtils', () => {
+  describe('defaultMobileV3ErrorMessageTranslator', () => {
+    it('should translate the error event to an error message', () => {
+      const errorName = 'onPlayerError';
+      const errorMessage = 'something went horribly wrong';
+      const playerErrorEvent = { message: errorMessage, name: errorName } as MobileV3PlayerErrorEvent;
+
+      expect(defaultMobileV3ErrorMessageTranslator(playerErrorEvent)).toEqual(`${errorMessage}\n(${errorName})`);
+    });
+  });
+
+  describe('defaultWebErrorMessageTranslator', () => {
+    it('should map the error code to the error message and return it', () => {
+      const errorCode = 2100;
+      const errorName = 'player-error';
+      const errorEvent = { code: errorCode, name: errorName } as ErrorEvent;
+      const expectedErrorMessage = ErrorUtils.defaultErrorMessages[errorCode];
+
+      expect(defaultWebErrorMessageTranslator(errorEvent)).toEqual(`${expectedErrorMessage}\n(${errorName})`);
+    });
+
+    it('should fall back to returning the error code and name if the associated error message could not be found', () => {
+      const errorCode = 9999;
+      const errorName = 'unknown-error';
+      const errorEvent = { code: errorCode, name: errorName } as ErrorEvent;
+
+      expect(defaultWebErrorMessageTranslator(errorEvent)).toEqual(`${errorCode} ${errorName}`);
+    });
+  });
+});

--- a/spec/errorutils.spec.ts
+++ b/spec/errorutils.spec.ts
@@ -6,7 +6,7 @@ import defaultWebErrorMessageTranslator = ErrorUtils.defaultWebErrorMessageTrans
 
 describe('ErrorUtils', () => {
   describe('defaultMobileV3ErrorMessageTranslator', () => {
-    it('should translate the error event to an error message', () => {
+    it('translates the error event to an error message', () => {
       const errorMessage = 'something went horribly wrong';
       const playerErrorEvent = { message: errorMessage } as MobileV3PlayerErrorEvent;
 
@@ -15,7 +15,7 @@ describe('ErrorUtils', () => {
   });
 
   describe('defaultWebErrorMessageTranslator', () => {
-    it('should map the error code to the error message and return it', () => {
+    it('maps the error code to the error message and return it', () => {
       const errorCode = 2100;
       const errorName = 'player-error';
       const errorEvent = { code: errorCode, name: errorName } as ErrorEvent;
@@ -24,7 +24,7 @@ describe('ErrorUtils', () => {
       expect(defaultWebErrorMessageTranslator(errorEvent)).toEqual(`${expectedErrorMessage}\n(${errorName})`);
     });
 
-    it('should fall back to returning the error code and name if the associated error message could not be found', () => {
+    it('falls back to returning the error code and name if the associated error message could not be found', () => {
       const errorCode = 9999;
       const errorName = 'unknown-error';
       const errorEvent = { code: errorCode, name: errorName } as ErrorEvent;

--- a/spec/errorutils.spec.ts
+++ b/spec/errorutils.spec.ts
@@ -7,11 +7,10 @@ import defaultWebErrorMessageTranslator = ErrorUtils.defaultWebErrorMessageTrans
 describe('ErrorUtils', () => {
   describe('defaultMobileV3ErrorMessageTranslator', () => {
     it('should translate the error event to an error message', () => {
-      const errorName = 'onPlayerError';
       const errorMessage = 'something went horribly wrong';
-      const playerErrorEvent = { message: errorMessage, name: errorName } as MobileV3PlayerErrorEvent;
+      const playerErrorEvent = { message: errorMessage } as MobileV3PlayerErrorEvent;
 
-      expect(defaultMobileV3ErrorMessageTranslator(playerErrorEvent)).toEqual(`${errorMessage}\n(${errorName})`);
+      expect(defaultMobileV3ErrorMessageTranslator(playerErrorEvent)).toEqual(errorMessage);
     });
   });
 

--- a/spec/mobilev3playerapi.spec.ts
+++ b/spec/mobilev3playerapi.spec.ts
@@ -1,0 +1,26 @@
+import { PlayerAPI } from 'bitmovin-player';
+import { isMobileV3PlayerAPI, MobileV3PlayerAPI, MobileV3PlayerEvent } from '../src/ts/mobilev3playerapi';
+import { PlayerWrapper } from '../src/ts/uimanager';
+
+describe('isMobileV3PlayerAPI', () => {
+  const playerApi = { exports: { PlayerEvent: { } } } as PlayerAPI;
+  const mobileV3PlayerApi = { exports: { PlayerEvent: MobileV3PlayerEvent } } as unknown as MobileV3PlayerAPI;
+  const wrappedPlayerApi = new PlayerWrapper(playerApi);
+  const wrappedMobileV3PlayerApi = new PlayerWrapper(mobileV3PlayerApi);
+
+  it('should return false for a regular PlayerAPI instance', () => {
+    expect(isMobileV3PlayerAPI(playerApi)).toBeFalsy();
+  });
+
+  it('should return false for a regular wrapped PlayerAPI instance', () => {
+    expect(isMobileV3PlayerAPI(wrappedPlayerApi.getPlayer())).toBeFalsy();
+  });
+
+  it('should return true for a mobile v3 PlayerAPI instance', () => {
+    expect(isMobileV3PlayerAPI(mobileV3PlayerApi)).toBeTruthy();
+  });
+
+  it('should return false for a mobile v3 wrapped PlayerAPI instance', () => {
+    expect(isMobileV3PlayerAPI(wrappedMobileV3PlayerApi.getPlayer())).toBeTruthy();
+  });
+});

--- a/spec/uimanager.spec.ts
+++ b/spec/uimanager.spec.ts
@@ -1,6 +1,7 @@
 import { InternalUIConfig, PlayerWrapper, UIManager } from '../src/ts/uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 import { MockHelper, TestingPlayerAPI } from './helper/MockHelper';
+import { MobileV3PlayerEvent } from '../src/ts/mobilev3playerapi';
 
 jest.mock('../src/ts/dom');
 
@@ -75,7 +76,9 @@ describe('UIManager', () => {
     });
     describe('when a PlaylistTransition event is part of PlayerEvent', () => {
       beforeEach(() => {
-        (playerMock.exports.PlayerEvent as any).PlaylistTransition = 'playlisttransition';
+        (playerMock.exports.PlayerEvent as any).SourceError = MobileV3PlayerEvent.SourceError;
+        (playerMock.exports.PlayerEvent as any).PlayerError = MobileV3PlayerEvent.PlayerError;
+        (playerMock.exports.PlayerEvent as any).PlaylistTransition = MobileV3PlayerEvent.PlaylistTransition;
       });
       it('attaches the listener', () => {
         const onSpy = jest.spyOn(playerMock, 'on');

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -5,6 +5,7 @@ import {TvNoiseCanvas} from './tvnoisecanvas';
 import {ErrorUtils } from '../errorutils';
 import { ErrorEvent, PlayerAPI, PlayerEventBase } from 'bitmovin-player';
 import {
+  isMobileV3PlayerAPI,
   MobileV3PlayerAPI, MobileV3PlayerErrorEvent, MobileV3PlayerEvent, MobileV3SourceErrorEvent,
 } from '../mobilev3playerapi';
 
@@ -172,16 +173,4 @@ function customizeErrorMessage(
   }
 
   return message;
-}
-
-function isMobileV3PlayerAPI(player: PlayerAPI | MobileV3PlayerAPI): player is MobileV3PlayerAPI {
-  let everyKeyExists = true;
-
-  for (const key in MobileV3PlayerEvent) {
-    if (MobileV3PlayerEvent.hasOwnProperty(key) && !player.exports.PlayerEvent.hasOwnProperty(key)) {
-      everyKeyExists = false;
-    }
-  }
-
-  return everyKeyExists;
 }

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -153,24 +153,19 @@ function customizeErrorMessage(
   errorMessages: ErrorMessageTranslator | ErrorMessageMap,
   event: ErrorEvent | MobileV3PlayerErrorEvent | MobileV3SourceErrorEvent,
 ): string | undefined {
-  let message = undefined;
-  // Process message vocabularies
-  if (errorMessages) {
-    if (typeof errorMessages === 'function') {
-      // Translation function for all errors
-      message = errorMessages(event);
-    } else if (errorMessages[event.code]) {
-      // It's not a translation function, so it must be a map of strings or translation functions
-      let customMessage = errorMessages[event.code];
-
-      if (typeof customMessage === 'string') {
-        message = customMessage;
-      } else {
-        // The message is a translation function, so we call it
-        message = customMessage(event);
-      }
-    }
+  if (!errorMessages) {
+    return undefined;
   }
 
-  return message;
+  // Process message vocabularies
+  if (typeof errorMessages === 'function') {
+    // Translation function for all errors
+    return errorMessages(event);
+  }
+  if (errorMessages[event.code]) {
+    // It's not a translation function, so it must be a map of strings or translation functions
+    const customMessage = errorMessages[event.code];
+
+    return typeof customMessage === 'string' ? customMessage : customMessage(event);
+  }
 }

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -2,21 +2,11 @@ import {ContainerConfig, Container} from './container';
 import {Label, LabelConfig} from './label';
 import {UIInstanceManager} from '../uimanager';
 import {TvNoiseCanvas} from './tvnoisecanvas';
-import {ErrorUtils, MobileV3PlayerErrorEvent, MobileV3SourceErrorEvent } from '../errorutils';
-import { ErrorEvent, PlayerAPI, PlayerEventBase, PlayerEvent, PlayerEventCallback } from 'bitmovin-player';
-
-
-export enum MobileV3PlayerEvent {
-  SourceError = 'sourceerror',
-  PlayerError = 'playererror',
-};
-
-export type MobileV3PlayerEventType = PlayerEvent | MobileV3PlayerEvent;
-
-export interface MobileV3PlayerAPI extends PlayerAPI {
-  on(eventType: MobileV3PlayerEventType, callback: PlayerEventCallback): void;
-  exports: PlayerAPI['exports'] & { PlayerEvent: MobileV3PlayerEventType };
-}
+import {ErrorUtils } from '../errorutils';
+import { ErrorEvent, PlayerAPI, PlayerEventBase } from 'bitmovin-player';
+import {
+  MobileV3PlayerAPI, MobileV3PlayerErrorEvent, MobileV3PlayerEvent, MobileV3SourceErrorEvent,
+} from '../mobilev3playerapi';
 
 export interface ErrorMessageTranslator {
   (error: ErrorEvent): string;
@@ -160,7 +150,7 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
 
 function customizeErrorMessage(
   errorMessages: ErrorMessageTranslator | ErrorMessageMap,
-  event: ErrorEvent | MobileV3PlayerErrorEvent | MobileV3SourceErrorEvent
+  event: ErrorEvent | MobileV3PlayerErrorEvent | MobileV3SourceErrorEvent,
 ): string | undefined {
   let message = undefined;
   // Process message vocabularies

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -108,38 +108,39 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
     }, this.config);
   }
 
-  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
+  configure(player: PlayerAPI | MobileV3PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
     let config = this.getConfig();
 
-    player.on(player.exports.PlayerEvent.Error, (event: ErrorEvent) => {
-      let message = ErrorUtils.defaultErrorMessageTranslator(event);
-
-      // errorMessages configured in `UIConfig` take precedence `ErrorMessageOverlayConfig`
-      let errorMessages = uimanager.getConfig().errorMessages || config.messages;
-      // Process message vocabularies
-      if (errorMessages) {
-        if (typeof errorMessages === 'function') {
-          // Translation function for all errors
-          message = errorMessages(event);
-        } else if (errorMessages[event.code]) {
-          // It's not a translation function, so it must be a map of strings or translation functions
-          let customMessage = errorMessages[event.code];
-
-          if (typeof customMessage === 'string') {
-            message = customMessage;
-          } else {
-            // The message is a translation function, so we call it
-            message = customMessage(event);
-          }
-        }
+    const handleErrorMessage = (
+      event: ErrorEvent | MobileV3SourceErrorEvent | MobileV3PlayerErrorEvent,
+      message: string,
+    ) => {
+      const customizedMessage = customizeErrorMessage(uimanager.getConfig().errorMessages || config.messages, event);
+      if (customizedMessage) {
+        message = customizedMessage;
       }
 
       this.errorLabel.setText(message);
       this.tvNoiseBackground.start();
       this.show();
-    });
+    };
+
+    if (isMobileV3PlayerAPI(player)) {
+      const errorEventHandler = (event: MobileV3SourceErrorEvent | MobileV3PlayerErrorEvent) => {
+        const message = ErrorUtils.defaultMobileV3ErrorMessageTranslator(event);
+        handleErrorMessage(event, message);
+      };
+
+      player.on(MobileV3PlayerEvent.PlayerError, errorEventHandler);
+      player.on(MobileV3PlayerEvent.SourceError, errorEventHandler);
+    } else {
+      player.on(player.exports.PlayerEvent.Error, (event: ErrorEvent) => {
+        let message = ErrorUtils.defaultWebErrorMessageTranslator(event);
+        handleErrorMessage(event, message);
+      });
+    }
 
     player.on(player.exports.PlayerEvent.SourceLoaded, (event: PlayerEventBase) => {
       if (this.isShown()) {
@@ -155,4 +156,42 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
     // Canvas rendering must be explicitly stopped, else it just continues forever and hogs resources
     this.tvNoiseBackground.stop();
   }
+}
+
+function customizeErrorMessage(
+  errorMessages: ErrorMessageTranslator | ErrorMessageMap,
+  event: ErrorEvent | MobileV3PlayerErrorEvent | MobileV3SourceErrorEvent
+): string | undefined {
+  let message = undefined;
+  // Process message vocabularies
+  if (errorMessages) {
+    if (typeof errorMessages === 'function') {
+      // Translation function for all errors
+      message = errorMessages(event);
+    } else if (errorMessages[event.code]) {
+      // It's not a translation function, so it must be a map of strings or translation functions
+      let customMessage = errorMessages[event.code];
+
+      if (typeof customMessage === 'string') {
+        message = customMessage;
+      } else {
+        // The message is a translation function, so we call it
+        message = customMessage(event);
+      }
+    }
+  }
+
+  return message;
+}
+
+function isMobileV3PlayerAPI(player: PlayerAPI | MobileV3PlayerAPI): player is MobileV3PlayerAPI {
+  let everyKeyExists = true;
+
+  for (const key in MobileV3PlayerEvent) {
+    if (MobileV3PlayerEvent.hasOwnProperty(key) && !player.exports.PlayerEvent.hasOwnProperty(key)) {
+      everyKeyExists = false;
+    }
+  }
+
+  return everyKeyExists;
 }

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -2,7 +2,7 @@ import {ContainerConfig, Container} from './container';
 import {Label, LabelConfig} from './label';
 import {UIInstanceManager} from '../uimanager';
 import {TvNoiseCanvas} from './tvnoisecanvas';
-import {ErrorUtils } from '../errorutils';
+import { ErrorUtils } from '../errorutils';
 import { ErrorEvent, PlayerAPI, PlayerEventBase } from 'bitmovin-player';
 import {
   isMobileV3PlayerAPI,

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -2,8 +2,21 @@ import {ContainerConfig, Container} from './container';
 import {Label, LabelConfig} from './label';
 import {UIInstanceManager} from '../uimanager';
 import {TvNoiseCanvas} from './tvnoisecanvas';
-import {ErrorUtils} from '../errorutils';
-import { ErrorEvent, PlayerAPI, PlayerEventBase } from 'bitmovin-player';
+import {ErrorUtils, MobileV3PlayerErrorEvent, MobileV3SourceErrorEvent } from '../errorutils';
+import { ErrorEvent, PlayerAPI, PlayerEventBase, PlayerEvent, PlayerEventCallback } from 'bitmovin-player';
+
+
+export enum MobileV3PlayerEvent {
+  SourceError = 'sourceerror',
+  PlayerError = 'playererror',
+};
+
+export type MobileV3PlayerEventType = PlayerEvent | MobileV3PlayerEvent;
+
+export interface MobileV3PlayerAPI extends PlayerAPI {
+  on(eventType: MobileV3PlayerEventType, callback: PlayerEventCallback): void;
+  exports: PlayerAPI['exports'] & { PlayerEvent: MobileV3PlayerEventType };
+}
 
 export interface ErrorMessageTranslator {
   (error: ErrorEvent): string;

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -10,7 +10,7 @@ import {
 } from '../mobilev3playerapi';
 
 export interface ErrorMessageTranslator {
-  (error: ErrorEvent): string;
+  (error: ErrorEvent | MobileV3PlayerErrorEvent): string;
 }
 
 export interface ErrorMessageMap {

--- a/src/ts/errorutils.ts
+++ b/src/ts/errorutils.ts
@@ -67,7 +67,11 @@ export namespace ErrorUtils {
     3100: 'An Advertising module error has occurred. Refer to the attached AdvertisingError.',
   };
 
-  export const defaultErrorMessageTranslator: ErrorMessageTranslator = (error: ErrorEvent) => {
+  export const defaultMobileV3ErrorMessageTranslator = (error: MobileV3PlayerErrorEvent | MobileV3SourceErrorEvent) => {
+    return `${error.message}\n(${error.name})`;
+  }
+
+  export const defaultWebErrorMessageTranslator: ErrorMessageTranslator = (error: ErrorEvent) => {
     const errorMessage = ErrorUtils.defaultErrorMessages[error.code];
 
     if (errorMessage) {

--- a/src/ts/errorutils.ts
+++ b/src/ts/errorutils.ts
@@ -69,7 +69,7 @@ export namespace ErrorUtils {
   };
 
   export const defaultMobileV3ErrorMessageTranslator = (error: MobileV3PlayerErrorEvent | MobileV3SourceErrorEvent) => {
-    return `${error.message}\n(${error.name})`;
+    return error.message;
   };
 
   export const defaultWebErrorMessageTranslator: ErrorMessageTranslator = (error: ErrorEvent) => {

--- a/src/ts/errorutils.ts
+++ b/src/ts/errorutils.ts
@@ -1,17 +1,6 @@
 import {ErrorMessageMap, ErrorMessageTranslator} from './components/errormessageoverlay';
-import { ErrorEvent, PlayerEventBase } from 'bitmovin-player';
-
-export interface MobileV3PlayerErrorEvent extends PlayerEventBase {
-  name: 'onPlayerError';
-  code: number;
-  message: string;
-}
-
-export interface MobileV3SourceErrorEvent extends PlayerEventBase {
-  name: 'onSourceError';
-  code: number;
-  message: string;
-}
+import { ErrorEvent } from 'bitmovin-player';
+import { MobileV3PlayerErrorEvent, MobileV3SourceErrorEvent } from './mobilev3playerapi';
 
 export namespace ErrorUtils {
 
@@ -81,7 +70,7 @@ export namespace ErrorUtils {
 
   export const defaultMobileV3ErrorMessageTranslator = (error: MobileV3PlayerErrorEvent | MobileV3SourceErrorEvent) => {
     return `${error.message}\n(${error.name})`;
-  }
+  };
 
   export const defaultWebErrorMessageTranslator: ErrorMessageTranslator = (error: ErrorEvent) => {
     const errorMessage = ErrorUtils.defaultErrorMessages[error.code];

--- a/src/ts/errorutils.ts
+++ b/src/ts/errorutils.ts
@@ -1,5 +1,17 @@
 import {ErrorMessageMap, ErrorMessageTranslator} from './components/errormessageoverlay';
-import { ErrorEvent } from 'bitmovin-player';
+import { ErrorEvent, PlayerEventBase } from 'bitmovin-player';
+
+export interface MobileV3PlayerErrorEvent extends PlayerEventBase {
+  name: 'onPlayerError';
+  code: number;
+  message: string;
+}
+
+export interface MobileV3SourceErrorEvent extends PlayerEventBase {
+  name: 'onSourceError';
+  code: number;
+  message: string;
+}
 
 export namespace ErrorUtils {
 

--- a/src/ts/mobilev3playerapi.ts
+++ b/src/ts/mobilev3playerapi.ts
@@ -8,13 +8,11 @@ export enum MobileV3PlayerEvent {
 }
 
 export interface MobileV3PlayerErrorEvent extends PlayerEventBase {
-  name: 'onPlayerError';
   code: number;
   message: string;
 }
 
 export interface MobileV3SourceErrorEvent extends PlayerEventBase {
-  name: 'onSourceError';
   code: number;
   message: string;
 }

--- a/src/ts/mobilev3playerapi.ts
+++ b/src/ts/mobilev3playerapi.ts
@@ -27,13 +27,11 @@ export interface MobileV3PlayerAPI extends PlayerAPI {
 }
 
 export function isMobileV3PlayerAPI(player: WrappedPlayer | PlayerAPI | MobileV3PlayerAPI): player is MobileV3PlayerAPI {
-  let everyKeyExists = true;
-
   for (const key in MobileV3PlayerEvent) {
     if (MobileV3PlayerEvent.hasOwnProperty(key) && !player.exports.PlayerEvent.hasOwnProperty(key)) {
-      everyKeyExists = false;
+      return false;
     }
   }
 
-  return everyKeyExists;
+  return true;
 }

--- a/src/ts/mobilev3playerapi.ts
+++ b/src/ts/mobilev3playerapi.ts
@@ -23,3 +23,15 @@ export interface MobileV3PlayerAPI extends PlayerAPI {
   on(eventType: MobileV3PlayerEventType, callback: PlayerEventCallback): void;
   exports: PlayerAPI['exports'] & { PlayerEvent: MobileV3PlayerEventType };
 }
+
+export function isMobileV3PlayerAPI(player: PlayerAPI | MobileV3PlayerAPI): player is MobileV3PlayerAPI {
+  let everyKeyExists = true;
+
+  for (const key in MobileV3PlayerEvent) {
+    if (MobileV3PlayerEvent.hasOwnProperty(key) && !player.exports.PlayerEvent.hasOwnProperty(key)) {
+      everyKeyExists = false;
+    }
+  }
+
+  return everyKeyExists;
+}

--- a/src/ts/mobilev3playerapi.ts
+++ b/src/ts/mobilev3playerapi.ts
@@ -1,0 +1,25 @@
+import { PlayerAPI, PlayerEvent, PlayerEventBase, PlayerEventCallback } from 'bitmovin-player';
+
+export enum MobileV3PlayerEvent {
+  SourceError = 'sourceerror',
+  PlayerError = 'playererror',
+}
+
+export interface MobileV3PlayerErrorEvent extends PlayerEventBase {
+  name: 'onPlayerError';
+  code: number;
+  message: string;
+}
+
+export interface MobileV3SourceErrorEvent extends PlayerEventBase {
+  name: 'onSourceError';
+  code: number;
+  message: string;
+}
+
+export type MobileV3PlayerEventType = PlayerEvent | MobileV3PlayerEvent;
+
+export interface MobileV3PlayerAPI extends PlayerAPI {
+  on(eventType: MobileV3PlayerEventType, callback: PlayerEventCallback): void;
+  exports: PlayerAPI['exports'] & { PlayerEvent: MobileV3PlayerEventType };
+}

--- a/src/ts/mobilev3playerapi.ts
+++ b/src/ts/mobilev3playerapi.ts
@@ -1,8 +1,10 @@
 import { PlayerAPI, PlayerEvent, PlayerEventBase, PlayerEventCallback } from 'bitmovin-player';
+import { WrappedPlayer } from './uimanager';
 
 export enum MobileV3PlayerEvent {
   SourceError = 'sourceerror',
   PlayerError = 'playererror',
+  PlaylistTransition = 'playlisttransition',
 }
 
 export interface MobileV3PlayerErrorEvent extends PlayerEventBase {
@@ -24,7 +26,7 @@ export interface MobileV3PlayerAPI extends PlayerAPI {
   exports: PlayerAPI['exports'] & { PlayerEvent: MobileV3PlayerEventType };
 }
 
-export function isMobileV3PlayerAPI(player: PlayerAPI | MobileV3PlayerAPI): player is MobileV3PlayerAPI {
+export function isMobileV3PlayerAPI(player: WrappedPlayer | PlayerAPI | MobileV3PlayerAPI): player is MobileV3PlayerAPI {
   let everyKeyExists = true;
 
   for (const key in MobileV3PlayerEvent) {

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -12,6 +12,7 @@ import { PlayerAPI, PlayerEventCallback, PlayerEventBase, PlayerEvent, AdEvent, 
 import { VolumeController } from './volumecontroller';
 import { i18n, CustomVocabulary, Vocabularies } from './localization/i18n';
 import { FocusVisibilityTracker } from './focusvisibilitytracker';
+import { isMobileV3PlayerAPI, MobileV3PlayerAPI, MobileV3PlayerEvent } from './mobilev3playerapi';
 
 export interface LocalizationConfig {
   /**
@@ -192,15 +193,14 @@ export class UIManager {
       this.config.events.onUpdated.dispatch(this);
     };
 
-    this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.SourceLoaded, updateSource);
+    const wrappedPlayer = this.managerPlayerWrapper.getPlayer();
+
+    wrappedPlayer.on(this.player.exports.PlayerEvent.SourceLoaded, updateSource);
 
     // The PlaylistTransition event is only available on Mobile v3 for now.
     // This event is fired when a new source becomes active in the player.
-    if ((this.player.exports.PlayerEvent as any).PlaylistTransition) {
-      this.managerPlayerWrapper.getPlayer().on(
-        (this.player.exports.PlayerEvent as any).PlaylistTransition,
-        updateSource,
-      );
+    if (isMobileV3PlayerAPI(wrappedPlayer)) {
+      wrappedPlayer.on(MobileV3PlayerEvent.PlaylistTransition, updateSource);
     }
 
     if (uiconfig.container) {
@@ -762,7 +762,7 @@ class InternalUIInstanceManager extends UIInstanceManager {
 /**
  * Extended interface of the {@link Player} for use in the UI.
  */
-interface WrappedPlayer extends PlayerAPI {
+export interface WrappedPlayer extends PlayerAPI {
   /**
    * Fires an event on the player that targets all handlers in the UI but never enters the real player.
    * @param event the event to fire


### PR DESCRIPTION
## Description

`PlayerEvent.Error` does not exist anymore in the Mobile SDKs V3. Instead of this `PlayerEvent.SourceError` and `PlayerEvent.PlayerError` event is introduced.

### Problem
The UI does not support the new Error events in Mobile SDKs

### Solution
Listen for `PlayerEvent.SourceError` and `PlayerEvent.PlayerError` along with `PlayerEvent.Error` and make sure the message is displayed correctly. Before we had mapping of error code with error message internally, but now it is not needed as the `PlayerErrorEvent` or `SourceErrorEvent` will have the message already. We have to use it directly and apply the customization config, if present.