### PR TITLE
Revert to previous seeking behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [develop]
-
-### Changed
-- Current time now gets updated immediately during a seek, to reflect the new behavior of `getCurrentTime` API
-
 ## [3.28.1]
 
 ### Fixed

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -133,7 +133,6 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     };
 
     player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
-    player.on(player.exports.PlayerEvent.Seek, playbackTimeHandler);
     player.on(player.exports.PlayerEvent.Seeked, playbackTimeHandler);
 
     player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -252,10 +252,7 @@ export class SeekBar extends Component<SeekBarConfig> {
           this.setPlaybackPosition(playbackPositionPercentage);
         }
 
-        if (!isPlayerSeeking) {
-          // During seeking, buffer levels may be off during the transition.
-          this.setBufferPosition(playbackPositionPercentage + bufferPercentage);
-        }
+        this.setBufferPosition(playbackPositionPercentage + bufferPercentage);
 
         this.setAriaSliderMinMax('0', playerDuration.toString());
       }


### PR DESCRIPTION
This PR reverts the code introduced with https://github.com/bitmovin/bitmovin-player-ui/pull/398.
The behavior of `getCurrentTime` will not change after all, so there is no need to make a UI change. 
More on this here: https://github.com/bitmovin/bitdash/pull/5125.