### PR TITLE
Fix jumping behaviour of the seekbar scrubber while still seeking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Fixed
-- Dragging the scrubber in the seekbar jumping between locations during a seek operation
+- The scrubber could jump to an old position during a seek operation when it was dragged.
 
 ## [3.31.0] - 2021-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Dragging the scrubber in the seekbar jumping between locations during a seek operation
+
 ## [3.31.0] - 2021-10-12
 
 ### Added

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -52,4 +52,49 @@ describe('SeekBar', () => {
       expect(clearSpy).toHaveBeenCalled();
     });
   });
+
+  describe('playback position', () => {
+    let setPlaybackPositionSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.spyOn(playerMock, 'getDuration').mockReturnValue(20);
+      seekbar.configure(playerMock, uiInstanceManagerMock);
+
+      setPlaybackPositionSpy = jest.spyOn(seekbar, 'setPlaybackPosition');
+    })
+
+    describe('when the player is seeking', () => {
+      beforeEach(() => {
+        jest.spyOn(seekbar, 'isSeeking').mockReturnValue(true);
+      })
+
+      test.each`
+      isLive
+      ${false}
+      ${true}
+      `('will not be set when isLive=$isLive and a stall ended event is fired', ({isLive}) => {
+        if (isLive) {
+          jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(-60);
+        }
+        jest.spyOn(playerMock, 'isLive').mockReturnValue(isLive);
+
+        playerMock.eventEmitter.fireStallEndedEvent();
+        expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(0);
+      })
+    })
+
+    test.each`
+      isLive
+      ${false}
+      ${true}
+      `('will not be set when isLive=$isLive and a stall ended event is fired', ({isLive}) => {
+      if (isLive) {
+        jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(-60);
+      }
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(isLive);
+
+      playerMock.eventEmitter.fireStallEndedEvent();
+      expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(1);
+    })
+  })
 });

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -63,38 +63,23 @@ describe('SeekBar', () => {
       setPlaybackPositionSpy = jest.spyOn(seekbar, 'setPlaybackPosition');
     })
 
