### PR TITLE
[PW-5266] Update UI for new seeking behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Changed
+- Current time now gets updated immediately during a seek, to reflect new behavior of `getCurrentTime` API
+
 ## [3.28.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Changed
-- Current time now gets updated immediately during a seek, to reflect new behavior of `getCurrentTime` API
+- Current time now gets updated immediately during a seek, to reflect the new behavior of `getCurrentTime` API
 
 ## [3.28.1]
 

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -133,7 +133,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     };
 
     player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
-    player.on(player.exports.PlayerEvent.Seeked, playbackTimeHandler);
+    player.on(player.exports.PlayerEvent.Seek, playbackTimeHandler);
 
     player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.TimeShifted, updateLiveTimeshiftState);

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -134,6 +134,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
 
     player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
     player.on(player.exports.PlayerEvent.Seek, playbackTimeHandler);
+    player.on(player.exports.PlayerEvent.Seeked, playbackTimeHandler);
 
     player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.TimeShifted, updateLiveTimeshiftState);

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -252,7 +252,10 @@ export class SeekBar extends Component<SeekBarConfig> {
           this.setPlaybackPosition(playbackPositionPercentage);
         }
 
-        this.setBufferPosition(playbackPositionPercentage + bufferPercentage);
+        if (!isPlayerSeeking) {
+          // During seeking, buffer levels may be off during the transition.
+          this.setBufferPosition(playbackPositionPercentage + bufferPercentage);
+        }
 
         this.setAriaSliderMinMax('0', playerDuration.toString());
       }


### PR DESCRIPTION
As you know, we have changed a bit the behavior of the `getCurrentTime` API. So now we return the seek target immediately, and we won't wait for the seeking to be complete. This created a small inconsistency in the UI since the playback time label still only gets refreshed after the Seeked event. Also, a glitch in the buffer level can be observed during the transition from Seek to Seeked: suddenly the buffer is huge and then it gets reset 👀 

**Changes:**
- update the playback time label on Seek event
- do not update the buffer level during seekings since it currently causes a glitch due to the sudden changes that happen to the buffer level during the transition