### PR TITLE
Fix empty lines in subtitles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,8 @@ local.properties
 # Code Recommenders
 .recommenders/
 
+### VsCode ###
+.vscode
 
 ### Windows ###
 # Windows thumbnail cache files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Current time now gets updated immediately during a seek, to reflect the new behavior of `getCurrentTime` API
 
+### Fixed
+- Empty lines being added to subtitles
+
 ## [3.28.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Current time now gets updated immediately during a seek, to reflect the new behavior of `getCurrentTime` API
 
 ### Fixed
-- Empty lines being added to VTT subtitles
+- An empty line being added to subtitle boxes when VTT positioning attributes are present.
 
 ## [3.28.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Current time now gets updated immediately during a seek, to reflect the new behavior of `getCurrentTime` API
 
 ### Fixed
-- Empty lines being added to subtitles
+- Empty lines being added to VTT subtitles
 
 ## [3.28.1]
 

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -41,7 +41,7 @@
 
     // Break labels into separate lines
     // sass-lint:disable force-pseudo-nesting
-    &:nth-child(1n-1)::after {
+    &:nth-child(n+2)::after {
       content: '\A';
       white-space: pre-line;
     }

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -41,9 +41,11 @@
 
     // Break labels into separate lines
     // sass-lint:disable force-pseudo-nesting
-    &:nth-child(n+2)::after {
+    &:nth-child(1n-1)::after {
       content: '\A';
       white-space: pre-line;
+      // VTT flex styling can increase this elements height, making the background larger
+      height: 0;
     }
   }
 


### PR DESCRIPTION
We accidentally added empty lines to Subtitles. From the following subtitle
```
00:00:00.000 --> 00:00:05.000
We are in for a ride.
```
we would get the following overlay:
![image](https://user-images.githubusercontent.com/29116195/128170615-a19d990f-7e2a-42f4-8ce5-c06251b11c0a.png)

this extra empty line got added because of our support for multiple subtitles cues by the following CSS rule:
```css
.bmpui-ui-subtitle-overlay .bmpui-ui-subtitle-label:nth-child(1n-1):after {
    content: "\A";
    white-space: pre-line;
}
```
This pseudo element should put each subtitle cue into a separate line, but when WebVTT styling is applied, the height of the pseudo element became one line instead of 0, due to `display: inline-flex`.