### PR TITLE
Fix unnecessary DOM element creation on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Fixed
+- Unnecessary DOM element creation on release
+
 ## [3.38.0] - 2022-08-30
 
 ### Fixed

--- a/src/ts/components/component.ts
+++ b/src/ts/components/component.ts
@@ -292,6 +292,13 @@ export class Component<Config extends ComponentConfig> {
     return this.element;
   }
 
+  /**
+   * Checks if this component has a DOM element.
+   */
+  hasDomElement(): boolean {
+    return Boolean(this.element);
+  }
+
   setAriaLabel(label: LocalizableText): void {
     this.setAriaAttr('label', i18n.performLocalization(label));
   }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -485,7 +485,12 @@ export class UIManager {
 
   private releaseUi(ui: InternalUIInstanceManager): void {
     ui.releaseControls();
-    ui.getUI().getDomElement().remove();
+
+    const uiContainer = ui.getUI();
+    if (uiContainer.hasDomElement()) {
+      uiContainer.getDomElement().remove();
+    }
+
     ui.clearEventHandlers();
   }
 


### PR DESCRIPTION

### Problem
When releasing the UI shortly after creation, there may not be a DOM element associated with the UiContainer component.
When the getter `getDomElement()` is called, the element is then created, only to be removed again right after.

This creates unnecessary operations and allocates memory.


### Changes
- When destroying, check if DOM element exists before calling getter