### PR TITLE
set time format after ready event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Fixed
+- Duration format not getting updated from `mm:ss` to `hh:mm:ss`
+
 ## [3.37.0] - 2022-04-12
 
 ### Fixed

--- a/spec/components/playbacktimelabel.spec.ts
+++ b/spec/components/playbacktimelabel.spec.ts
@@ -76,7 +76,6 @@ describe('PlaybackTimeLabel', () => {
 
       jest.spyOn(playerMock, 'getDuration').mockReturnValue(100);
       playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
-      playerMock.eventEmitter.fireReadyEvent();
       expect(playbackTimeLabel.getText()).toEqual('01:40');
     });
 

--- a/spec/components/playbacktimelabel.spec.ts
+++ b/spec/components/playbacktimelabel.spec.ts
@@ -62,10 +62,13 @@ describe('PlaybackTimeLabel', () => {
       jest.spyOn(playerMock, 'getCurrentTime').mockReturnValue(30);
 
       playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+      playerMock.eventEmitter.fireEvent<PlayerEventBase>(
+        {type: PlayerEvent.Ready, timestamp: Date.now()}
+      );
       expect(playbackTimeLabel.getText()).toEqual('01:10');
     });
 
-    it.only('displays the total time mm:ss', () => {
+    it('displays the total time mm:ss', () => {
       jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
       playbackTimeLabel = new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.TotalTime });
 
@@ -81,7 +84,7 @@ describe('PlaybackTimeLabel', () => {
       expect(playbackTimeLabel.getText()).toEqual('01:40');
     });
 
-    it.only('displays the total time hh:mm:ss', () => {
+    it('displays the total time hh:mm:ss', () => {
       jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
       playbackTimeLabel = new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.TotalTime });
 

--- a/spec/components/playbacktimelabel.spec.ts
+++ b/spec/components/playbacktimelabel.spec.ts
@@ -1,6 +1,7 @@
 import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 import { UIInstanceManager } from '../../src/ts/uimanager';
 import { PlaybackTimeLabel, PlaybackTimeLabelMode } from '../../src/ts/components/playbacktimelabel';
+import { PlayerEvent, PlayerEventBase} from 'bitmovin-player';
 
 const liveEdgeActiveCssClassName = 'ui-playbacktimelabel-live-edge';
 
@@ -64,7 +65,8 @@ describe('PlaybackTimeLabel', () => {
       expect(playbackTimeLabel.getText()).toEqual('01:10');
     });
 
-    it('displays the total time', () => {
+    it.only('displays the total time mm:ss', () => {
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
       playbackTimeLabel = new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.TotalTime });
 
       // Setup DOM Mock
@@ -73,7 +75,29 @@ describe('PlaybackTimeLabel', () => {
 
       jest.spyOn(playerMock, 'getDuration').mockReturnValue(100);
       playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+      playerMock.eventEmitter.fireEvent<PlayerEventBase>(
+        {type: PlayerEvent.Ready, timestamp: Date.now()}
+      );
       expect(playbackTimeLabel.getText()).toEqual('01:40');
+    });
+
+    it.only('displays the total time hh:mm:ss', () => {
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
+      playbackTimeLabel = new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.TotalTime });
+
+      // Setup DOM Mock
+      const mockDomElement = MockHelper.generateDOMMock();
+      jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
+
+      jest.spyOn(playerMock, 'getDuration').mockReturnValue(0);
+      expect(playbackTimeLabel.getText()).toEqual(undefined);
+
+      jest.spyOn(playerMock, 'getDuration').mockReturnValue(3600);
+      playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+      playerMock.eventEmitter.fireEvent<PlayerEventBase>(
+        {type: PlayerEvent.Ready, timestamp: Date.now()}
+      );
+      expect(playbackTimeLabel.getText()).toEqual('01:00:00');
     });
   });
 

--- a/spec/components/playbacktimelabel.spec.ts
+++ b/spec/components/playbacktimelabel.spec.ts
@@ -62,9 +62,7 @@ describe('PlaybackTimeLabel', () => {
       jest.spyOn(playerMock, 'getCurrentTime').mockReturnValue(30);
 
       playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
-      playerMock.eventEmitter.fireEvent<PlayerEventBase>(
-        {type: PlayerEvent.Ready, timestamp: Date.now()}
-      );
+      playerMock.eventEmitter.fireReadyEvent();
       expect(playbackTimeLabel.getText()).toEqual('01:10');
     });
 
@@ -78,9 +76,7 @@ describe('PlaybackTimeLabel', () => {
 
       jest.spyOn(playerMock, 'getDuration').mockReturnValue(100);
       playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
-      playerMock.eventEmitter.fireEvent<PlayerEventBase>(
-        {type: PlayerEvent.Ready, timestamp: Date.now()}
-      );
+      playerMock.eventEmitter.fireReadyEvent();
       expect(playbackTimeLabel.getText()).toEqual('01:40');
     });
 
@@ -97,9 +93,7 @@ describe('PlaybackTimeLabel', () => {
 
       jest.spyOn(playerMock, 'getDuration').mockReturnValue(3600);
       playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
-      playerMock.eventEmitter.fireEvent<PlayerEventBase>(
-        {type: PlayerEvent.Ready, timestamp: Date.now()}
-      );
+      playerMock.eventEmitter.fireReadyEvent();
       expect(playbackTimeLabel.getText()).toEqual('01:00:00');
     });
   });

--- a/spec/components/playbacktimelabel.spec.ts
+++ b/spec/components/playbacktimelabel.spec.ts
@@ -80,7 +80,20 @@ describe('PlaybackTimeLabel', () => {
       expect(playbackTimeLabel.getText()).toEqual('01:40');
     });
 
