### PR TITLE
Fix timeshift markers causing unhandled exception timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## [develop]
+
+### Fixed
+- Update the markers on live streams causing unhandled exception after player is destroyed
 
 ## [3.32.0] - 2021-12-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
 ### Fixed
-- Update the markers on live streams causing unhandled exception after player is destroyed
+- Updating the markers on live streams causing unhandled exception after player is destroyed
 
 ## [3.32.0] - 2021-12-21
 

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -208,6 +208,7 @@ export class TimelineMarkersHandler {
 
     // Stop updater when playback continues (no matter if the updater was started before)
     this.player.on(this.player.exports.PlayerEvent.Play, () => this.pausedTimeshiftUpdater.clear());
+    this.player.on(this.player.exports.PlayerEvent.Destroy, () => this.pausedTimeshiftUpdater.clear());
   }
 
   protected prefixCss(cssClassOrId: string): string {


### PR DESCRIPTION
## Problem
When you launch a stream and destroy the player before the 'Play' event is sent out, the console will report an unhandled exception to update the markers every 1 second. This is caused due to the `configureLivePausedTimeshiftUpdater` scheduling the timeout every 1s, but we never clear this timeout if the player was destroyed.

## Fix
Listen for player destroyed and clear the `pausedTimeshiftUpdater` 
