### PR TITLE
Use error message from `ErrorEvent` when one is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [develop]
 
+### Changed
+- `PlayerError` events that provide a message are displayed instead of default messages
+
 ### Fixed
 - Updating the markers on live streams causing unhandled exception after player is destroyed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2577,9 +2577,9 @@
       "dev": true
     },
     "bitmovin-player": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.28.0.tgz",
-      "integrity": "sha512-2gRZnqoUMmJY2oSyEYbokMKHVcqZ1KzRjnpB5TkorC79kLKqq09+/12p04T8iVkroPAosICkElxLKIstEIHzcQ==",
+      "version": "8.76.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.76.0.tgz",
+      "integrity": "sha512-wv45U3XM8v+Zwu2w6CgJ2KMFiaWuGt7COFgJeUsLEnY5eLbpw7Ffbp6EW1mlsL/5z+9OiGkdcWdkYQFS5BOrzw==",
       "dev": true
     },
     "bl": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/jest": "^24.0.11",
     "@types/jsdom": "^12.2.4",
     "autoprefixer": "^6.5.2",
-    "bitmovin-player": "^8.28.0",
+    "bitmovin-player": "^8.74.0",
     "browser-sync": "^2.26.3",
     "browserify": "^13.1.1",
     "cssnano": "^3.8.0",

--- a/src/ts/errorutils.ts
+++ b/src/ts/errorutils.ts
@@ -73,7 +73,7 @@ export namespace ErrorUtils {
   };
 
   export const defaultWebErrorMessageTranslator: ErrorMessageTranslator = (error: ErrorEvent) => {
-    const errorMessage = ErrorUtils.defaultErrorMessages[error.code];
+    const errorMessage = error.message ?? ErrorUtils.defaultErrorMessages[error.code];
 
     if (errorMessage) {
       // Use the error message text if there is one


### PR DESCRIPTION
We have started attaching more context to error events in bitdash. This includes a message property as well (introduced in 8.74).

Change: use the message from the event if there is one, fallback to the default message.

Before:
<img width="428" alt="Schermata 2022-01-17 alle 14 12 01" src="https://user-images.githubusercontent.com/24275000/149775252-a97b619f-de9e-4db9-9ee3-ffaee79fb4b0.png">

After:
<img width="686" alt="Schermata 2022-01-17 alle 14 11 39" src="https://user-images.githubusercontent.com/24275000/149775264-a7f65cf9-9552-4152-a9f6-7ad10cc1c0b7.png">