-    it('displays the total time hh:mm:ss', () => {
+    it('displays the total time hh:mm:ss if duration is greater than 1 hour', () => {
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
+      playbackTimeLabel = new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.TotalTime });
+
+      // Setup DOM Mock
+      const mockDomElement = MockHelper.generateDOMMock();
+      jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
+
+      jest.spyOn(playerMock, 'getDuration').mockReturnValue(3600);
+      playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+      expect(playbackTimeLabel.getText()).toEqual('01:00:00');
+    });
+
+    it('updates time format on ready event', () => {
       jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
       playbackTimeLabel = new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.TotalTime });
 
@@ -89,10 +102,10 @@ describe('PlaybackTimeLabel', () => {
       jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
 
       jest.spyOn(playerMock, 'getDuration').mockReturnValue(0);
-      expect(playbackTimeLabel.getText()).toEqual(undefined);
+      playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+      expect(playbackTimeLabel.getText()).toEqual('00:00');
 
       jest.spyOn(playerMock, 'getDuration').mockReturnValue(3600);
-      playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
       playerMock.eventEmitter.fireReadyEvent();
       expect(playbackTimeLabel.getText()).toEqual('01:00:00');
     });

--- a/spec/components/playbacktimelabel.spec.ts
+++ b/spec/components/playbacktimelabel.spec.ts
@@ -62,7 +62,6 @@ describe('PlaybackTimeLabel', () => {
       jest.spyOn(playerMock, 'getCurrentTime').mockReturnValue(30);
 
       playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
-      playerMock.eventEmitter.fireReadyEvent();
       expect(playbackTimeLabel.getText()).toEqual('01:10');
     });
 

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -276,6 +276,13 @@ export class PlayerEventEmitter {
     });
   }
 
+  fireReadyEvent(): void {
+    this.fireEvent<PlayerEventBase>({
+      type: PlayerEvent.Ready,
+      timestamp: Date.now()
+    });
+  }
+
   // Subtitle Events
   fireSubtitleAddedEvent(id: string, label: string): void {
     this.fireEvent<SubtitleEvent>({

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -139,7 +139,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
       StringUtils.FORMAT_HHMMSS : StringUtils.FORMAT_MMSS;
       playbackTimeHandler();
-    }
+    };
 
     player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
     player.on(player.exports.PlayerEvent.Ready, playbackReadyHandler);

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -135,9 +135,10 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     };
 
     let playbackReadyHandler = () => {
-    // Set time format depending on source duration
-    this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
+      // Set time format depending on source duration
+      this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
       StringUtils.FORMAT_HHMMSS : StringUtils.FORMAT_MMSS;
+      playbackTimeHandler();
     }
 
     player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -118,7 +118,9 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
 
     let playbackTimeHandler = () => {
       if (!live && player.getDuration() !== Infinity) {
-        this.setTime(PlayerUtils.getCurrentTimeRelativeToSeekableRange(player), player.getDuration());
+        this.setTime(
+          PlayerUtils.getCurrentTimeRelativeToSeekableRange(player),
+          player.getDuration());
       }
 
       // To avoid 'jumping' in the UI by varying label sizes due to non-monospaced fonts,
@@ -132,7 +134,14 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       }
     };
 
+    let playbackReadyHandler = () => {
+    // Set time format depending on source duration
+    this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
+      StringUtils.FORMAT_HHMMSS : StringUtils.FORMAT_MMSS;
+    }
+
     player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
+    player.on(player.exports.PlayerEvent.Ready, playbackReadyHandler);
     player.on(player.exports.PlayerEvent.Seeked, playbackTimeHandler);
 
     player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);
@@ -150,12 +159,6 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
         'min-width': null,
       });
 
-      // Set time format depending on source duration
-      this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
-        StringUtils.FORMAT_HHMMSS : StringUtils.FORMAT_MMSS;
-
-      // Update time after the format has been set
-      playbackTimeHandler();
     };
     uimanager.getConfig().events.onUpdated.subscribe(init);
 

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -134,7 +134,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       }
     };
 
-    let playbackReadyHandler = () => {
+    let updateTimeFormatBasedOnDuration = () => {
       // Set time format depending on source duration
       this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
       StringUtils.FORMAT_HHMMSS : StringUtils.FORMAT_MMSS;
@@ -142,7 +142,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     };
 
     player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
-    player.on(player.exports.PlayerEvent.Ready, playbackReadyHandler);
+    player.on(player.exports.PlayerEvent.Ready, updateTimeFormatBasedOnDuration);
     player.on(player.exports.PlayerEvent.Seeked, playbackTimeHandler);
 
     player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);
@@ -160,6 +160,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
         'min-width': null,
       });
 
+      updateTimeFormatBasedOnDuration();
     };
     uimanager.getConfig().events.onUpdated.subscribe(init);
 


### PR DESCRIPTION
### The problem

It was found that in certain circumstances the time label would not count the hours, only the minutes and seconds that remain.

### The cause

The time label has a format that is defined when it's initialized. If the player duration when it's initialized < 1 hour, this format will be _mm:ss_ so the hour quantity would always be ignored.

```
        Player                                       Player UI
---------------------------------------------------------------
player not ready yet                                    |
player duration = 0                                     |
             |                                 UI time label initializes
             |                                 set time format, read duration
             |                                  < 1 hour => time format = mm:ss   
             |                                    display 00:00
player ready,                                            |
player duration = 01:30:00           =>            display 30:00
```
                                