### PR TITLE
Fix travis CI status badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bitmovin Player UI [![npm version](https://badge.fury.io/js/bitmovin-player-ui.svg)](https://badge.fury.io/js/bitmovin-player-ui) [![Build Status](https://travis-ci.com/bitmovin/bitmovin-player-ui.svg?branch=master)](https://travis-ci.com/bitmovin/bitmovin-player-ui)
+# Bitmovin Player UI [![npm version](https://badge.fury.io/js/bitmovin-player-ui.svg)](https://badge.fury.io/js/bitmovin-player-ui) [![Build Status](https://app.travis-ci.com/bitmovin/bitmovin-player-ui.svg?branch=develop)](https://app.travis-ci.com/bitmovin/bitmovin-player-ui)
 The Bitmovin Adaptive Streaming Player UI
 
 Read more about the usage, along with other important information about the Bitmovin Player at https://bitmovin.com/ and https://bitmovin.com/docs/player.


### PR DESCRIPTION
Travis has updated the URL for status badges, resulting in a 404 when accessing the one that is currently displayed in the readme.

Also, the branch that used to be referenced does not exist anymore - it is now `main`.
However, since `develop` is now the default branch, it makes more sense to show the build status of that one.