### PR TITLE
Reduce CI build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Build and prepare for a potential 'npm publish'
         run: gulp npm-prepare
 
+      - name: Package artifact for upload
+        run: tar -czvf artifact.tar.gz dist
+        shell: bash
+
       - uses: actions/upload-artifact@v3
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: |
-            ${{ github.workspace }}/**/*
-            .npmignore
-            .nvmrc
-            .gitignore
-            !node_modules
-            !.idea
-            !.vscode
+            ${{ github.workspace }}/dist/**/*
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: |
-            ${{ github.workspace }}/dist/**/*
+            ${{ github.workspace }}/artifact.tar.gz
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,6 @@ jobs:
         run: tar -xzvf artifact/artifact.tar.gz -C .
         shell: bash
 
-      - name: Check files are where they are expected
-        run: ls -l dist/; ls -l dist/css; ls -l dist/js; 
-
       - name: Publish
         run: ./publish.sh
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - uses: actions/download-artifact@v3
         with:
           path: .
+
+      - name: Unpackage artifact files
+        run: tar -xzvf artifact.tar.gz
+        shell: bash
 
       - name: Allow execution of publish script
         run: chmod +x publish.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           path: .
 
       - name: Unpackage artifact files
-        run: tar -xzvf artifact.tar.gz
+        run: tar -xzvf artifact/artifact.tar.gz -C .
         shell: bash
 
       - name: Check files are where they are expected

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,8 @@ jobs:
         run: tar -xzvf artifact.tar.gz
         shell: bash
 
-      - name: Allow execution of publish script
-        run: chmod +x publish.sh
-        working-directory: artifact
-
       - name: Publish
         run: ./publish.sh
-        working-directory: artifact
         shell: bash
         env:
           NPM_DRY_RUN: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,5 @@ jobs:
         working-directory: artifact
         shell: bash
         env:
-          NPM_DRY_RUN: false
+          NPM_DRY_RUN: true
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
         run: tar -xzvf artifact.tar.gz
         shell: bash
 
+      - name: Check files are where they are expected
+        run: ls -l dist/; ls -l dist/css; ls -l dist/js; 
+
       - name: Publish
         run: ./publish.sh
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,5 @@ jobs:
         run: ./publish.sh
         shell: bash
         env:
-          NPM_DRY_RUN: true
+          NPM_DRY_RUN: false
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Reduce CI & Release workflows run time:
- CI workflow by ~30 sec by 
  - storing only the built files as the artifact (thanks @offnertho for the idea)
  - putting the artifact files into a tarball
- Release workflow by ~15-20 sec by
  - checkout out the repo freshly instead of downloading all files as the artifact
  - downloading only the built files as tarball artifact