### PR TITLE
Line align "end" not correct for multiple line cues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Fixed
+- Incorrect line alignment for subtitle cues from WebVTT tracks.
+- Incorrect edges of reference for vertical writing cues in block positioning from WebVTT tracks.
+- An empty line is added in vertical subtitle cues.
+
 ## [3.36.0] - 2022-03-15
 
 ### Added

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -203,8 +203,8 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'bottom', '50%');
+              expect(spyCss).toHaveBeenCalledTimes(11);
+              expect(spyCss).toHaveBeenNthCalledWith(8, 'bottom', '50%');
             });
           });
         });
@@ -221,7 +221,7 @@ describe('Vtt Utils', () => {
 
           expect(spyCss).toHaveBeenCalledTimes(11);
           expect(spyCss).toHaveBeenNthCalledWith(6, 'writing-mode', 'vertical-lr');
-          expect(spyCss).toHaveBeenNthCalledWith(7, 'right', '0');
+          expect(spyCss).toHaveBeenNthCalledWith(8, 'left', '0');
         });
 
         describe('Line positioning', () => {
@@ -248,8 +248,8 @@ describe('Vtt Utils', () => {
 
             VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '50%');
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'left', '50%');
           });
 
           it('should set positive line positioning', () => {
@@ -264,8 +264,8 @@ describe('Vtt Utils', () => {
 
             VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '19.047619047619047%');
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'left', '19.047619047619047%');
           });
 
           it('should set negative line positioning', () => {
@@ -280,8 +280,8 @@ describe('Vtt Utils', () => {
 
             VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '80.95238095238095%');
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'left', '80.95238095238095%');
           });
 
           describe('Line alignment', () => {
@@ -298,7 +298,7 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(12);
+              expect(spyCss).toHaveBeenCalledTimes(11);
             });
 
             it('should do center line alignment', () => {
@@ -314,8 +314,8 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'right', '47.5%');
+              expect(spyCss).toHaveBeenCalledTimes(12);
+              expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '47.5%');
             });
 
             it('should do end line alignment', () => {
@@ -331,8 +331,8 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(14);
-              expect(spyCss).toHaveBeenNthCalledWith(11, 'left', '50%');
+              expect(spyCss).toHaveBeenCalledTimes(11);
+              expect(spyCss).toHaveBeenNthCalledWith(8, 'right', '50%');
             });
           });
         });
@@ -349,7 +349,7 @@ describe('Vtt Utils', () => {
 
           expect(spyCss).toHaveBeenCalledTimes(11);
           expect(spyCss).toHaveBeenNthCalledWith(6, 'writing-mode', 'vertical-rl');
-          expect(spyCss).toHaveBeenNthCalledWith(7, 'left', '0');
+          expect(spyCss).toHaveBeenNthCalledWith(8, 'right', '0');
         });
 
         describe('Line positioning', () => {
@@ -376,8 +376,8 @@ describe('Vtt Utils', () => {
 
             VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '50%');
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'right', '50%');
           });
 
           it('should set positive line positioning', () => {
@@ -392,8 +392,8 @@ describe('Vtt Utils', () => {
 
             VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '19.047619047619047%');
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'right', '19.047619047619047%');
           });
 
           it('should set negative line positioning', () => {
@@ -408,8 +408,8 @@ describe('Vtt Utils', () => {
 
             VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-            expect(spyCss).toHaveBeenCalledTimes(12);
-            expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '80.95238095238095%');
+            expect(spyCss).toHaveBeenCalledTimes(11);
+            expect(spyCss).toHaveBeenNthCalledWith(8, 'right', '80.95238095238095%');
           });
 
           describe('Line alignment', () => {
@@ -426,7 +426,7 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(12);
+              expect(spyCss).toHaveBeenCalledTimes(11);
             });
 
             it('should do center line alignment', () => {
@@ -442,8 +442,8 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '47.5%');
+              expect(spyCss).toHaveBeenCalledTimes(12);
+              expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '47.5%');
             });
 
             it('should do end line alignment', () => {
@@ -459,8 +459,8 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(14);
-              expect(spyCss).toHaveBeenNthCalledWith(11, 'right', '50%');
+              expect(spyCss).toHaveBeenCalledTimes(11);
+              expect(spyCss).toHaveBeenNthCalledWith(8, 'left', '50%');
             });
           });
         });

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -188,7 +188,7 @@ describe('Vtt Utils', () => {
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(12);
-              expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-14px');
+              expect(spyCss).toHaveBeenNthCalledWith(9, 'top', '47.5%');
             });
 
             it('should do end line alignment', () => {
@@ -203,8 +203,8 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(12);
-              expect(spyCss).toHaveBeenNthCalledWith(9, 'margin-top', '-28px');
+              expect(spyCss).toHaveBeenCalledTimes(13);
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'bottom', '50%');
             });
           });
         });
