### PR TITLE
Export localization and Spatial Navigation

### DIFF
--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -14,6 +14,11 @@ export { StorageUtils } from './storageutils';
 export { ErrorUtils } from './errorutils';
 // Localization
 export { i18n } from './localization/i18n';
+// Spatial Navigation
+export { SpatialNavigation } from './spatialnavigation/spatialnavigation';
+export { NavigationGroup } from './spatialnavigation/navigationgroup';
+export { RootNavigationGroup } from './spatialnavigation/rootnavigationgroup';
+export { ListNavigationGroup, ListOrientation } from './spatialnavigation/ListNavigationGroup';
 // Components
 export { Button } from './components/button';
 export { ControlBar } from './components/controlbar';

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -12,6 +12,8 @@ export { UIUtils } from './uiutils';
 export { BrowserUtils } from './browserutils';
 export { StorageUtils } from './storageutils';
 export { ErrorUtils } from './errorutils';
+// Localization
+export { i18n } from './localization/i18n';
 // Components
 export { Button } from './components/button';
 export { ControlBar } from './components/controlbar';


### PR DESCRIPTION
Add exports to `main.ts`:
- `localization/i18n.ts`
- `spatialnavigation/*`

This allows their usage in externally configured UIs