-    describe('when the player is seeking', () => {
-      beforeEach(() => {
-        jest.spyOn(seekbar, 'isSeeking').mockReturnValue(true);
-      })
-
-      test.each`
-      isLive
-      ${false}
-      ${true}
-      `('will not be set when isLive=$isLive and a stall ended event is fired', ({isLive}) => {
-        if (isLive) {
-          jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(-60);
-        }
-        jest.spyOn(playerMock, 'isLive').mockReturnValue(isLive);
-
-        playerMock.eventEmitter.fireStallEndedEvent();
-        expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(0);
-      })
-    })
-
     test.each`
-      isLive
-      ${false}
-      ${true}
-      `('will not be set when isLive=$isLive and a stall ended event is fired', ({isLive}) => {
-      if (isLive) {
-        jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(-60);
-      }
-      jest.spyOn(playerMock, 'isLive').mockReturnValue(isLive);
+      isLive | isSeeking | timesCalled
+      ${false} | ${true} | ${0}
+      ${true} | ${true} | ${0}
+      ${false} | ${false} | ${1}
+      ${true} | ${false} | ${1}
+      `('will not be set when isLive=$isLive, isSeeking=$isSeeking and a stall ended event is fired',
+        ({isLive, isSeeking, timesCalled}) => {
+          if (isLive) {
+            jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(-60);
+          }
+          jest.spyOn(seekbar, 'isSeeking').mockReturnValue(isSeeking);
+          jest.spyOn(playerMock, 'isLive').mockReturnValue(isLive);
 
-      playerMock.eventEmitter.fireStallEndedEvent();
-      expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(1);
-    })
+          playerMock.eventEmitter.fireStallEndedEvent();
+
+          expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(timesCalled);
+        })
   })
 });

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -249,7 +249,9 @@ export class SeekBar extends Component<SeekBarConfig> {
         // paused nor playing. Playback updates are handled in the Timeout below.
         if (this.config.smoothPlaybackPositionUpdateIntervalMs === SeekBar.SMOOTH_PLAYBACK_POSITION_UPDATE_DISABLED
           || forceUpdate || player.isPaused() || (player.isPaused() === player.isPlaying())) {
-          this.setPlaybackPosition(playbackPositionPercentage);
+          if (!this.isSeeking()) {
+            this.setPlaybackPosition(playbackPositionPercentage);
+          }
         }
 
         this.setBufferPosition(playbackPositionPercentage + bufferPercentage);
@@ -478,6 +480,10 @@ export class SeekBar extends Component<SeekBarConfig> {
     let currentTimeUpdateDeltaSecs = updateIntervalMs / 1000;
 
     this.smoothPlaybackPositionUpdater = new Timeout(updateIntervalMs, () => {
+      if (this.isSeeking()) {
+        return;
+      }
+
       currentTimeSeekBar += currentTimeUpdateDeltaSecs;
 
       try {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -219,8 +219,8 @@ export class SeekBar extends Component<SeekBarConfig> {
           // This case must be explicitly handled to avoid division by zero
           this.setPlaybackPosition(100);
         } else {
-          let playbackPositionPercentage = 100 - (100 / player.getMaxTimeShift() * player.getTimeShift());
           if (!this.isSeeking()) {
+            const playbackPositionPercentage = 100 - (100 / player.getMaxTimeShift() * player.getTimeShift());
             this.setPlaybackPosition(playbackPositionPercentage);
           }
           this.setAriaSliderMinMax(player.getMaxTimeShift().toString(), '0');

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -249,11 +249,12 @@ export class SeekBar extends Component<SeekBarConfig> {
 
         // Update playback position only in paused state or in the initial startup state where player is neither
         // paused nor playing. Playback updates are handled in the Timeout below.
-        if (this.config.smoothPlaybackPositionUpdateIntervalMs === SeekBar.SMOOTH_PLAYBACK_POSITION_UPDATE_DISABLED
-          || forceUpdate || player.isPaused() || (player.isPaused() === player.isPlaying())) {
-          if (!this.isSeeking()) {
-            this.setPlaybackPosition(playbackPositionPercentage);
-          }
+        const isInInitialStartupState = this.config.smoothPlaybackPositionUpdateIntervalMs === SeekBar.SMOOTH_PLAYBACK_POSITION_UPDATE_DISABLED
+            || forceUpdate || player.isPaused();
+        const isNeitherPausedNorPlaying = player.isPaused() === player.isPlaying()
+
+        if ((isInInitialStartupState || isNeitherPausedNorPlaying) && !this.isSeeking()) {
+          this.setPlaybackPosition(playbackPositionPercentage);
         }
 
         this.setBufferPosition(playbackPositionPercentage + bufferPercentage);

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -220,7 +220,9 @@ export class SeekBar extends Component<SeekBarConfig> {
           this.setPlaybackPosition(100);
         } else {
           let playbackPositionPercentage = 100 - (100 / player.getMaxTimeShift() * player.getTimeShift());
-          this.setPlaybackPosition(playbackPositionPercentage);
+          if (!this.isSeeking()) {
+            this.setPlaybackPosition(playbackPositionPercentage);
+          }
           this.setAriaSliderMinMax(player.getMaxTimeShift().toString(), '0');
         }
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -251,7 +251,7 @@ export class SeekBar extends Component<SeekBarConfig> {
         // paused nor playing. Playback updates are handled in the Timeout below.
         const isInInitialStartupState = this.config.smoothPlaybackPositionUpdateIntervalMs === SeekBar.SMOOTH_PLAYBACK_POSITION_UPDATE_DISABLED
             || forceUpdate || player.isPaused();
-        const isNeitherPausedNorPlaying = player.isPaused() === player.isPlaying()
+        const isNeitherPausedNorPlaying = player.isPaused() === player.isPlaying();
 
         if ((isInInitialStartupState || isNeitherPausedNorPlaying) && !this.isSeeking()) {
           this.setPlaybackPosition(playbackPositionPercentage);


### PR DESCRIPTION
As already identified by @iktumi  on https://github.com/bitmovin/bitmovin-player-ui/pull/387, the scrubber will bounce forward and backward while seeking. 

Why:
This happens due to the smooth transition of the scrubber connected to the current time of the player.
Every time the scrubber is moved, the relevant seek information is updated with the current time, which then moves the scrubber. 
Also when the player fires the appropriate events like 'Seeked' the position will be updated, which will overwrite the newly dragged position. 

Fix:
Do not update the scrubber position if the user is currently seeking, but still allow other operations such as dragging and position updates to update the scrubber. 