@@ -315,7 +315,7 @@ describe('Vtt Utils', () => {
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-14px');
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'right', '47.5%');
             });
 
             it('should do end line alignment', () => {
@@ -331,8 +331,8 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-right', '-28px');
+              expect(spyCss).toHaveBeenCalledTimes(14);
+              expect(spyCss).toHaveBeenNthCalledWith(11, 'left', '50%');
             });
           });
         });
@@ -443,7 +443,7 @@ describe('Vtt Utils', () => {
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-14px');
+              expect(spyCss).toHaveBeenNthCalledWith(10, 'left', '47.5%');
             });
 
             it('should do end line alignment', () => {
@@ -459,8 +459,8 @@ describe('Vtt Utils', () => {
 
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
-              expect(spyCss).toHaveBeenCalledTimes(13);
-              expect(spyCss).toHaveBeenNthCalledWith(10, 'margin-left', '-28px');
+              expect(spyCss).toHaveBeenCalledTimes(14);
+              expect(spyCss).toHaveBeenNthCalledWith(11, 'right', '50%');
             });
           });
         });
@@ -662,6 +662,7 @@ function generateSubtitleCueBoxMock(hasRegion: boolean, vttProps?: VTTProperties
   const region = hasRegion ? vttRegionProps : null;
   const SubtitleCueBoxClass: jest.Mock<SubtitleLabel> = jest.fn().mockImplementation(() => (
     {
+      getText: () => "",
       vtt: {
         ...generateVttProps(vttProps),
         region,

--- a/spec/vttutils.spec.ts
+++ b/spec/vttutils.spec.ts
@@ -188,7 +188,7 @@ describe('Vtt Utils', () => {
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(12);
-              expect(spyCss).toHaveBeenNthCalledWith(9, 'top', '47.5%');
+              expect(spyCss).toHaveBeenNthCalledWith(9, 'transform', 'translateY(-50%)');
             });
 
             it('should do end line alignment', () => {
@@ -315,7 +315,7 @@ describe('Vtt Utils', () => {
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(12);
-              expect(spyCss).toHaveBeenNthCalledWith(9, 'left', '47.5%');
+              expect(spyCss).toHaveBeenNthCalledWith(9, 'transform', 'translateX(-50%)');
             });
 
             it('should do end line alignment', () => {
@@ -443,7 +443,7 @@ describe('Vtt Utils', () => {
               VttUtils.setVttCueBoxStyles(mockRegionContainer, subtitleOverLaySize);
 
               expect(spyCss).toHaveBeenCalledTimes(12);
-              expect(spyCss).toHaveBeenNthCalledWith(9, 'right', '47.5%');
+              expect(spyCss).toHaveBeenNthCalledWith(9, 'transform', 'translateX(50%)');
             });
 
             it('should do end line alignment', () => {
@@ -662,7 +662,7 @@ function generateSubtitleCueBoxMock(hasRegion: boolean, vttProps?: VTTProperties
   const region = hasRegion ? vttRegionProps : null;
   const SubtitleCueBoxClass: jest.Mock<SubtitleLabel> = jest.fn().mockImplementation(() => (
     {
-      getText: () => "",
+      getText: () => '',
       vtt: {
         ...generateVttProps(vttProps),
         region,

--- a/src/scss/skin-modern/components/_subtitleoverlay.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay.scss
@@ -59,6 +59,7 @@
       white-space: pre-line;
       // VTT flex styling can increase this elements height, making the background larger
       height: 0;
+      width: 0;
     }
   }
 

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -136,7 +136,6 @@ const setCueBoxPositionForVerticalWriting = (
 ) => {
     const writingMode = direction === Direction.Right ?
       'vertical-lr' : 'vertical-rl';
-    const opositeEdge = direction;
 
     cueContainerDom.css('writing-mode', writingMode);
     cueContainerDom.css(Direction.Top, '0');
@@ -184,7 +183,6 @@ const setCssForCenterLineAlign = (
   direction: Direction,
   relativeCueBoxPosition: number) => {
   const overlayReferenceEdge = DirectionPair.get(direction);
-  const opositeEdge = DirectionPair.get(direction);
   const centerOffset = lineHeightPercent * lineCount / 2;
   const offset = relativeCueBoxPosition - centerOffset;
   cueContainerDom.css(overlayReferenceEdge, `${offset}%`);
@@ -194,9 +192,8 @@ const setCssForEndLineAlign = (
   cueContainerDom: DOM,
   direction: Direction,
   offset: number) => {
-      const overlayReferenceEdge = DirectionPair.get(direction);
-      const opositeEdge = direction;
-      cueContainerDom.css(opositeEdge, `${100 - offset}%`);
+      const opositeToOverlayReferenceEdge = direction;
+      cueContainerDom.css(opositeToOverlayReferenceEdge, `${100 - offset}%`);
 };
 
 export namespace VttUtils {

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -85,7 +85,7 @@ const setVttLine = (
  * Defines the writing direction of the Cue Box
  * https://w3.org/TR/webvtt1/#webvtt-cue-writing-direction
  */
-const setVttWritingDirection = (
+const setVttWritingDirectionAndCueBoxPositioning = (
   cueContainerDom: DOM, vtt: VTTProperties,
   subtitleOverlaySize: Size,
 ) => {
@@ -147,7 +147,7 @@ export namespace VttUtils {
     const cueContainerDom = cueContainer.getDomElement();
 
     setDefaultVttStyles(cueContainerDom, vtt);
-    setVttWritingDirection(cueContainerDom, vtt, subtitleOverlaySize);
+    setVttWritingDirectionAndCueBoxPositioning(cueContainerDom, vtt, subtitleOverlaySize);
 
     // https://w3.org/TR/webvtt1/#webvtt-cue-text-alignment
     const textAlign = vtt.align === 'middle' ? 'center' : vtt.align;

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -40,13 +40,13 @@ const setDefaultVttStyles = (cueContainerDom: DOM, vtt: VTTProperties) => {
  * Align the Cue Box's line
  * https://w3.org/TR/webvtt1/#webvtt-cue-line-alignment
  */
-const setVttLineAlign = (cueContainerDom: DOM, { lineAlign }: VTTProperties, direction: Direction) => {
+const setVttLineAlign = (cueContainerDom: DOM, { lineAlign }: VTTProperties, direction: Direction, lineCount: number) => {
   switch (lineAlign) {
     case 'center':
       cueContainerDom.css(`margin-${direction}`, `${-lineHeight / 2}px`);
       break;
     case 'end':
-      cueContainerDom.css(`margin-${direction}`, `${-lineHeight}px`);
+      cueContainerDom.css(`margin-${direction}`, `${-lineHeight * lineCount}px`);
   }
 };
 
@@ -59,6 +59,7 @@ const setVttLine = (
   vtt: VTTProperties,
   direction: Direction,
   subtitleOverLaySize: Size,
+  lineCount: number 
 ) => {
   if (vtt.line === 'auto') {
     return;
@@ -78,7 +79,7 @@ const setVttLine = (
   }
 
   cueContainerDom.css(direction, `${relativeLinePosition}%`);
-  setVttLineAlign(cueContainerDom, vtt, direction);
+  setVttLineAlign(cueContainerDom, vtt, direction, lineCount);
 };
 
 /**
@@ -88,21 +89,22 @@ const setVttLine = (
 const setVttWritingDirectionAndCueBoxPositioning = (
   cueContainerDom: DOM, vtt: VTTProperties,
   subtitleOverlaySize: Size,
+  lineCount: number
 ) => {
   if (vtt.vertical === '') {
     cueContainerDom.css('writing-mode', 'horizontal-tb');
     cueContainerDom.css(Direction.Bottom, '0');
-    setVttLine(cueContainerDom, vtt, Direction.Top, subtitleOverlaySize);
+    setVttLine(cueContainerDom, vtt, Direction.Top, subtitleOverlaySize, lineCount);
   } else if (vtt.vertical === 'lr') {
     cueContainerDom.css('writing-mode', 'vertical-lr');
     cueContainerDom.css(Direction.Right, '0');
     cueContainerDom.css(Direction.Top, '0');
-    setVttLine(cueContainerDom, vtt, Direction.Right, subtitleOverlaySize);
+    setVttLine(cueContainerDom, vtt, Direction.Right, subtitleOverlaySize, lineCount);
   } else if (vtt.vertical === 'rl') {
     cueContainerDom.css('writing-mode', 'vertical-rl');
     cueContainerDom.css(Direction.Left, '0');
     cueContainerDom.css(Direction.Top, '0');
-    setVttLine(cueContainerDom, vtt, Direction.Left, subtitleOverlaySize);
+    setVttLine(cueContainerDom, vtt, Direction.Left, subtitleOverlaySize, lineCount);
   }
 };
 
@@ -138,6 +140,7 @@ const setVttPositionAlign = (cueContainerDom: DOM, vtt: VTTProperties, direction
   }
 };
 
+
 export namespace VttUtils {
   export const setVttCueBoxStyles = (
     cueContainer: SubtitleLabel,
@@ -145,9 +148,13 @@ export namespace VttUtils {
   ) => {
     const vtt = cueContainer.vtt;
     const cueContainerDom = cueContainer.getDomElement();
+    const countLines = (innerHtml: string) =>
+      innerHtml.split("<br />").length;
+    const lineCount = countLines(cueContainer.getText());
 
     setDefaultVttStyles(cueContainerDom, vtt);
-    setVttWritingDirectionAndCueBoxPositioning(cueContainerDom, vtt, subtitleOverlaySize);
+
+    setVttWritingDirectionAndCueBoxPositioning(cueContainerDom, vtt, subtitleOverlaySize, lineCount);
 
     // https://w3.org/TR/webvtt1/#webvtt-cue-text-alignment
     const textAlign = vtt.align === 'middle' ? 'center' : vtt.align;

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -51,8 +51,6 @@ const setVttLineAlign = (
   { lineAlign }: VTTProperties,
   direction: Direction,
   relativeCueBoxPosition: number) => {
-  console.log('[i] setLineAlign: lineAlign, offset, direction',
-    lineAlign, relativeCueBoxPosition, direction);
   switch (lineAlign) {
     case 'center':
       setCssForCenterLineAlign(
@@ -110,7 +108,6 @@ const setVttWritingDirectionAndCueBoxPositioning = (
   cueContainerDom: DOM, vtt: VTTProperties,
   subtitleOverlaySize: Size,
 ) => {
-  console.log('[i] setVttWritingDirection: vtt.vertical', vtt.vertical);
   switch (vtt.vertical) {
   case '':
     cueContainerDom.css('writing-mode', 'horizontal-tb');
@@ -119,7 +116,6 @@ const setVttWritingDirectionAndCueBoxPositioning = (
     break;
   // "lr" is "left to right" so this is vertical growing right
   case 'lr':
-    console.log('[i] lr');
     setCueBoxPositionForVerticalWriting(
       cueContainerDom, Direction.Right, vtt, subtitleOverlaySize);
     break;
@@ -198,8 +194,6 @@ const setCssForEndLineAlign = (
   cueContainerDom: DOM,
   direction: Direction,
   offset: number) => {
-      console.log('[i] setCssForEnd: direction, offset',
-        direction, offset);
       const overlayReferenceEdge = DirectionPair.get(direction);
       const opositeEdge = direction;
       cueContainerDom.css(opositeEdge, `${100 - offset}%`);

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -50,9 +50,8 @@ const setVttLineAlign = (
   cueContainerDom: DOM,
   { lineAlign }: VTTProperties,
   direction: Direction,
-  relativeCueBoxPosition: number) =>
-{
-  console.log("[i] setLineAlign: lineAlign, offset, direction",
+  relativeCueBoxPosition: number) => {
+  console.log('[i] setLineAlign: lineAlign, offset, direction',
     lineAlign, relativeCueBoxPosition, direction);
   switch (lineAlign) {
     case 'center':
@@ -73,11 +72,11 @@ const setVttLine = (
   cueContainerDom: DOM,
   vtt: VTTProperties,
   direction: Direction,
-  subtitleOverLaySize: Size
+  subtitleOverLaySize: Size,
 ) => {
   const overlayReferenceEdge = DirectionPair.get(direction);
   if (vtt.line === 'auto' && vtt.vertical) {
-    cueContainerDom.css(overlayReferenceEdge, "0");
+    cueContainerDom.css(overlayReferenceEdge, '0');
     return;
   }
   if (vtt.line === 'auto' && !vtt.vertical) {
@@ -97,7 +96,7 @@ const setVttLine = (
     relativeLinePosition = (100 * absoluteLinePosition) / subtitleOverLaySize.height;
   }
 
-  if (vtt.lineAlign !== "end")
+  if (vtt.lineAlign !== 'end')
     cueContainerDom.css(
       overlayReferenceEdge, `${relativeLinePosition}%`);
   setVttLineAlign(cueContainerDom, vtt, direction, relativeLinePosition);
@@ -109,9 +108,9 @@ const setVttLine = (
  */
 const setVttWritingDirectionAndCueBoxPositioning = (
   cueContainerDom: DOM, vtt: VTTProperties,
-  subtitleOverlaySize: Size
+  subtitleOverlaySize: Size,
 ) => {
-  console.log("[i] setVttWritingDirection: vtt.vertical", vtt.vertical);
+  console.log('[i] setVttWritingDirection: vtt.vertical', vtt.vertical);
   switch (vtt.vertical) {
   case '':
     cueContainerDom.css('writing-mode', 'horizontal-tb');
@@ -120,7 +119,7 @@ const setVttWritingDirectionAndCueBoxPositioning = (
     break;
   // "lr" is "left to right" so this is vertical growing right
   case 'lr':
-    console.log("[i] lr");
+    console.log('[i] lr');
     setCueBoxPositionForVerticalWriting(
       cueContainerDom, Direction.Right, vtt, subtitleOverlaySize);
     break;
@@ -137,10 +136,10 @@ const setCueBoxPositionForVerticalWriting = (
   cueContainerDom: DOM,
   direction: Direction,
   vtt: VTTProperties,
-  subtitleOverlaySize: Size
+  subtitleOverlaySize: Size,
 ) => {
     const writingMode = direction === Direction.Right ?
-      "vertical-lr" : "vertical-rl";
+      'vertical-lr' : 'vertical-rl';
     const opositeEdge = direction;
 
     cueContainerDom.css('writing-mode', writingMode);
@@ -181,14 +180,13 @@ const setVttPositionAlign = (cueContainerDom: DOM, vtt: VTTProperties, direction
 };
 
 const countLines = (innerHtml: string) =>
-  innerHtml.split("<br />").length;
+  innerHtml.split('<br />').length;
 
 // this is only a rough approximation based in a standard line height
-const setCssForCenterLineAlign =(
+const setCssForCenterLineAlign = (
   cueContainerDom: DOM,
   direction: Direction,
-  relativeCueBoxPosition: number) =>
-{
+  relativeCueBoxPosition: number) => {
   const overlayReferenceEdge = DirectionPair.get(direction);
   const opositeEdge = DirectionPair.get(direction);
   const centerOffset = lineHeightPercent * lineCount / 2;
@@ -199,9 +197,8 @@ const setCssForCenterLineAlign =(
 const setCssForEndLineAlign = (
   cueContainerDom: DOM,
   direction: Direction,
-  offset: number) =>
-{
-      console.log("[i] setCssForEnd: direction, offset",
+  offset: number) => {
+      console.log('[i] setCssForEnd: direction, offset',
         direction, offset);
       const overlayReferenceEdge = DirectionPair.get(direction);
       const opositeEdge = direction;

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -7,7 +7,7 @@ const lineHeight = 28;
 
 // Default relative line height
 const lineHeightPercent = 5;
-let lineCount: number;
+let lineCount: number = 1;
 
 const defaultLineNumber = 21; // Our default amount of lines
 
@@ -16,6 +16,11 @@ enum Direction {
   Bottom = 'bottom',
   Left = 'left',
   Right = 'right',
+}
+
+enum VttVerticalWriting {
+  GrowingRight = 'lr',
+  GrowingLeft = 'rl',
 }
 
 const DirectionPair = new Map<Direction, Direction>([
@@ -114,12 +119,11 @@ const setVttWritingDirectionAndCueBoxPositioning = (
     cueContainerDom.css(Direction.Bottom, '0');
     setVttLine(cueContainerDom, vtt, Direction.Bottom, subtitleOverlaySize);
     break;
-  // "lr" is "left to right" so this is vertical growing right
-  case 'lr':
+  case VttVerticalWriting.GrowingRight:
     setCueBoxPositionForVerticalWriting(
       cueContainerDom, Direction.Right, vtt, subtitleOverlaySize);
     break;
-  case 'rl':
+  case VttVerticalWriting.GrowingLeft:
     setCueBoxPositionForVerticalWriting(
       cueContainerDom, Direction.Left, vtt, subtitleOverlaySize);
     break;
@@ -177,15 +181,21 @@ const setVttPositionAlign = (cueContainerDom: DOM, vtt: VTTProperties, direction
 const countLines = (innerHtml: string) =>
   innerHtml.split('<br />').length;
 
-// this is only a rough approximation based in a standard line height
 const setCssForCenterLineAlign = (
   cueContainerDom: DOM,
   direction: Direction,
   relativeCueBoxPosition: number) => {
-  const overlayReferenceEdge = DirectionPair.get(direction);
-  const centerOffset = lineHeightPercent * lineCount / 2;
-  const offset = relativeCueBoxPosition - centerOffset;
-  cueContainerDom.css(overlayReferenceEdge, `${offset}%`);
+  switch (direction) {
+    case Direction.Bottom:
+      cueContainerDom.css('transform', 'translateY(-50%)');
+      break;
+    case Direction.Left:
+      cueContainerDom.css('transform', 'translateX(50%)');
+      break;
+    case Direction.Right:
+      cueContainerDom.css('transform', 'translateX(-50%)');
+      break;
+  }
 };
 
 const setCssForEndLineAlign = (

--- a/src/ts/vttutils.ts
+++ b/src/ts/vttutils.ts
@@ -23,6 +23,8 @@ enum VttVerticalWriting {
   GrowingLeft = 'rl',
 }
 
+type VerticalWritingDirection = Direction.Left | Direction.Right;
+
 const DirectionPair = new Map<Direction, Direction>([
   [Direction.Top, Direction.Bottom],
   [Direction.Bottom, Direction.Top],
@@ -130,11 +132,9 @@ const setVttWritingDirectionAndCueBoxPositioning = (
   }
 };
 
-// todo: limit type of the parameter `direction` to
-//   Direction.Right, Direction.Left
 const setCueBoxPositionForVerticalWriting = (
   cueContainerDom: DOM,
-  direction: Direction,
+  direction: VerticalWritingDirection,
   vtt: VTTProperties,
   subtitleOverlaySize: Size,
 ) => {


### PR DESCRIPTION
## Summary

Vtt cues with style
`00:00:00.000 --> 00:00:09.000 line:83%,end`
with multiple lines don't render cue box position correctly.

## Detail

Such cues would use css **margin-\*** properties to apply line alignment,(*) but the method uses the cue line height in the calculation. First commits in this branch corrected this with a line count factor, but it was still not accurate. One problem is that values in pixels are only calculated at a future step (e.g. in the user agent browser).

One solution is to use relative sizes and offset proportions and compensate vtt **lineAlign** in the CSS properties that implement vtt **line** (**top**, **bottom**, **left**, **right**). This is the approach in this branch.

There remains the problem of line align "center" style which would need to calculate the cue height, because at the moment I didn't find a way to express this in CSS. While this last WebVTT incompliance remains, in this branch a relative size of 5% for cue line replaces the 28 _px_ that was used before. This is standard and will scale to any resolution.

---

### Notes

(*) WebVtt line alignment: https://www.w3.org/TR/webvtt1/#webvtt-cue-line-alignment