### PR TITLE
[PW-5720] Reset styles on subtitle overlay content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
 
 ### Added
 - Sort `AudioTracks` inside the `AudioTrackSelectBox` and the `AudioTrackListBox` by their identifier.
+- Style reset for subtitle overlay element to prevent undesired CSS rules
+collisions.
 
 ## [3.29.0]
 
@@ -224,7 +226,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - UI not hiding after selecting an item within a `ListBox`
 
 ## [3.4.6]
-	
+
 ### Fixed
 - Allow npm package to be imported in server side app without `navigator` error
 
@@ -258,7 +260,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Stopping timeshift offset updater of `SeekBar` when player is destroyed
-- `box-sizing` style of `SeekBar` and `SeekBarLabel` 
+- `box-sizing` style of `SeekBar` and `SeekBarLabel`
 
 ## [3.4.0]
 
@@ -503,7 +505,7 @@ License change from LGPLv3 to MIT.
 - Removed `VolumeControlButton`'s `VolumeSlider` slide-in animation in the legacy skin to fix the slider knob at 100% bug
 
 ### Fixed
-- Vertical `VolumeSlider` knob in legacy skin was not visible when set to a low volume 
+- Vertical `VolumeSlider` knob in legacy skin was not visible when set to a low volume
 - Legacy skin's `VolumeSlider` knob was always rendered at 100% when appearing after being hidden
 - Avoid `ItemSelectionList` DOM recreation on item selection to avoid unexpected events (e.g. `mouseenter`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Sort `AudioTracks` inside the `AudioTrackSelectBox` and the `AudioTrackListBox` by their identifier.
-- Style reset for subtitle overlay element to prevent undesired CSS rules
-collisions.
+- Style reset for subtitle overlay element to prevent undesired CSS rules collisions.
 
 ## [3.29.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Added
+- Style reset for subtitle overlay element to prevent undesired CSS rules collisions.
+
 ## [3.30.0]
 
 ### Added
 - Sort `AudioTracks` inside the `AudioTrackSelectBox` and the `AudioTrackListBox` by their identifier.
-- Style reset for subtitle overlay element to prevent undesired CSS rules collisions.
 
 ## [3.29.0]
 

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -55,3 +55,10 @@
     transition: bottom $animation-duration-short ease-in;
   }
 }
+
+.#{$prefix}-ui-uicontainer .#{$prefix}-ui-subtitle-overlay * {
+  // This aims to prevent possibly conflicting style definitions inherited
+  // from target applications whuch can break subtitle styling. It's still possible
+  // to override this with selector of higher priority score.
+  all: unset;
+}

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -3,6 +3,7 @@
 
 .#{$prefix}-ui-uicontainer .#{$prefix}-ui-subtitle-overlay {
   @extend %ui-container;
+
   @include hidden;
 
   bottom: 0;

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -24,7 +24,7 @@
   }
 
   p {
-    // It may happen that we sender <p> inside of an <span> and the `all: unset;` reseting above sets
+    // It may happen that we render <p> inside of an <span> and the `all: unset;` reseting above sets
     // p to inherit the inline display instead of its default display block so this sets it back.
     display: block;
   }

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -1,64 +1,71 @@
 @import '../variables';
 @import '../mixins';
 
-.#{$prefix}-ui-subtitle-overlay {
-  @extend %ui-container;
+.#{$prefix}-ui-uicontainer {
+  .#{$prefix}-ui-subtitle-overlay {
+    @extend %ui-container;
+    @include hidden;
 
-  @include hidden;
-
-  bottom: 0;
-  font-size: 1.2em;
-  left: 0;
-  pointer-events: none;
-  position: absolute;
-  right: 0;
-  text-align: center;
-  top: 0;
-  transition: bottom $animation-duration-short ease-out;
-
-  .#{$prefix}-subtitle-region-container {
+    bottom: 0;
+    font-size: 1.2em;
+    left: 0;
+    pointer-events: none;
     position: absolute;
+    right: 0;
+    text-align: center;
+    top: 0;
+    transition: bottom $animation-duration-short ease-out;
 
-    &.#{$prefix}-subtitle-position-default {
-      bottom: 2em;
-      left: 3em;
-      right: 3em;
-      top: initial;
+    * {
+      // This aims to prevent possibly conflicting style definitions inherited
+      // from target applications which can break subtitles styling. It's still possible
+      // to override this with selector of higher priority score.
+      all: unset;
     }
 
-    &.#{$prefix}-subtitle-position-bottom > div {
-      bottom: 0;
+    p {
+      // It may happen that we sender <p> inside of an <span> and the `all: unset;` reseting above sets
+      // p to inherit the inline display instead of its default display block so this sets it back.
+      display: block;
+    }
+
+    .#{$prefix}-subtitle-region-container {
       position: absolute;
-      width: 100%;
+
+      &.#{$prefix}-subtitle-position-default {
+        bottom: 2em;
+        left: 3em;
+        right: 3em;
+        top: initial;
+      }
+
+      &.#{$prefix}-subtitle-position-bottom > div {
+        bottom: 0;
+        position: absolute;
+        width: 100%;
+      }
+    }
+
+    .#{$prefix}-ui-subtitle-label {
+      @include text-border($subtitle-text-border-color);
+
+      color: $subtitle-text-color;
+      height: fit-content;
+
+      // Break labels into separate lines
+      // sass-lint:disable force-pseudo-nesting
+      &:nth-child(1n-1)::after {
+        content: '\A';
+        white-space: pre-line;
+        // VTT flex styling can increase this elements height, making the background larger
+        height: 0;
+      }
+    }
+
+    // Move the subtitle up above the controlbar when it appears to avoid them overlapping
+    &.#{$prefix}-controlbar-visible {
+      bottom: 5em;
+      transition: bottom $animation-duration-short ease-in;
     }
   }
