### PR TITLE
Replace npm `prepublish` with `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/js/framework/main.d.ts",
   "scripts": {
     "test": "npx jest",
-    "prepublish": "gulp npm-prepare"
+    "prepare": "gulp npm-prepare"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `prepublish` script got deprecated, and does not get executed anymore when running `npm publish` on newer npm versions.
Instead, we can use `prepare`, which has the same behavior (runs on `install`, `ci`, `publish`, and more)

For reference:
- https://github.com/npm/npm/issues/10074
- https://docs.npmjs.com/cli/v7/using-npm/scripts
