### PR TITLE
[PW-5093] Add handling for `cueUpdate` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Added
-- Support for subtitle `CueUpdate` events
+- Support for `CueUpdate` events that where introduced in player v8.60.0
 
 ## [3.26.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Added
+- Support for subtitle `cueUpdate` events
+
 ## [3.26.0]
 
 ### Fixed

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -50,5 +50,16 @@ describe('SubtitleOverlay', () => {
       playerMock.eventEmitter.fireSubtitleCueUpdateEvent();
       expect(updateLabelSpy).toHaveBeenCalled();
     });
+
+    it('ignores cueUpdate event if it does not match a previous cue', () => {
+      const updateLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'updateLabel');
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
+
+      playerMock.eventEmitter.fireSubtitleCueEnterEvent();
+      expect(updateLabelSpy).not.toHaveBeenCalled();
+
+      playerMock.eventEmitter.fireSubtitleCueUpdateEvent('some different text');
+      expect(updateLabelSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -32,12 +32,23 @@ describe('SubtitleOverlay', () => {
       expect(addLabelSpy).toHaveBeenCalled();
     });
 
-    it('removes a subtitle label con cueExit', () => {
+    it('removes a subtitle label on cueExit', () => {
       playerMock.eventEmitter.fireSubtitleCueEnterEvent();
       const removeLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'removeLabel');
       jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
       playerMock.eventEmitter.fireSubtitleCueExitEvent();
       expect(removeLabelSpy).toHaveBeenCalled();
+    });
+
+    it('updates a subtitle label on cueUpdate', () => {
+      const updateLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'updateLabel');
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
+
+      playerMock.eventEmitter.fireSubtitleCueEnterEvent();
+      expect(updateLabelSpy).not.toHaveBeenCalled();
+
+      playerMock.eventEmitter.fireSubtitleCueUpdateEvent();
+      expect(updateLabelSpy).toHaveBeenCalled();
     });
   });
 });

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -41,7 +41,7 @@ describe('SubtitleOverlay', () => {
     });
 
     it('updates a subtitle label on cueUpdate', () => {
-      const updateLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'updateLabel');
+      const updateLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'replaceLabel');
       jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
 
       playerMock.eventEmitter.fireSubtitleCueEnterEvent();
@@ -52,7 +52,7 @@ describe('SubtitleOverlay', () => {
     });
 
     it('ignores cueUpdate event if it does not match a previous cue', () => {
-      const updateLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'updateLabel');
+      const updateLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'replaceLabel');
       jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
 
       playerMock.eventEmitter.fireSubtitleCueEnterEvent();

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -306,12 +306,12 @@ export class PlayerEventEmitter {
     } as SubtitleCueEvent);
   }
 
-  fireSubtitleCueUpdateEvent(): void {
+  fireSubtitleCueUpdateEvent(text = 'Test Subtitle'): void {
     this.fireEvent<SubtitleCueEvent>({
       subtitleId: 'subtitleId',
       start: 0,
       end: 10,
-      text: 'Test Subtitle',
+      text,
       type: PlayerEvent.CueUpdate,
     } as SubtitleCueEvent);
   }

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -306,6 +306,16 @@ export class PlayerEventEmitter {
     } as SubtitleCueEvent);
   }
 
