### PR TITLE
Fix CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bitmovin Player UI [![npm version](https://badge.fury.io/js/bitmovin-player-ui.svg)](https://badge.fury.io/js/bitmovin-player-ui) [![Build Status](https://travis-ci.org/bitmovin/bitmovin-player-ui.svg?branch=master)](https://travis-ci.org/bitmovin/bitmovin-player-ui)
+# Bitmovin Player UI [![npm version](https://badge.fury.io/js/bitmovin-player-ui.svg)](https://badge.fury.io/js/bitmovin-player-ui) [![Build Status](https://travis-ci.com/bitmovin/bitmovin-player-ui.svg?branch=master)](https://travis-ci.com/bitmovin/bitmovin-player-ui)
 The Bitmovin Adaptive Streaming Player UI
 
 Read more about the usage, along with other important information about the Bitmovin Player at https://bitmovin.com/ and https://bitmovin.com/docs/player.


### PR DESCRIPTION
We recently migrated from travis-ci.org to travis-ci.com.

This change points the status badge in the readme file to the new URL.