-
-  .#{$prefix}-ui-subtitle-label {
-    @include text-border($subtitle-text-border-color);
-
-    color: $subtitle-text-color;
-    height: fit-content;
-
-    // Break labels into separate lines
-    // sass-lint:disable force-pseudo-nesting
-    &:nth-child(1n-1)::after {
-      content: '\A';
-      white-space: pre-line;
-      // VTT flex styling can increase this elements height, making the background larger
-      height: 0;
-    }
-  }
-
-  // Move the subtitle up above the controlbar when it appears to avoid them overlapping
-  &.#{$prefix}-controlbar-visible {
-    bottom: 5em;
-    transition: bottom $animation-duration-short ease-in;
-  }
-}
-
-.#{$prefix}-ui-uicontainer .#{$prefix}-ui-subtitle-overlay * {
-  // This aims to prevent possibly conflicting style definitions inherited
-  // from target applications which can break subtitles styling. It's still possible
-  // to override this with selector of higher priority score.
-  all: unset;
 }

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -58,7 +58,7 @@
 
 .#{$prefix}-ui-uicontainer .#{$prefix}-ui-subtitle-overlay * {
   // This aims to prevent possibly conflicting style definitions inherited
-  // from target applications whuch can break subtitle styling. It's still possible
+  // from target applications which can break subtitles styling. It's still possible
   // to override this with selector of higher priority score.
   all: unset;
 }

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -1,71 +1,69 @@
 @import '../variables';
 @import '../mixins';
 
-.#{$prefix}-ui-uicontainer {
-  .#{$prefix}-ui-subtitle-overlay {
-    @extend %ui-container;
-    @include hidden;
+.#{$prefix}-ui-uicontainer .#{$prefix}-ui-subtitle-overlay {
+  @extend %ui-container;
+  @include hidden;
 
-    bottom: 0;
-    font-size: 1.2em;
-    left: 0;
-    pointer-events: none;
+  bottom: 0;
+  font-size: 1.2em;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 0;
+  transition: bottom $animation-duration-short ease-out;
+
+  * {
+    // This aims to prevent possibly conflicting style definitions inherited
+    // from target applications which can break subtitles styling. It's still possible
+    // to override this with selector of higher priority score.
+    all: unset;
+  }
+
+  p {
+    // It may happen that we sender <p> inside of an <span> and the `all: unset;` reseting above sets
+    // p to inherit the inline display instead of its default display block so this sets it back.
+    display: block;
+  }
+
+  .#{$prefix}-subtitle-region-container {
     position: absolute;
-    right: 0;
-    text-align: center;
-    top: 0;
-    transition: bottom $animation-duration-short ease-out;
 
-    * {
-      // This aims to prevent possibly conflicting style definitions inherited
-      // from target applications which can break subtitles styling. It's still possible
-      // to override this with selector of higher priority score.
-      all: unset;
+    &.#{$prefix}-subtitle-position-default {
+      bottom: 2em;
+      left: 3em;
+      right: 3em;
+      top: initial;
     }
 
-    p {
-      // It may happen that we sender <p> inside of an <span> and the `all: unset;` reseting above sets
-      // p to inherit the inline display instead of its default display block so this sets it back.
-      display: block;
-    }
-
-    .#{$prefix}-subtitle-region-container {
+    &.#{$prefix}-subtitle-position-bottom > div {
+      bottom: 0;
       position: absolute;
-
-      &.#{$prefix}-subtitle-position-default {
-        bottom: 2em;
-        left: 3em;
-        right: 3em;
-        top: initial;
-      }
-
-      &.#{$prefix}-subtitle-position-bottom > div {
-        bottom: 0;
-        position: absolute;
-        width: 100%;
-      }
+      width: 100%;
     }
+  }
 
-    .#{$prefix}-ui-subtitle-label {
-      @include text-border($subtitle-text-border-color);
+  .#{$prefix}-ui-subtitle-label {
+    @include text-border($subtitle-text-border-color);
 
-      color: $subtitle-text-color;
-      height: fit-content;
+    color: $subtitle-text-color;
+    height: fit-content;
 
-      // Break labels into separate lines
-      // sass-lint:disable force-pseudo-nesting
-      &:nth-child(1n-1)::after {
-        content: '\A';
-        white-space: pre-line;
-        // VTT flex styling can increase this elements height, making the background larger
-        height: 0;
-      }
+    // Break labels into separate lines
+    // sass-lint:disable force-pseudo-nesting
+    &:nth-child(1n-1)::after {
+      content: '\A';
+      white-space: pre-line;
+      // VTT flex styling can increase this elements height, making the background larger
+      height: 0;
     }
+  }
 
-    // Move the subtitle up above the controlbar when it appears to avoid them overlapping
-    &.#{$prefix}-controlbar-visible {
-      bottom: 5em;
-      transition: bottom $animation-duration-short ease-in;
-    }
+  // Move the subtitle up above the controlbar when it appears to avoid them overlapping
+  &.#{$prefix}-controlbar-visible {
+    bottom: 5em;
+    transition: bottom $animation-duration-short ease-in;
   }
 }


### PR DESCRIPTION
It may happen that TTML elements rendered inside of `bmpui-ui-subtitle-overlay` conflict with other style definitions on the target application resulting in broken or unexpected subtitle styling. This aims to perform some basic reset on elements nested inside of `bmpui-ui-subtitle-overlay` to try to prevent this.