### PR TITLE
[Fix] Jumping scrubber when a segment is downloaded and the scrubber is dragged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - The scrubber could jump to an old position during a seek operation when it was dragged.
+- The Seekbar scrubber could jump to an old position on touch devices when a new buffer is available during a seek operation.
 
 ## [3.31.0] - 2021-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - The scrubber could jump to an old position during a seek operation when it was dragged.
-- The Seekbar scrubber could jump to an old position on touch devices when a new buffer is available during a seek operation.
+- The Seekbar scrubber could jump to an old position on touch devices when the buffer updates during a seek operation.
 
 ## [3.31.0] - 2021-10-12
 

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -91,6 +91,43 @@ describe('SeekBar', () => {
       playerMock.eventEmitter.fireSegmentRequestFinished();
       expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(1);
     });
+
+    describe('vod event tracking', () => {
+
+      beforeEach(() => {
+        jest.spyOn(playerMock, 'getDuration').mockReturnValue(50);
+
+        jest.spyOn(playerMock, 'getSeekableRange').mockImplementation(() => ({start: 30, end: 40}));
+
+        const currentTime = 35;
+        jest.spyOn(playerMock, 'getCurrentTime').mockReturnValue(currentTime);
+
+        playerMock.eventEmitter.fireSeekEvent(currentTime);
+        playerMock.eventEmitter.fireSeekedEvent();
+      })
+
+      it('will use the last known playback position location after a successful segment request download and the user is scrubbing', function () {
+        const firstPlaybackPercentage = seekbar['playbackPositionPercentage'];
+
+        jest.spyOn(playerMock, 'getSeekableRange').mockImplementation(() => ({start: 26, end: 30}));
+
+        seekbar['onSeekPreviewEvent'](40, true)
+
+        playerMock.eventEmitter.fireSegmentRequestFinished();
+
+        expect(setPlaybackPositionSpy).toHaveBeenLastCalledWith(firstPlaybackPercentage);
+      });
+
+      it('will update the scrubber location after a successful segment request download and the user is not scrubbing', function () {
+        jest.spyOn(playerMock, 'getSeekableRange').mockImplementation(() => ({start: 26, end: 30}));
+
+        seekbar['onSeekPreviewEvent'](18, false)
+
+        playerMock.eventEmitter.fireSegmentRequestFinished();
+
+        expect(setPlaybackPositionSpy).toHaveBeenLastCalledWith(18);
+      });
+    });
   })
 
   describe('buffer levels', () => {

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -82,18 +82,17 @@ describe('SeekBar', () => {
           expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(timesCalled);
         })
 
-    it('will be moved after a successful seeked event', function () {
+    it('will be moved after a successful seeked event',  () => {
       playerMock.eventEmitter.fireSeekedEvent();
       expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('will move after a successful segment request download', function () {
+    it('will move after a successful segment request download',  () => {
       playerMock.eventEmitter.fireSegmentRequestFinished();
       expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(1);
     });
 
     describe('vod event tracking', () => {
-
       let setBufferPositionSpy: jest.SpyInstance;
 
       beforeEach(() => {
@@ -110,7 +109,7 @@ describe('SeekBar', () => {
         playerMock.eventEmitter.fireSeekedEvent();
       })
 
-      it('will use the last known playback position location after a successful segment request download and the user is scrubbing', function () {
+      it('will use the last known playback position location after a successful segment request download and the user is scrubbing', () => {
         const firstPlaybackPercentage = seekbar['playbackPositionPercentage'];
 
         jest.spyOn(playerMock, 'getSeekableRange').mockImplementation(() => ({start: 26, end: 30}));
@@ -125,7 +124,7 @@ describe('SeekBar', () => {
         expect(setBufferPositionSpy).toHaveBeenLastCalledWith(expectedPlaybackPercentage)
       });
 
-      it('will update the scrubber location after a successful segment request download and the user is not scrubbing', function () {
+      it('will update the scrubber location after a successful segment request download and the user is not scrubbing', () => {
         jest.spyOn(playerMock, 'getSeekableRange').mockImplementation(() => ({start: 26, end: 30}));
 
         seekbar['onSeekPreviewEvent'](18, false)

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -87,14 +87,17 @@ describe('SeekBar', () => {
       expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('will not move after a successful segment request download', function () {
+    it('will move after a successful segment request download', function () {
       playerMock.eventEmitter.fireSegmentRequestFinished();
-      expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(0);
+      expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(1);
     });
   })
 
   describe('buffer levels', () => {
     beforeEach(() => {
+      jest.spyOn(playerMock, 'getDuration').mockReturnValue(20);
+      jest.spyOn(playerMock, 'getMaxTimeShift').mockReturnValue(-60);
+
       seekbar.configure(playerMock, uiInstanceManagerMock);
     })
 
@@ -106,12 +109,13 @@ describe('SeekBar', () => {
 
       const setBufferPositionSpy = jest.spyOn(seekbar, 'setBufferPosition');
       jest.spyOn(playerMock, 'isLive').mockReturnValue(isLive);
-      const value = 100;
+      jest.spyOn(playerMock, 'getCurrentTime').mockReturnValue(35);
+      jest.spyOn(playerMock, 'getSeekableRange').mockReturnValue({start:30, end: 40});
 
       playerMock.eventEmitter.fireSegmentRequestFinished();
 
       expect(setBufferPositionSpy).toHaveBeenCalledTimes(1);
-      expect(setBufferPositionSpy).toHaveBeenCalledWith(isLive ? 100 : value);
+      expect(setBufferPositionSpy).toHaveBeenCalledWith(isLive ? 100 : 25);
     })
   });
 });

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -81,5 +81,37 @@ describe('SeekBar', () => {
 
           expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(timesCalled);
         })
+
+    it('will be moved after a successful seeked event', function () {
+      playerMock.eventEmitter.fireSeekedEvent();
+      expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('will not move after a successful segment request download', function () {
+      playerMock.eventEmitter.fireSegmentRequestFinished();
+      expect(setPlaybackPositionSpy).toHaveBeenCalledTimes(0);
+    });
   })
+
+  describe('buffer levels', () => {
+    beforeEach(() => {
+      seekbar.configure(playerMock, uiInstanceManagerMock);
+    })
+
+    test.each`
+    isLive
+    ${true} 
+    ${false}
+    `('should get updated accordingly when a request has finished and isLive=$isLive', ({isLive}) => {
+
+      const setBufferPositionSpy = jest.spyOn(seekbar, 'setBufferPosition');
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(isLive);
+      const value = 100;
+
+      playerMock.eventEmitter.fireSegmentRequestFinished();
+
+      expect(setBufferPositionSpy).toHaveBeenCalledTimes(1);
+      expect(setBufferPositionSpy).toHaveBeenCalledWith(isLive ? 100 : value);
+    })
+  });
 });

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -94,7 +94,11 @@ describe('SeekBar', () => {
 
     describe('vod event tracking', () => {
 
+      let setBufferPositionSpy: jest.SpyInstance;
+
       beforeEach(() => {
+        setBufferPositionSpy = jest.spyOn(seekbar, 'setBufferPosition');
+
         jest.spyOn(playerMock, 'getDuration').mockReturnValue(50);
 
         jest.spyOn(playerMock, 'getSeekableRange').mockImplementation(() => ({start: 30, end: 40}));
@@ -116,6 +120,9 @@ describe('SeekBar', () => {
         playerMock.eventEmitter.fireSegmentRequestFinished();
 
         expect(setPlaybackPositionSpy).toHaveBeenLastCalledWith(firstPlaybackPercentage);
+
+        const expectedPlaybackPercentage = 18;
+        expect(setBufferPositionSpy).toHaveBeenLastCalledWith(expectedPlaybackPercentage)
       });
 
       it('will update the scrubber location after a successful segment request download and the user is not scrubbing', function () {
@@ -126,6 +133,7 @@ describe('SeekBar', () => {
         playerMock.eventEmitter.fireSegmentRequestFinished();
 
         expect(setPlaybackPositionSpy).toHaveBeenLastCalledWith(18);
+        expect(setBufferPositionSpy).toHaveBeenLastCalledWith(18)
       });
     });
   })

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -105,6 +105,7 @@ export namespace MockHelper {
         isStalled: jest.fn(),
         isCasting: jest.fn(),
         isViewModeAvailable: jest.fn(),
+        seek: jest.fn(),
 
         // Event faker
         eventEmitter: eventHelper,

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -13,6 +13,7 @@ import {
   PlayerEventBase,
   PlayerEventCallback,
   SeekEvent,
+  SegmentRequestFinishedEvent,
   SubtitleCueEvent,
   SubtitleEvent,
   SubtitleTrack,
@@ -59,6 +60,21 @@ export class PlayerEventEmitter {
       time: 10,
       timestamp: Date.now(),
       type: PlayerEvent.Paused,
+    });
+  }
+
+  public fireSegmentRequestFinished() {
+    this.fireEvent<SegmentRequestFinishedEvent>({
+      timestamp: Date.now(),
+      type: PlayerEvent.SegmentRequestFinished,
+      httpStatus: 200,
+      downloadTime: 0,
+      mimeType: 'video/mp4',
+      success: true,
+      uid: 'unique-id',
+      size: 1,
+      duration: 1,
+      isInit: false,
     });
   }
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -290,12 +290,10 @@ export class SeekBar extends Component<SeekBarConfig> {
     player.on(player.exports.PlayerEvent.TimeChanged, playbackPositionHandler);
     // update bufferlevel when buffering is complete
     player.on(player.exports.PlayerEvent.StallEnded, playbackPositionHandler);
-    // update playback position when a seek has finished
-    player.on(player.exports.PlayerEvent.Seeked, playbackPositionHandler);
     // update playback position when a timeshift has finished
     player.on(player.exports.PlayerEvent.TimeShifted, playbackPositionHandler);
     // update bufferlevel when a segment has been downloaded
-    player.on(player.exports.PlayerEvent.SegmentRequestFinished, playbackPositionHandler);
+    player.on(player.exports.PlayerEvent.SegmentRequestFinished, () => updateBufferLevel(getPlaybackPositionPercentage()));
 
     this.configureLivePausedTimeshiftUpdater(player, uimanager, playbackPositionHandler);
 
@@ -305,9 +303,12 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.setSeeking(true);
     };
 
-    let onPlayerSeeked = () => {
+    let onPlayerSeeked = (event: PlayerEventBase = null, forceUpdate: boolean = false ) => {
       isPlayerSeeking = false;
       this.setSeeking(false);
+
+      // update playback position when a seek has finished
+      playbackPositionHandler(event, forceUpdate)
     };
 
     let restorePlayingState = function () {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -342,7 +342,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     this.onSeekPreview.subscribe((sender: SeekBar, args: SeekPreviewEventArgs) => {
       // Notify UI manager of seek preview
       uimanager.onSeekPreview.dispatch(sender, args);
-      scrubbing = true;
+      scrubbing = args.scrubbing;
     });
 
     // Rate-limited scrubbing seek

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -318,7 +318,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.setSeeking(false);
 
       // update playback position when a seek has finished
-      playbackPositionHandler(event, forceUpdate)
+      playbackPositionHandler(event, forceUpdate);
     };
 
     let restorePlayingState = function () {

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -302,7 +302,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     // update playback position when a timeshift has finished
     player.on(player.exports.PlayerEvent.TimeShifted, playbackPositionHandler);
     // update bufferlevel when a segment has been downloaded
-    player.on(player.exports.PlayerEvent.SegmentRequestFinished, () => updateBufferLevel(getPlaybackPositionPercentage()));
+    player.on(player.exports.PlayerEvent.SegmentRequestFinished, playbackPositionHandler);
 
     this.configureLivePausedTimeshiftUpdater(player, uimanager, playbackPositionHandler);
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -252,6 +252,8 @@ export class SeekBar extends Component<SeekBarConfig> {
 
       let playbackPositionPercentage = getPlaybackPositionPercentage();
 
+      updateBufferLevel(playbackPositionPercentage);
+
       // The segment request finished is used to help the playback position move, when the smooth playback position is not enabled.
       // At the same time when the user is scrubbing, we also move the position of the seekbar to display a preview during scrubbing.
       // When the user is scrubbing we do not record this as a user seek operation, as the user has yet to finish their seek,
@@ -284,8 +286,6 @@ export class SeekBar extends Component<SeekBarConfig> {
 
         this.setAriaSliderMinMax('0', player.getDuration().toString());
       }
-
-      updateBufferLevel(playbackPositionPercentage);
 
       if (this.isUiShown) {
         this.setAriaSliderValues();


### PR DESCRIPTION
Problem:
When using the scrubber on a touch device or dragging it with the mouse, there is a chance that the scrubber will bounce back to the previous position. 
This happens due to the segment request finished updating the playback location and the user is also is dragging the scrubber. Both operations happen in parallel but there is no seeking happening yet, since dragging does not start a seek operation until the user drops the seek bar.

Also it is possible that the `seeked` event fired from the player is not in sync with setting the seeking, since they are tracked in 2 different event callbacks.

Resolve:
- Keep track of the scrubbing action to not trigger a position update if there was a segment request finished. 
- Move both `seeked` handling callbacks into one callback. 