### PR TITLE
PW-8039 Fix/spatialnavigation/bounding client rect

### DIFF
--- a/src/ts/spatialnavigation/navigationalgorithm.ts
+++ b/src/ts/spatialnavigation/navigationalgorithm.ts
@@ -57,22 +57,11 @@ function distance(a: Vector, b: Vector): number {
  * @param element The element to get the center of
  */
 function getElementVector(element: HTMLElement): Vector {
-  const boundingRect = element.getBoundingClientRect();
-
-  let _x: number;
-  let _y: number;
-
-  if (boundingRect.hasOwnProperty('x') && boundingRect.hasOwnProperty('y')) {
-    _x = boundingRect.x;
-    _y = boundingRect.y;
-  } else {
-    _x = boundingRect.left;
-    _y = boundingRect.top;
-  }
+  const boundingRect = getBoundingRectFromElement(element);
 
   return {
-    x: _x + boundingRect.width / 2,
-    y: _y + boundingRect.height / 2,
+    x: boundingRect.x + boundingRect.width / 2,
+    y: boundingRect.y + boundingRect.height / 2,
   };
 }
 
@@ -136,3 +125,22 @@ export function getElementInDirection(
     // return the element closest to the current element
     .shift()?.element;
 }
+
+/**
+ * Returns DOMRect like object containing horizontal X and vertical Y coordinates from and HTMLElement.
+ * Handles use-cases for getBoundingClientRect when the return type can be either
+ * a ClientRect or DOMRect object type.
+ *
+ * @param element The currently selected element
+ */
+export function getBoundingRectFromElement(element: HTMLElement) {
+  const boundingRect = element.getBoundingClientRect();
+
+  if (typeof boundingRect.x !== 'number' && typeof boundingRect.y !== 'number') {
+    boundingRect.x = boundingRect.left;
+    boundingRect.y = boundingRect.height;
+  }
+
+  return boundingRect;
+}
+

--- a/src/ts/spatialnavigation/navigationalgorithm.ts
+++ b/src/ts/spatialnavigation/navigationalgorithm.ts
@@ -59,9 +59,20 @@ function distance(a: Vector, b: Vector): number {
 function getElementVector(element: HTMLElement): Vector {
   const boundingRect = element.getBoundingClientRect();
 
+  let _x: number;
+  let _y: number;
+
+  if (boundingRect.hasOwnProperty('x') && boundingRect.hasOwnProperty('y')) {
+    _x = boundingRect.x;
+    _y = boundingRect.y;
+  } else {
+    _x = boundingRect.left;
+    _y = boundingRect.top;
+  }
+
   return {
-    x: boundingRect.left + boundingRect.width / 2,
-    y: boundingRect.top + boundingRect.height / 2,
+    x: _x + boundingRect.width / 2,
+    y: _y + boundingRect.height / 2,
   };
 }
 

--- a/src/ts/spatialnavigation/navigationalgorithm.ts
+++ b/src/ts/spatialnavigation/navigationalgorithm.ts
@@ -60,8 +60,8 @@ function getElementVector(element: HTMLElement): Vector {
   const boundingRect = element.getBoundingClientRect();
 
   return {
-    x: boundingRect.x + boundingRect.width / 2,
-    y: boundingRect.y + boundingRect.height / 2,
+    x: boundingRect.left + boundingRect.width / 2,
+    y: boundingRect.top + boundingRect.height / 2,
   };
 }
 

--- a/src/ts/spatialnavigation/seekbarhandler.ts
+++ b/src/ts/spatialnavigation/seekbarhandler.ts
@@ -1,6 +1,7 @@
 import { RootNavigationGroup } from './rootnavigationgroup';
 import { NodeEventSubscriber } from './nodeeventsubscriber';
 import { Action, Direction } from './types';
+import {getBoundingRectFromElement} from './navigationalgorithm';
 
 const DefaultScrubSpeedPercentage = 0.005;
 const ScrubSpeedClearInterval = 100;
@@ -51,21 +52,11 @@ export class SeekBarHandler {
 
   private initializeCursorPosition(seekBarWrapper: HTMLElement): void {
     const playbackPositionMarker = getPlaybackPositionMarker(seekBarWrapper);
-    const rect = playbackPositionMarker.getBoundingClientRect();
+    const rect = getBoundingRectFromElement(playbackPositionMarker);
 
-    let _x: number;
-    let _y: number;
 
-    if (rect.hasOwnProperty('x') && rect.hasOwnProperty('y')) {
-      _x = rect.x;
-      _y = rect.y;
-    } else {
-      _x = rect.left;
-      _y = rect.top;
-    }
-
-    const startX = _x + (rect.width / 2);
-    const startY = _y;
+    const startX = rect.x + (rect.width / 2);
+    const startY = rect.y;
 
     this.cursorPosition.x = startX;
     this.cursorPosition.y = startY;

--- a/src/ts/spatialnavigation/seekbarhandler.ts
+++ b/src/ts/spatialnavigation/seekbarhandler.ts
@@ -52,8 +52,8 @@ export class SeekBarHandler {
   private initializeCursorPosition(seekBarWrapper: HTMLElement): void {
     const playbackPositionMarker = getPlaybackPositionMarker(seekBarWrapper);
     const rect = playbackPositionMarker.getBoundingClientRect();
-    const startX = rect.x + (rect.width / 2);
-    const startY = rect.y;
+    const startX = rect.left + (rect.width / 2);
+    const startY = rect.top;
 
     this.cursorPosition.x = startX;
     this.cursorPosition.y = startY;

--- a/src/ts/spatialnavigation/seekbarhandler.ts
+++ b/src/ts/spatialnavigation/seekbarhandler.ts
@@ -52,8 +52,20 @@ export class SeekBarHandler {
   private initializeCursorPosition(seekBarWrapper: HTMLElement): void {
     const playbackPositionMarker = getPlaybackPositionMarker(seekBarWrapper);
     const rect = playbackPositionMarker.getBoundingClientRect();
-    const startX = rect.left + (rect.width / 2);
-    const startY = rect.top;
+
+    let _x: number;
+    let _y: number;
+
+    if (rect.hasOwnProperty('x') && rect.hasOwnProperty('y')) {
+      _x = rect.x;
+      _y = rect.y;
+    } else {
+      _x = rect.left;
+      _y = rect.top;
+    }
+
+    const startX = _x + (rect.width / 2);
+    const startY = _y;
 
     this.cursorPosition.x = startX;
     this.cursorPosition.y = startY;


### PR DESCRIPTION
On tested Tizen and Webos systems, the HTMLElement.`getBoundingClientRect()` returns a **ClientRect** object instead of the expected **DOMRect** object. The **ClientRect** object does NOT contain `x` and `y` properties but instead both **ClientRect** and **DOMRect** do contain `left` and `top` properties.

~~Changed navigationalgorithm.`getElementVector` to use `left` and `top`~~
~~Changed seekbarhandler.`initializeCursorPosition` to use `left` and `top`~~

Changed navigationalgorithm.`getElementVector` to use `left` and `top` in instances where `x` and `y` are not available
Changed seekbarhandler.`initializeCursorPosition` to use `left` and `top` in instances where `x` and `y` are not available