### PR TITLE
[PW-4867] Fix VTT position end alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- VTT cue positioning when position alignment is `end` or `right`
+
 ## [3.27.0] - 2021-04-11
 
 ### Added

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -551,7 +551,7 @@ describe('Vtt Utils', () => {
 
             expect(spyCss).toHaveBeenCalledTimes(12);
             expect(spyCss).toHaveBeenNthCalledWith(10, 'left', 'auto');
-            expect(spyCss).toHaveBeenNthCalledWith(11, 'right', '30%');
+            expect(spyCss).toHaveBeenNthCalledWith(11, 'right', '70%');
           });
         });
       });
@@ -645,7 +645,7 @@ describe('Vtt Utils', () => {
 
             expect(spyCss).toHaveBeenCalledTimes(13);
             expect(spyCss).toHaveBeenNthCalledWith(11, 'top', 'auto');
-            expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', '30%');
+            expect(spyCss).toHaveBeenNthCalledWith(12, 'bottom', '70%');
           });
         });
       });

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -128,7 +128,7 @@ const setVttPositionAlign = (cueContainerDom: DOM, vtt: VTTProperties, direction
         break;
       case 'line-right':
         cueContainerDom.css(direction, 'auto');
-        cueContainerDom.css(DirectionPair.get(direction), `${vtt.position}%`);
+        cueContainerDom.css(DirectionPair.get(direction), `${100 - vtt.position}%`);
         cueContainerDom.css('justify-content', 'flex-end');
         break;
       default:


### PR DESCRIPTION
When the align property of the VTT cue is set to `end` or `right`, we set the CSS `right` property to the VTT position value. This is wrong because this moves the cue to a totally different position.

I think the whole understanding of the VTT cue positioning is wrong. We think that the cues should be positioned to the VTT cue `position` offset from the `start`, `end`, `left`, or `right` side of the video container. But this is not true, the cue should be positioned to the offset in the writing direction of the VTT.

When position align is set to `end` or `right` the cue text should be present on the right side of the cue box.
When the position align is set to `start` or `left`, the cue text should be present on the left side of the cue box.

This PR fixes the cue position when the position align is set to `end` of `right`.

This is how the cue should look like when the position is 80% and based on position align, it should be aligned at the left or right side of the cue box.

![Untitled Diagram (1)](https://user-images.githubusercontent.com/16763170/122036162-8bab8780-cdd3-11eb-90be-cd6cbb0f3f0f.jpg)
