### PR TITLE
[PW-5202] Fix inconsistent audio track listing + wrong default audio

### DIFF
--- a/src/ts/audiotrackutils.ts
+++ b/src/ts/audiotrackutils.ts
@@ -46,7 +46,7 @@ export class AudioTrackSwitchHandler {
   private addAudioTrack = (event: AudioTrackEvent) => {
     const audioTrack = event.track;
     if (!this.listElement.hasItem(audioTrack.id)) {
-      this.listElement.addItem(audioTrack.id, i18n.getLocalizer(audioTrack.label));
+      this.listElement.addItem(audioTrack.id, i18n.getLocalizer(audioTrack.label), true);
     }
   };
 

--- a/src/ts/audiotrackutils.ts
+++ b/src/ts/audiotrackutils.ts
@@ -48,6 +48,8 @@ export class AudioTrackSwitchHandler {
     if (!this.listElement.hasItem(audioTrack.id)) {
       this.listElement.addItem(audioTrack.id, i18n.getLocalizer(audioTrack.label), true);
     }
+    // Refresh current audio selection
+    this.selectCurrentAudioTrack();
   };
 
   private removeAudioTrack = (event: AudioTrackEvent) => {

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -99,12 +99,13 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
   }
 
   /**
-   * Adds an item to this selector by appending it to the end of the list of items. If an item with the specified
-   * key already exists, it is replaced.
+   * Adds an item to this selector by doing a sorted insert or by appending the element to the end of the list of items.
+   * If an item with the specified key already exists, it is replaced.
    * @param key the key of the item to add
    * @param label the (human-readable) label of the item to add
+   * @param sortedInsert whether the item should be added respecting the order of keys
    */
-  addItem(key: string, label: LocalizableText) {
+  addItem(key: string, label: LocalizableText, sortedInsert = false) {
     const listItem = { key: key, label: i18n.performLocalization(label) };
 
     // Apply filter function
@@ -120,7 +121,17 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     // Try to remove key first to get overwrite behavior and avoid duplicate keys
     this.removeItem(key); // This will trigger an ItemRemoved and an ItemAdded event
 
-    this.items.push(listItem);
+    // Add the item to the list
+    if (sortedInsert) {
+      const index = this.items.findIndex(entry => entry.key > key);
+      if (index < 0) {
+          this.items.push(listItem);
+      } else {
+        this.items.splice(index, 0, listItem);
+      }
+    } else {
+      this.items.push(listItem);
+    }
     this.onItemAddedEvent(key);
   }
 


### PR DESCRIPTION
Issue: https://bitmovin.atlassian.net/browse/PW-5202

Customer reports incosistent ordering of audio tracks when using Native player, and sometimes the wrong language being initially selected in the UI (e.g. audio plays in English but the UI says Spanish or something else, basically the first track in the list is selected regardless).
I checked thoroughly, and all the APIs return the correct values:

- `getAvailableAudio` provides a consistently ordered list of tracks
- `getAudio` provides the correct audio track as `enabled`

Issue is mostly a UI issue:

- tracks are added to the list after listening to `AudioAdded` events. These can come in random order because the player merely listens to the video element events, and relays them out. We should not try to change the order of events imho. Also, as mentioned, `getAvailableAudio` does provide the list of sorted tracks. Issue can be fixed either by matching what the API returns, or by doing a sorted insert of tracks on `AudioAdded` events. I discussed with Daniel, and we opted for the latter option.
- the UI expects that audio and subtitle tracks are loaded before the `SourceLoaded` event, but that doesn't always happen on Native player. We cannot do much about that, and we are aware of the limitation from the many flaky tests that we have had to stabilize on Safari in the past. At the same time, it is expected that an `AudioChanged` event is dispatched if the audio changes after the `SourceLoaded` event. However that does not seem to happen: as far as I can see it's not even a regression. We may investigate this further, but for now we are just going to refresh the current audio selection both on `AudioChanged` and `AudioAdded`. This will fix the issue of the current audio language being wrong initially.

I will discuss with Daniel further about the missing `AudioChanged` event, and maybe create a follow-up. However, I don't think this is currently a formal spec of the player, so it's probably going to be addressed with lower priority.