+  fireSubtitleCueUpdateEvent(): void {
+    this.fireEvent<SubtitleCueEvent>({
+      subtitleId: 'subtitleId',
+      start: 0,
+      end: 10,
+      text: 'Test Subtitle',
+      type: PlayerEvent.CueUpdate,
+    } as SubtitleCueEvent);
+  }
+
   fireSubtitleCueExitEvent(): void {
     this.fireEvent<SubtitleCueEvent>({
       subtitleId: 'subtitleId',

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -69,11 +69,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     player.on(player.exports.PlayerEvent.CueUpdate, (event: SubtitleCueEvent) => {
       const label = this.generateLabel(event);
-      const previousLabel = subtitleManager.getPreviousCue(event);
+      const labelToReplace = subtitleManager.cueUpdate(event, label);
 
-      if (previousLabel) {
-        subtitleManager.cueUpdate(event, label);
-        this.subtitleContainerManager.replaceLabel(previousLabel, label);
+      if (labelToReplace) {
+        this.subtitleContainerManager.replaceLabel(labelToReplace, label);
       }
     });
 
@@ -371,12 +370,15 @@ class ActiveSubtitleManager {
     this.addCueToMap(event, label);
   }
 
-  cueUpdate(event: SubtitleCueEvent, label: SubtitleLabel): void {
-    this.addCueToMap(event, label);
-  }
+  cueUpdate(event: SubtitleCueEvent, label: SubtitleLabel): SubtitleLabel | undefined {
+    const labelToReplace = this.popCueFromMap(event);
 
-  getPreviousCue(event: SubtitleCueEvent): SubtitleLabel | undefined {
-    return this.popCueFromMap(event);
+    if (labelToReplace) {
+      this.addCueToMap(event, label);
+      return labelToReplace;
+    }
+
+    return undefined;
   }
 
   private addCueToMap(event: SubtitleCueEvent, label: SubtitleLabel): void {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -376,7 +376,7 @@ class ActiveSubtitleManager {
   }
 
   getPreviousCue(event: SubtitleCueEvent): SubtitleLabel | undefined {
-    return this.removeCueFromMap(event);
+    return this.popCueFromMap(event);
   }
 
   private addCueToMap(event: SubtitleCueEvent, label: SubtitleLabel): void {
@@ -390,7 +390,7 @@ class ActiveSubtitleManager {
     this.activeSubtitleCueCount++;
   }
 
-  private removeCueFromMap(event: SubtitleCueEvent): SubtitleLabel | undefined {
+  private popCueFromMap(event: SubtitleCueEvent): SubtitleLabel | undefined {
     let id = ActiveSubtitleManager.calculateId(event);
     let activeSubtitleCues = this.activeSubtitleCueMap[id];
 
@@ -442,7 +442,7 @@ class ActiveSubtitleManager {
    * @return {SubtitleLabel|null}
    */
   cueExit(event: SubtitleCueEvent): SubtitleLabel {
-    return this.removeCueFromMap(event);
+    return this.popCueFromMap(event);
   }
 
   /**

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -373,7 +373,7 @@ class ActiveSubtitleManager {
     this.addCueToMap(event, label);
   }
 
-  getPreviousCue(event: SubtitleCueEvent): SubtitleLabel {
+  getPreviousCue(event: SubtitleCueEvent): SubtitleLabel | undefined {
     return this.removeCueFromMap(event);
   }
 
@@ -388,7 +388,7 @@ class ActiveSubtitleManager {
     this.activeSubtitleCueCount++;
   }
 
-  private removeCueFromMap(event: SubtitleCueEvent): SubtitleLabel {
+  private removeCueFromMap(event: SubtitleCueEvent): SubtitleLabel | undefined {
     let id = ActiveSubtitleManager.calculateId(event);
     let activeSubtitleCues = this.activeSubtitleCueMap[id];
 
@@ -405,12 +405,10 @@ class ActiveSubtitleManager {
       this.activeSubtitleCueCount--;
 
       return activeSubtitleCue.label;
-    } else {
-      return null;
     }
   }
 
-  static generateImageTagText(imageData: string): string {
+  static generateImageTagText(imageData: string): string | undefined {
     if (!imageData) {
       return;
     }
@@ -427,13 +425,11 @@ class ActiveSubtitleManager {
    * @param event
    * @return {SubtitleLabel}
    */
-  getCues(event: SubtitleCueEvent): SubtitleLabel[] {
+  getCues(event: SubtitleCueEvent): SubtitleLabel[] | undefined {
     let id = ActiveSubtitleManager.calculateId(event);
     let activeSubtitleCues = this.activeSubtitleCueMap[id];
     if (activeSubtitleCues && activeSubtitleCues.length > 0) {
       return activeSubtitleCues.map((cue) => cue.label);
-    } else {
-      return null;
     }
   }
 
@@ -489,12 +485,12 @@ export class SubtitleRegionContainerManager {
         regionContainerId: label.vtt.region && label.vtt.region.id ? label.vtt.region.id : 'vtt',
         regionName: 'vtt',
       };
-    } else {
-      return {
-        regionContainerId: label.region || 'default',
-        regionName: label.region || 'default',
-      };
     }
+
+    return {
+      regionContainerId: label.region || 'default',
+      regionName: label.region || 'default',
+    };
   }
 
   /**

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -289,11 +289,13 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   removePreviewSubtitleLabel(): void {
-    if (this.previewSubtitleActive) {
-      this.previewSubtitleActive = false;
-      this.subtitleContainerManager.removeLabel(this.previewSubtitle);
-      this.updateComponents();
+    if (!this.previewSubtitleActive) {
+      return;
     }
+
+    this.previewSubtitleActive = false;
+    this.subtitleContainerManager.removeLabel(this.previewSubtitle);
+    this.updateComponents();
   }
 }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -54,8 +54,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     this.subtitleContainerManager = new SubtitleRegionContainerManager(this);
 
     player.on(player.exports.PlayerEvent.CueEnter, (event: SubtitleCueEvent) => {
-      let labelToAdd = this.generateLabel(event);
-      subtitleManager.cueEnter(event, labelToAdd);
+      const label = this.generateLabel(event);
+      subtitleManager.cueEnter(event, label);
 
       if (this.previewSubtitleActive) {
         this.subtitleContainerManager.removeLabel(this.previewSubtitle);
@@ -63,20 +63,16 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       this.show();
 
-      this.subtitleContainerManager.addLabel(labelToAdd, this.getDomElement().size());
+      this.subtitleContainerManager.addLabel(label, this.getDomElement().size());
       this.updateComponents();
     });
 
     player.on(player.exports.PlayerEvent.CueUpdate, (event: SubtitleCueEvent) => {
-      try {
-        const label = this.generateLabel(event);
-        const oldLabel = subtitleManager.getPreviousCue(event);
-        this.subtitleContainerManager.updateLabel(oldLabel, label);
-        subtitleManager.cueUpdate(event, label);
-      } catch(e) {
-        console.error(e);
-      }
-      
+      const label = this.generateLabel(event);
+      const oldLabel = subtitleManager.getPreviousCue(event);
+
+      subtitleManager.cueUpdate(event, label);
+      this.subtitleContainerManager.updateLabel(oldLabel, label);
     });
 
     player.on(player.exports.PlayerEvent.CueExit, (event: SubtitleCueEvent) => {
@@ -283,8 +279,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   enablePreviewSubtitleLabel(): void {
-    this.previewSubtitleActive = true;
     if (!this.subtitleManager.hasCues) {
+      this.previewSubtitleActive = true;
       this.subtitleContainerManager.addLabel(this.previewSubtitle);
       this.updateComponents();
       this.show();
@@ -292,9 +288,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   removePreviewSubtitleLabel(): void {
-    this.previewSubtitleActive = false;
-    this.subtitleContainerManager.removeLabel(this.previewSubtitle);
-    this.updateComponents();
+    if (this.previewSubtitleActive) {
+      this.previewSubtitleActive = false;
+      this.subtitleContainerManager.removeLabel(this.previewSubtitle);
+      this.updateComponents();
+    }
   }
 }
 
@@ -366,19 +364,12 @@ class ActiveSubtitleManager {
     return id;
   }
 
-  /**
-   * Adds a subtitle cue to the manager and returns the label that should be added to the subtitle overlay.
-   * @param event
-   * @return {SubtitleLabel}
-   */
   cueEnter(event: SubtitleCueEvent, label: SubtitleLabel): void {
     this.addCueToMap(event, label);
   }
 
   cueUpdate(event: SubtitleCueEvent, label: SubtitleLabel): void {
     this.addCueToMap(event, label);
-
-    console.log(this.activeSubtitleCueMap);
   }
 
   getPreviousCue(event: SubtitleCueEvent): SubtitleLabel {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -73,7 +73,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       if (previousLabel) {
         subtitleManager.cueUpdate(event, label);
-        this.subtitleContainerManager.updateLabel(previousLabel, label);
+        this.subtitleContainerManager.replaceLabel(previousLabel, label);
       }
     });
 
@@ -536,7 +536,7 @@ export class SubtitleRegionContainerManager {
     this.subtitleRegionContainers[regionContainerId].addLabel(label, overlaySize);
   }
 
-  updateLabel(previousLabel: SubtitleLabel, newLabel: SubtitleLabel): void {
+  replaceLabel(previousLabel: SubtitleLabel, newLabel: SubtitleLabel): void {
     const { regionContainerId } = this.getRegion(previousLabel);
 
     this.subtitleRegionContainers[regionContainerId].removeLabel(previousLabel);

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -69,10 +69,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     player.on(player.exports.PlayerEvent.CueUpdate, (event: SubtitleCueEvent) => {
       const label = this.generateLabel(event);
-      const oldLabel = subtitleManager.getPreviousCue(event);
+      const previousLabel = subtitleManager.getPreviousCue(event);
 
       subtitleManager.cueUpdate(event, label);
-      this.subtitleContainerManager.updateLabel(oldLabel, label);
+      this.subtitleContainerManager.updateLabel(previousLabel, label);
     });
 
     player.on(player.exports.PlayerEvent.CueExit, (event: SubtitleCueEvent) => {
@@ -126,13 +126,12 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   generateLabel(event: SubtitleCueEvent): SubtitleLabel {
-    // Sanitize cue data (must be done before the cue ID is generated in subtitleManager.cueEnter)
+    // Sanitize cue data (must be done before the cue ID is generated in subtitleManager.cueEnter / update)
     if (event.position) {
       // Sometimes the positions are undefined, we assume them to be zero
       event.position.row = event.position.row || 0;
       event.position.column = event.position.column || 0;
     }
-
     
     const label = new SubtitleLabel({
       // Prefer the HTML subtitle text if set, else try generating a image tag as string from the image attribute,
@@ -537,10 +536,10 @@ export class SubtitleRegionContainerManager {
     this.subtitleRegionContainers[regionContainerId].addLabel(label, overlaySize);
   }
 
-  updateLabel(label: SubtitleLabel, newLabel: SubtitleLabel): void {
-    const { regionContainerId } = this.getRegion(label);
+  updateLabel(previousLabel: SubtitleLabel, newLabel: SubtitleLabel): void {
+    const { regionContainerId } = this.getRegion(previousLabel);
 
-    this.subtitleRegionContainers[regionContainerId].removeLabel(label);
+    this.subtitleRegionContainers[regionContainerId].removeLabel(previousLabel);
     this.subtitleRegionContainers[regionContainerId].addLabel(newLabel);
   }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -161,9 +161,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     let enabled = false;
 
     const updateCEA608FontSize = () => {
-
-      console.log("UPDATE FONTS");
-
       const dummyLabel = new SubtitleLabel({ text: 'X' });
       dummyLabel.getDomElement().css({
         // By using a large font size we do not need to use multiple letters and can get still an
@@ -242,8 +239,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         // Skip all non-CEA608 cues
         return;
       }
-      
-      console.log("PROCESS LABEL");
 
       if (!enabled) {
         enabled = true;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -71,8 +71,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       const label = this.generateLabel(event);
       const previousLabel = subtitleManager.getPreviousCue(event);
 
-      subtitleManager.cueUpdate(event, label);
-      this.subtitleContainerManager.updateLabel(previousLabel, label);
+      if (previousLabel) {
+        subtitleManager.cueUpdate(event, label);
+        this.subtitleContainerManager.updateLabel(previousLabel, label);
+      }
     });
 
     player.on(player.exports.PlayerEvent.CueExit, (event: SubtitleCueEvent) => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -57,6 +57,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       const label = this.generateLabel(event);
       subtitleManager.cueEnter(event, label);
 
+      this.preprocessLabelEventCallback.dispatch(event, label);
+
       if (this.previewSubtitleActive) {
         this.subtitleContainerManager.removeLabel(this.previewSubtitle);
       }
@@ -70,6 +72,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     player.on(player.exports.PlayerEvent.CueUpdate, (event: SubtitleCueEvent) => {
       const label = this.generateLabel(event);
       const labelToReplace = subtitleManager.cueUpdate(event, label);
+
+      this.preprocessLabelEventCallback.dispatch(event, label);
 
       if (labelToReplace) {
         this.subtitleContainerManager.replaceLabel(labelToReplace, label);
@@ -143,8 +147,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       regionStyle: event.regionStyle,
     });
 
-    this.preprocessLabelEventCallback.dispatch(event, label);
-
     return label;
   }
 
@@ -159,6 +161,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     let enabled = false;
 
     const updateCEA608FontSize = () => {
+
+      console.log("UPDATE FONTS");
+
       const dummyLabel = new SubtitleLabel({ text: 'X' });
       dummyLabel.getDomElement().css({
         // By using a large font size we do not need to use multiple letters and can get still an
@@ -237,6 +242,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         // Skip all non-CEA608 cues
         return;
       }
+      
+      console.log("PROCESS LABEL");
 
       if (!enabled) {
         enabled = true;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -143,7 +143,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       regionStyle: event.regionStyle,
     });
 
-    this.preprocessLabelEventCallback.dispatch(event);
+    this.preprocessLabelEventCallback.dispatch(event, label);
 
     return label;
   }
@@ -288,13 +288,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   removePreviewSubtitleLabel(): void {
-    if (!this.previewSubtitleActive) {
-      return;
+    if (this.previewSubtitleActive) {
+      this.previewSubtitleActive = false;
+      this.subtitleContainerManager.removeLabel(this.previewSubtitle);
+      this.updateComponents();
     }
-
-    this.previewSubtitleActive = false;
-    this.subtitleContainerManager.removeLabel(this.previewSubtitle);
-    this.updateComponents();
   }
 }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -134,7 +134,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       event.position.row = event.position.row || 0;
       event.position.column = event.position.column || 0;
     }
-    
+
     const label = new SubtitleLabel({
       // Prefer the HTML subtitle text if set, else try generating a image tag as string from the image attribute,
       // else use the plain text
@@ -488,12 +488,12 @@ export class SubtitleRegionContainerManager {
       return {
         regionContainerId: label.vtt.region && label.vtt.region.id ? label.vtt.region.id : 'vtt',
         regionName: 'vtt',
-      }
+      };
     } else {
       return {
         regionContainerId: label.region || 'default',
         regionName: label.region || 'default',
-      }
+      };
     }
   }
 


### PR DESCRIPTION
_Waiting until the player PR is finished before we merge this one_ 

This PR adds support for `cueUpdate` events

Changes to the UI: 

- Whenever `cueUpdate` event is triggered, we check if there is a previous cue in the `subtitleManager` that matches the id. 
- If a match is found we create a new subtitle label and replace the current one. 
- Matching by id works because `cueUpdate` events contain the same `start` and `text` properties as the `cueEnter` event, only the `html` content is different. 