### PR TITLE
[PW-6220] Provide ability to override ListBox aria-labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
+### Added
+- Support for providing custom `aria-label` when ListBox is used.
+
 ### Fixed
 - Updating the markers on live streams causing unhandled exception after player is destroyed
 

--- a/spec/components/listselector.spec.ts
+++ b/spec/components/listselector.spec.ts
@@ -62,9 +62,6 @@ describe('ListSelector', () => {
   });
 
   describe('addItem with custom aria label', () => {
-    beforeEach(() => {
-    });
-
     it('adds a new item with custom aria label', () => {
       listSelector.addItem('itemKey', 'itemLabel', false, 'itemAriaLabel');
 

--- a/spec/components/listselector.spec.ts
+++ b/spec/components/listselector.spec.ts
@@ -1,4 +1,4 @@
- import { ListItem, ListSelector, ListSelectorConfig } from '../../src/ts/components/listselector';
+import { ListItem, ListSelector, ListSelectorConfig } from '../../src/ts/components/listselector';
 
 class ListSelectorTestClass extends ListSelector<ListSelectorConfig> {
 }

--- a/spec/components/listselector.spec.ts
+++ b/spec/components/listselector.spec.ts
@@ -1,4 +1,4 @@
-import { ListItem, ListSelector, ListSelectorConfig } from '../../src/ts/components/listselector';
+ import { ListItem, ListSelector, ListSelectorConfig } from '../../src/ts/components/listselector';
 
 class ListSelectorTestClass extends ListSelector<ListSelectorConfig> {
 }
@@ -58,6 +58,49 @@ describe('ListSelector', () => {
       listSelector.addItem('itemKeyNew', 'itemLabelNew');
 
       expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('addItem with custom aria label', () => {
+    beforeEach(() => {
+    });
+
+    it('adds a new item with custom aria label', () => {
+      listSelector.addItem('itemKey', 'itemLabel', false, 'itemAriaLabel');
+
+      expect(listSelector.getItems()).toEqual([{ key: 'itemKey', label: 'itemLabel', ariaLabel: 'itemAriaLabel'}]);
+    });
+
+    it('adds new items to the end of the list with custom aria label', () => {
+      listSelector.addItem('A', 'itemA', false, 'itemAriaLabelA');
+      listSelector.addItem('C', 'itemC', false, 'itemAriaLabelB');
+      listSelector.addItem('B', 'itemB', false, 'itemAriaLabelC');
+
+      expect(listSelector.getItems()).toEqual([
+        { key: 'A', label: 'itemA', ariaLabel: 'itemAriaLabelA'},
+        { key: 'C', label: 'itemC', ariaLabel: 'itemAriaLabelB'},
+        { key: 'B', label: 'itemB', ariaLabel: 'itemAriaLabelC'},
+      ]);
+    });
+
+    it('adds items respecting the key order if sortedInsert is true and with custom aria label', () => {
+      const sortedInsert = true;
+      listSelector.addItem('A', 'itemA', sortedInsert, 'itemAriaLabelA');
+      listSelector.addItem('C', 'itemC', sortedInsert, 'itemAriaLabelC');
+      listSelector.addItem('B', 'itemB', sortedInsert, 'itemAriaLabelB');
+
+      expect(listSelector.getItems()).toEqual([
+        { key: 'A', label: 'itemA', ariaLabel: 'itemAriaLabelA'},
+        { key: 'B', label: 'itemB', ariaLabel: 'itemAriaLabelB' },
+        { key: 'C', label: 'itemC', ariaLabel: 'itemAriaLabelC' },
+      ]);
+    });
+
+    it('overrides existing value with custom aria label', () => {
+      listSelector.addItem('itemKey', 'itemLabelOld', false, 'itemAriaLabelOld');
+      listSelector.addItem('itemKey', 'itemLabelNew', false, 'itemAriaLabelNew');
+
+      expect(listSelector.getItems()).toEqual([{ key: 'itemKey', label: 'itemLabelNew', ariaLabel: 'itemAriaLabelNew' }]);
     });
   });
 

--- a/src/ts/components/listbox.ts
+++ b/src/ts/components/listbox.ts
@@ -109,6 +109,7 @@ export class ListBox extends ListSelector<ListSelectorConfig> {
     return new ListBoxItemButton({
       key: listItem.key,
       text: listItem.label,
+      ariaLabel: listItem.ariaLabel,
     });
   }
 

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -109,7 +109,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    * @param ariaLabel custom aria label for the listItem
    */
   addItem(key: string, label: LocalizableText, sortedInsert = false, ariaLabel = '') {
-    const listItem = { key: key, label: i18n.performLocalization(label), ...(ariaLabel && {ariaLabel: ariaLabel})};
+    const listItem = { key: key, label: i18n.performLocalization(label), ...(ariaLabel && { ariaLabel })};
 
     // Apply filter function
     if (this.config.filter && !this.config.filter(listItem)) {

--- a/src/ts/components/listselector.ts
+++ b/src/ts/components/listselector.ts
@@ -9,6 +9,8 @@ import { LocalizableText, i18n } from '../localization/i18n';
 export interface ListItem {
   key: string;
   label: LocalizableText;
+  sortedInsert?: boolean;
+  ariaLabel?: string;
 }
 
 /**
@@ -104,9 +106,10 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    * @param key the key of the item to add
    * @param label the (human-readable) label of the item to add
    * @param sortedInsert whether the item should be added respecting the order of keys
+   * @param ariaLabel custom aria label for the listItem
    */
-  addItem(key: string, label: LocalizableText, sortedInsert = false) {
-    const listItem = { key: key, label: i18n.performLocalization(label) };
+  addItem(key: string, label: LocalizableText, sortedInsert = false, ariaLabel = '') {
+    const listItem = { key: key, label: i18n.performLocalization(label), ...(ariaLabel && {ariaLabel: ariaLabel})};
 
     // Apply filter function
     if (this.config.filter && !this.config.filter(listItem)) {
@@ -199,7 +202,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
   synchronizeItems(newItems: ListItem[]): void {
     newItems
       .filter((item) => !this.hasItem(item.key))
-      .forEach((item) => this.addItem(item.key, item.label));
+      .forEach((item) => this.addItem(item.key, item.label, item.sortedInsert, item.ariaLabel));
 
     this.items
       .filter((item) => newItems.filter((i) => i.key === item.key).length === 0)


### PR DESCRIPTION
Problem: By default, we are using label/text as `aria-label` for list-item when Listbox is used. When complex HTML is used as a label customer wants to have an option to provide a different value for `aria-label`

Fix: provided an option to pass optional `aria-label` when  `additem` is called for adding new items to the Listbox