### PR TITLE
Add unit tests for aria label toggle

### DIFF
--- a/spec/components/playbacktogglebutton.spec.ts
+++ b/spec/components/playbacktogglebutton.spec.ts
@@ -38,11 +38,12 @@ describe('ToggleButton', () => {
       const offLocalizer = () => 'off';
 
       const config: ToggleButtonConfig = {
-        onAriaLabel: offLocalizer,
+        offAriaLabel: offLocalizer,
       };
 
       toggleButton = new ToggleButton(config);
       toggleButton.on();
+      toggleButton.off();
 
       expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'off');
     });

--- a/spec/components/playbacktogglebutton.spec.ts
+++ b/spec/components/playbacktogglebutton.spec.ts
@@ -1,0 +1,50 @@
+import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
+import { UIInstanceManager } from '../../src/ts/uimanager';
+import { ToggleButton } from '../../src/ts/components/togglebutton';
+import { ToggleButtonConfig } from '../../src/ts/components/togglebutton';
+import { DOM } from '../../src/ts/dom';
+
+let playerMock: TestingPlayerAPI;
+let uiInstanceManagerMock: UIInstanceManager;
+let mockDomElement: jest.Mocked<DOM>;
+
+let toggleButton: ToggleButton<ToggleButtonConfig>;
+
+describe('ToggleButton', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+
+    // Setup DOM Mock
+    mockDomElement = MockHelper.generateDOMMock();
+    jest.spyOn(ToggleButton.prototype, 'getDomElement').mockReturnValue(mockDomElement);
+  });
+
+  describe('aria label', () => {
+    it('should set on label when toggle state is on', () => {
+      const onLocalizer = () => 'on';
+
+      const config: ToggleButtonConfig = {
+        onAriaLabel: onLocalizer,
+      };
+
+      toggleButton = new ToggleButton(config);
+      toggleButton.on();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'on');
+    });
+
+    it('should set off label when toggle state is off', () => {
+      const offLocalizer = () => 'off';
+
+      const config: ToggleButtonConfig = {
+        onAriaLabel: offLocalizer,
+      };
+
+      toggleButton = new ToggleButton(config);
+      toggleButton.on();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'off');
+    });
+  });
+});

--- a/spec/components/playbacktogglebutton.spec.ts
+++ b/spec/components/playbacktogglebutton.spec.ts
@@ -34,8 +34,35 @@ describe('ToggleButton', () => {
       expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'on');
     });
 
+    it('should set on label when toggle state is on (string label)', () => {
+      const onLocalizer = 'on';
+
+      const config: ToggleButtonConfig = {
+        onAriaLabel: onLocalizer,
+      };
+
+      toggleButton = new ToggleButton(config);
+      toggleButton.on();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'on');
+    });
+
     it('should set off label when toggle state is off', () => {
       const offLocalizer = () => 'off';
+
+      const config: ToggleButtonConfig = {
+        offAriaLabel: offLocalizer,
+      };
+
+      toggleButton = new ToggleButton(config);
+      toggleButton.on();
+      toggleButton.off();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'off');
+    });
+
+    it('should set off label when toggle state is off (string label)', () => {
+      const offLocalizer = 'off';
 
       const config: ToggleButtonConfig = {
         offAriaLabel: offLocalizer,

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -42,7 +42,7 @@ export namespace MockHelper {
     return new UiInstanceManagerMockClass();
   }
 
-  export function generateDOMMock(): DOM {
+  export function generateDOMMock(): jest.Mocked<DOM> {
     const DOMClass: jest.Mock<DOM> = jest.fn().mockImplementation(() => ({
       addClass: jest.fn(),
       removeClass: jest.fn(),
@@ -56,7 +56,7 @@ export namespace MockHelper {
       append: jest.fn(),
     }));
 
-    return new DOMClass();
+    return new DOMClass() as jest.Mocked<DOM>;
   }
 
   export function getPlayerMock(): TestingPlayerAPI {

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -54,6 +54,7 @@ export namespace MockHelper {
       size: jest.fn(),
       empty: jest.fn(),
       append: jest.fn(),
+      attr: jest.fn(),
     }));
 
     return new DOMClass() as jest.Mocked<DOM>;


### PR DESCRIPTION
Adds unit tests for https://github.com/bitmovin/bitmovin-player-ui/pull/431

When a toggle button changes state through calling `on()` or `off()`, the `aria-label` should be updated accordingly.