### PR TITLE
Improve track list spatial navigation

### DIFF
--- a/spec/spatialnavigation/listnavigationgroup.spec.ts
+++ b/spec/spatialnavigation/listnavigationgroup.spec.ts
@@ -1,0 +1,50 @@
+import { UIContainer } from '../../src/ts/components/uicontainer';
+import { mockClass } from '../helper/mockClass';
+import { Action, Direction } from '../../src/ts/spatialnavigation/types';
+import { ListNavigationGroup } from '../../src/ts/spatialnavigation/ListNavigationGroup';
+
+jest.mock('../../src/ts/spatialnavigation/navigationgroup.ts');
+
+describe('ListNavigationGroup', () => {
+  let containerUiMock: jest.Mocked<UIContainer>;
+  let listNavigationGroup: ListNavigationGroup;
+
+  beforeEach(() => {
+    containerUiMock = mockClass(UIContainer);
+    containerUiMock.showUi = jest.fn();
+    containerUiMock.hideUi = jest.fn();
+
+    listNavigationGroup = new ListNavigationGroup(containerUiMock);
+
+  });
+
+  describe('handleAction', () => {
+    it('should dispatch an Action.BACK after an Action.SELECT was tracked', () => {
+      const handleActionSpy = jest.spyOn(listNavigationGroup, 'handleAction');
+
+      listNavigationGroup.handleAction(Action.SELECT);
+
+      expect(handleActionSpy).toHaveBeenCalledWith(Action.BACK);
+    });
+  });
+
+  describe('handleNavigation', () => {
+    test.each`
+      direction          | shouldDispatch
+      ${Direction.UP}    | ${false}
+      ${Direction.DOWN}  | ${false}
+      ${Direction.LEFT}  | ${true}
+      ${Direction.RIGHT} | ${true}
+    `('should dispatch an Action.BACK=$shouldDispatch on Direction.$direction', ({ direction, shouldDispatch }) => {
+      const handleActionSpy = jest.spyOn(listNavigationGroup, 'handleAction');
+
+      listNavigationGroup.handleNavigation(direction);
+
+      if (shouldDispatch) {
+        expect(handleActionSpy).toHaveBeenCalledWith(Action.BACK);
+      } else {
+        expect(handleActionSpy).not.toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/spec/spatialnavigation/listnavigationgroup.spec.ts
+++ b/spec/spatialnavigation/listnavigationgroup.spec.ts
@@ -1,25 +1,22 @@
 import { UIContainer } from '../../src/ts/components/uicontainer';
 import { mockClass } from '../helper/mockClass';
 import { Action, Direction } from '../../src/ts/spatialnavigation/types';
-import { ListNavigationGroup } from '../../src/ts/spatialnavigation/ListNavigationGroup';
+import { ListNavigationGroup, ListOrientation } from '../../src/ts/spatialnavigation/ListNavigationGroup';
 
 jest.mock('../../src/ts/spatialnavigation/navigationgroup.ts');
 
 describe('ListNavigationGroup', () => {
   let containerUiMock: jest.Mocked<UIContainer>;
-  let listNavigationGroup: ListNavigationGroup;
 
   beforeEach(() => {
     containerUiMock = mockClass(UIContainer);
     containerUiMock.showUi = jest.fn();
     containerUiMock.hideUi = jest.fn();
-
-    listNavigationGroup = new ListNavigationGroup(containerUiMock);
-
   });
 
   describe('handleAction', () => {
     it('should dispatch an Action.BACK after an Action.SELECT was tracked', () => {
+      const listNavigationGroup = new ListNavigationGroup(ListOrientation.Vertical, containerUiMock);
       const handleActionSpy = jest.spyOn(listNavigationGroup, 'handleAction');
 
       listNavigationGroup.handleAction(Action.SELECT);
@@ -30,21 +27,29 @@ describe('ListNavigationGroup', () => {
 
   describe('handleNavigation', () => {
     test.each`
-      direction          | shouldDispatch
-      ${Direction.UP}    | ${false}
-      ${Direction.DOWN}  | ${false}
-      ${Direction.LEFT}  | ${true}
-      ${Direction.RIGHT} | ${true}
-    `('should dispatch an Action.BACK=$shouldDispatch on Direction.$direction', ({ direction, shouldDispatch }) => {
-      const handleActionSpy = jest.spyOn(listNavigationGroup, 'handleAction');
+      direction          | orientation                   | shouldDispatch
+      ${Direction.UP}    | ${ListOrientation.Vertical}   | ${false}
+      ${Direction.DOWN}  | ${ListOrientation.Vertical}   | ${false}
+      ${Direction.LEFT}  | ${ListOrientation.Vertical}   | ${true}
+      ${Direction.RIGHT} | ${ListOrientation.Vertical}   | ${true}
+      ${Direction.UP}    | ${ListOrientation.Horizontal} | ${true}
+      ${Direction.DOWN}  | ${ListOrientation.Horizontal} | ${true}
+      ${Direction.LEFT}  | ${ListOrientation.Horizontal} | ${false}
+      ${Direction.RIGHT} | ${ListOrientation.Horizontal} | ${false}
+    `(
+      'should dispatch an Action.BACK=$shouldDispatch on Direction.$direction with Orientation.$orientation',
+      ({ direction, orientation, shouldDispatch }) => {
+        const listNavigationGroup = new ListNavigationGroup(orientation, containerUiMock);
+        const handleActionSpy = jest.spyOn(listNavigationGroup, 'handleAction');
 
-      listNavigationGroup.handleNavigation(direction);
+        listNavigationGroup.handleNavigation(direction);
 
-      if (shouldDispatch) {
-        expect(handleActionSpy).toHaveBeenCalledWith(Action.BACK);
-      } else {
-        expect(handleActionSpy).not.toHaveBeenCalled();
-      }
-    });
+        if (shouldDispatch) {
+          expect(handleActionSpy).toHaveBeenCalledWith(Action.BACK);
+        } else {
+          expect(handleActionSpy).not.toHaveBeenCalled();
+        }
+      },
+    );
   });
 });

--- a/src/ts/spatialnavigation/ListNavigationGroup.ts
+++ b/src/ts/spatialnavigation/ListNavigationGroup.ts
@@ -38,7 +38,8 @@ export class ListNavigationGroup extends NavigationGroup {
     super.handleNavigation(direction);
 
     if (!this.listNavigationDirections.includes(direction)) {
-      // close the container on any input other than up and down
+      // close the container on navigation inputs that don't align
+      // with the orientation of the list
       this.handleAction(Action.BACK);
     }
   }

--- a/src/ts/spatialnavigation/ListNavigationGroup.ts
+++ b/src/ts/spatialnavigation/ListNavigationGroup.ts
@@ -2,7 +2,7 @@ import { NavigationGroup } from './navigationgroup';
 import { Action, Direction } from './types';
 
 export class ListNavigationGroup extends NavigationGroup {
-  public handleAction(action: Action) {
+  public handleAction(action: Action): void {
     super.handleAction(action);
 
     if (action === Action.SELECT) {
@@ -11,7 +11,7 @@ export class ListNavigationGroup extends NavigationGroup {
     }
   }
 
-  public handleNavigation(direction: Direction) {
+  public handleNavigation(direction: Direction): void {
     super.handleNavigation(direction);
 
     if (![Direction.UP, Direction.DOWN].includes(direction)) {

--- a/src/ts/spatialnavigation/ListNavigationGroup.ts
+++ b/src/ts/spatialnavigation/ListNavigationGroup.ts
@@ -1,0 +1,22 @@
+import { NavigationGroup } from './navigationgroup';
+import { Action, Direction } from './types';
+
+export class ListNavigationGroup extends NavigationGroup {
+  public handleAction(action: Action) {
+    super.handleAction(action);
+
+    if (action === Action.SELECT) {
+      // close the container when a list entry is selected
+      this.handleAction(Action.BACK);
+    }
+  }
+
+  public handleNavigation(direction: Direction) {
+    super.handleNavigation(direction);
+
+    if (![Direction.UP, Direction.DOWN].includes(direction)) {
+      // close the container on any input other than up and down
+      this.handleAction(Action.BACK);
+    }
+  }
+}

--- a/src/ts/spatialnavigation/ListNavigationGroup.ts
+++ b/src/ts/spatialnavigation/ListNavigationGroup.ts
@@ -1,7 +1,30 @@
 import { NavigationGroup } from './navigationgroup';
 import { Action, Direction } from './types';
+import { Container } from '../components/container';
+import { Component } from '../components/component';
+
+export enum ListOrientation {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+}
 
 export class ListNavigationGroup extends NavigationGroup {
+  private readonly listNavigationDirections: Direction[];
+
+  constructor(orientation: ListOrientation, container: Container<unknown>, ...components: Component<unknown>[]) {
+    super(container, ...components);
+
+    switch (orientation) {
+      case ListOrientation.Vertical:
+        this.listNavigationDirections = [Direction.UP, Direction.DOWN];
+        break;
+
+      case ListOrientation.Horizontal:
+        this.listNavigationDirections = [Direction.LEFT, Direction.RIGHT];
+        break;
+    }
+  }
+
   public handleAction(action: Action): void {
     super.handleAction(action);
 
@@ -14,7 +37,7 @@ export class ListNavigationGroup extends NavigationGroup {
   public handleNavigation(direction: Direction): void {
     super.handleNavigation(direction);
 
-    if (![Direction.UP, Direction.DOWN].includes(direction)) {
+    if (!this.listNavigationDirections.includes(direction)) {
       // close the container on any input other than up and down
       this.handleAction(Action.BACK);
     }

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -49,8 +49,7 @@ import { SubtitleListBox } from './components/subtitlelistbox';
 import { AudioTrackListBox } from './main';
 import { SpatialNavigation } from './spatialnavigation/spatialnavigation';
 import { RootNavigationGroup } from './spatialnavigation/rootnavigationgroup';
-import { NavigationGroup } from './spatialnavigation/navigationgroup';
-import { ListNavigationGroup } from './spatialnavigation/ListNavigationGroup';
+import { ListNavigationGroup, ListOrientation } from './spatialnavigation/ListNavigationGroup';
 
 export namespace UIFactory {
 
@@ -509,8 +508,8 @@ export namespace UIFactory {
 
     const spatialNavigation = new SpatialNavigation(
       new RootNavigationGroup(uiContainer, playbackToggleOverlay, seekBar, audioToggleButton, subtitleToggleButton),
-      new ListNavigationGroup(subtitleListPanel, subtitleListBox),
-      new ListNavigationGroup(audioTrackListPanel, audioTrackListBox),
+      new ListNavigationGroup(ListOrientation.Vertical, subtitleListPanel, subtitleListBox),
+      new ListNavigationGroup(ListOrientation.Vertical, audioTrackListPanel, audioTrackListBox),
     );
 
     return {

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -50,6 +50,7 @@ import { AudioTrackListBox } from './main';
 import { SpatialNavigation } from './spatialnavigation/spatialnavigation';
 import { RootNavigationGroup } from './spatialnavigation/rootnavigationgroup';
 import { NavigationGroup } from './spatialnavigation/navigationgroup';
+import { ListNavigationGroup } from './spatialnavigation/ListNavigationGroup';
 
 export namespace UIFactory {
 
@@ -508,8 +509,8 @@ export namespace UIFactory {
 
     const spatialNavigation = new SpatialNavigation(
       new RootNavigationGroup(uiContainer, playbackToggleOverlay, seekBar, audioToggleButton, subtitleToggleButton),
-      new NavigationGroup(subtitleListPanel, subtitleListBox),
-      new NavigationGroup(audioTrackListPanel, audioTrackListBox),
+      new ListNavigationGroup(subtitleListPanel, subtitleListBox),
+      new ListNavigationGroup(audioTrackListPanel, audioTrackListBox),
     );
 
     return {


### PR DESCRIPTION
The current spatial navigation implementation did not close list/track navigation groups if the user clicked `Left` or `Right` buttons of the remote or when a list item/track was selected.

This PR therefore introduces a `ListNavigationGroup` that automatically closes the navigation group when user navigates left or right (or up and down depending on the `ListOrientation`) and when a list item was selected.