### PR TITLE
Add configuration to enter fullscreen on initial play

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [unreleased]
+
+### Added
+- Configuration option to enter fullscreen when clicking `PlaybackToggleButton` or `HugePlaybackToggleButton` to initiate the initial playback
+
 ## [3.42.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 ### Added
-- Configuration option to enter fullscreen when clicking `PlaybackToggleButton` or `HugePlaybackToggleButton` to initiate the initial playback
+- `UIConfig.enterFullscreenOnInitialPlayback` to enter fullscreen when clicking `PlaybackToggleButton` or `HugePlaybackToggleButton` to initiate the initial playback
 
 ## [3.42.0]
 

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -70,6 +70,11 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
         // playback is blocked (e.g. on mobile devices due to the programmatic play() call), we loose the chance to
         // ever start playback through a user interaction again with this button.
         togglePlayback();
+
+        if (this.config.enterFullscreenOnInitialPlayback) {
+          player.setViewMode(player.exports.ViewMode.Fullscreen);
+        }
+
         return;
       }
 

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -1,5 +1,4 @@
-import {ToggleButtonConfig} from './togglebutton';
-import {PlaybackToggleButton} from './playbacktogglebutton';
+import {PlaybackToggleButton, PlaybackToggleButtonConfig} from './playbacktogglebutton';
 import {DOM} from '../dom';
 import {UIInstanceManager} from '../uimanager';
 import { PlayerAPI, PlayerEventBase, WarningEvent } from 'bitmovin-player';
@@ -10,7 +9,7 @@ import { i18n } from '../localization/i18n';
  */
 export class HugePlaybackToggleButton extends PlaybackToggleButton {
 
-  constructor(config: ToggleButtonConfig = {}) {
+  constructor(config: PlaybackToggleButtonConfig = {}) {
     super(config);
 
     this.config = this.mergeConfig(config, {

--- a/src/ts/components/hugeplaybacktogglebutton.ts
+++ b/src/ts/components/hugeplaybacktogglebutton.ts
@@ -23,6 +23,11 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
     // Update button state through API events
     super.configure(player, uimanager, false);
 
+    // Set enterFullscreenOnInitialPlayback if set in the uimanager config
+    if (typeof uimanager.getConfig().enterFullscreenOnInitialPlayback === 'boolean') {
+      this.config.enterFullscreenOnInitialPlayback = uimanager.getConfig().enterFullscreenOnInitialPlayback;
+    }
+
     let togglePlayback = () => {
       if (player.isPlaying() || this.isPlayInitiated) {
         player.pause('ui');

--- a/src/ts/components/playbacktogglebutton.ts
+++ b/src/ts/components/playbacktogglebutton.ts
@@ -38,6 +38,7 @@ export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfi
     super.configure(player, uimanager);
 
     let isSeeking = false;
+    let firstPlay = true;
 
     // Handler to update button state based on player state
     let playbackStateHandler = () => {
@@ -57,6 +58,7 @@ export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfi
     // Call handler upon these events
     player.on(player.exports.PlayerEvent.Play, (e) => {
       this.isPlayInitiated = true;
+      firstPlay = false;
       playbackStateHandler();
     });
 
@@ -82,6 +84,7 @@ export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfi
     player.on(player.exports.PlayerEvent.Warning, (event: WarningEvent) => {
       if (event.code === player.exports.WarningCode.PLAYBACK_COULD_NOT_BE_STARTED) {
         this.isPlayInitiated = false;
+        firstPlay = true;
         this.off();
       }
     });
@@ -115,6 +118,10 @@ export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfi
           player.pause('ui');
         } else {
           player.play('ui');
+
+          if (firstPlay && this.config.enterFullscreenOnInitialPlayback) {
+            player.setViewMode(player.exports.ViewMode.Fullscreen);
+          }
         }
       });
     }

--- a/src/ts/components/playbacktogglebutton.ts
+++ b/src/ts/components/playbacktogglebutton.ts
@@ -4,15 +4,24 @@ import {PlayerUtils} from '../playerutils';
 import { PlayerAPI, WarningEvent } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
 
+export interface PlaybackToggleButtonConfig extends ToggleButtonConfig {
+  /**
+   * Specify whether the player should be set to enter fullscreen by clicking on the playback toggle button
+   * when initiating the initial playback.
+   * Default is false.
+   */
+  enterFullscreenOnInitialPlayback?: boolean;
+}
+
 /**
  * A button that toggles between playback and pause.
  */
-export class PlaybackToggleButton extends ToggleButton<ToggleButtonConfig> {
+export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfig> {
 
   private static readonly CLASS_STOPTOGGLE = 'stoptoggle';
   protected isPlayInitiated: boolean;
 
-  constructor(config: ToggleButtonConfig = {}) {
+  constructor(config: PlaybackToggleButtonConfig = {}) {
     super(config);
 
     this.config = this.mergeConfig(config, {

--- a/src/ts/components/playbacktogglebutton.ts
+++ b/src/ts/components/playbacktogglebutton.ts
@@ -37,6 +37,11 @@ export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfi
   configure(player: PlayerAPI, uimanager: UIInstanceManager, handleClickEvent: boolean = true): void {
     super.configure(player, uimanager);
 
+    // Set enterFullscreenOnInitialPlayback if set in the uimanager config
+    if (typeof uimanager.getConfig().enterFullscreenOnInitialPlayback === 'boolean') {
+      this.config.enterFullscreenOnInitialPlayback = uimanager.getConfig().enterFullscreenOnInitialPlayback;
+    }
+
     let isSeeking = false;
     let firstPlay = true;
 

--- a/src/ts/components/playbacktoggleoverlay.ts
+++ b/src/ts/components/playbacktoggleoverlay.ts
@@ -1,14 +1,23 @@
 import {Container, ContainerConfig} from './container';
 import {HugePlaybackToggleButton} from './hugeplaybacktogglebutton';
 
+export interface PlaybackToggleOverlayConfig extends ContainerConfig {
+  /**
+   * Specify whether the player should be set to enter fullscreen by clicking on the playback toggle button
+   * when initiating the initial playback.
+   * Default is false.
+   */
+  enterFullscreenOnInitialPlayback?: boolean;
+}
+
 /**
  * Overlays the player and displays error messages.
  */
-export class PlaybackToggleOverlay extends Container<ContainerConfig> {
+export class PlaybackToggleOverlay extends Container<PlaybackToggleOverlayConfig> {
 
   private playbackToggleButton: HugePlaybackToggleButton;
 
-  constructor(config: ContainerConfig = {}) {
+  constructor(config: PlaybackToggleOverlayConfig = {}) {
     super(config);
 
     this.playbackToggleButton = new HugePlaybackToggleButton();

--- a/src/ts/components/playbacktoggleoverlay.ts
+++ b/src/ts/components/playbacktoggleoverlay.ts
@@ -20,7 +20,9 @@ export class PlaybackToggleOverlay extends Container<PlaybackToggleOverlayConfig
   constructor(config: PlaybackToggleOverlayConfig = {}) {
     super(config);
 
-    this.playbackToggleButton = new HugePlaybackToggleButton();
+    this.playbackToggleButton = new HugePlaybackToggleButton({
+      enterFullscreenOnInitialPlayback: Boolean(config.enterFullscreenOnInitialPlayback),
+    });
 
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-playbacktoggle-overlay',

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -91,8 +91,8 @@ export interface UIConfig {
    */
   enableSeekPreview?: boolean;
   /**
-   * Specifies if the player should be set to fullscreen by clicking on the `PlaybackToggleButton` or
-   * `HugePlaybackToggleButton` when attempting the initial playback start.
+   * Specifies if the player should enter fullscreen by clicking on the `PlaybackToggleButton`,
+   * `HugePlaybackToggleButton`, or `PlaybackToggleOverlay` when attempting the initial playback start.
    * Default: false
    */
   enterFullscreenOnInitialPlayback?: boolean;

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -91,9 +91,9 @@ export interface UIConfig {
    */
   enableSeekPreview?: boolean;
   /**
-   * Specify whether the player should be set to enter fullscreen by clicking on the playback toggle button
-   * when initiating the initial playback.
-   * Default is false.
+   * Specifies if the player should be set to fullscreen by clicking on the `PlaybackToggleButton` or
+   * `HugePlaybackToggleButton` when attempting the initial playback start.
+   * Default: false
    */
   enterFullscreenOnInitialPlayback?: boolean;
 }

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -90,4 +90,10 @@ export interface UIConfig {
    * Default: true
    */
   enableSeekPreview?: boolean;
+  /**
+   * Specify whether the player should be set to enter fullscreen by clicking on the playback toggle button
+   * when initiating the initial playback.
+   * Default is false.
+   */
+  enterFullscreenOnInitialPlayback?: boolean;
 }

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -129,7 +129,7 @@ export namespace UIFactory {
         }),
         new Container({
           components: [
-            new PlaybackToggleButton(),
+            new PlaybackToggleButton({ enterFullscreenOnInitialPlayback: false }),
             new VolumeToggleButton(),
             new VolumeSlider(),
             new Spacer(),
@@ -149,7 +149,7 @@ export namespace UIFactory {
       components: [
         subtitleOverlay,
         new BufferingOverlay(),
-        new PlaybackToggleOverlay(),
+        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
         new CastStatusOverlay(),
         controlBar,
         new TitleBar(),
@@ -171,7 +171,7 @@ export namespace UIFactory {
       components: [
         new BufferingOverlay(),
         new AdClickOverlay(),
-        new PlaybackToggleOverlay(),
+        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
         new Container({
           components: [
             new AdMessageLabel({ text: i18n.getLocalizer('ads.remainingTime')}),
@@ -183,7 +183,7 @@ export namespace UIFactory {
           components: [
             new Container({
               components: [
-                new PlaybackToggleButton(),
+                new PlaybackToggleButton({ enterFullscreenOnInitialPlayback: false }),
                 new VolumeToggleButton(),
                 new VolumeSlider(),
                 new Spacer(),
@@ -274,7 +274,7 @@ export namespace UIFactory {
         subtitleOverlay,
         new BufferingOverlay(),
         new CastStatusOverlay(),
-        new PlaybackToggleOverlay(),
+        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
         new RecommendationOverlay(),
         controlBar,
         new TitleBar({
@@ -308,7 +308,7 @@ export namespace UIFactory {
       components: [
         new BufferingOverlay(),
         new AdClickOverlay(),
-        new PlaybackToggleOverlay(),
+        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
         new TitleBar({
           components: [
             // dummy label with no content to move buttons to the right
@@ -352,7 +352,7 @@ export namespace UIFactory {
       components: [
         new SubtitleOverlay(),
         new BufferingOverlay(),
-        new PlaybackToggleOverlay(),
+        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
         new Watermark(),
         controlBar,
         new TitleBar({ keepHiddenWithoutMetadata: true }),
@@ -447,7 +447,7 @@ export namespace UIFactory {
     });
 
     const seekBar = new SeekBar({ label: new SeekBarLabel() });
-    const playbackToggleOverlay = new PlaybackToggleOverlay();
+    const playbackToggleOverlay = new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false });
     const subtitleToggleButton = new SettingsToggleButton({
       settingsPanel: subtitleListPanel,
       autoHideWhenNoActiveSettings: true,

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -129,7 +129,7 @@ export namespace UIFactory {
         }),
         new Container({
           components: [
-            new PlaybackToggleButton({ enterFullscreenOnInitialPlayback: false }),
+            new PlaybackToggleButton(),
             new VolumeToggleButton(),
             new VolumeSlider(),
             new Spacer(),
@@ -149,7 +149,7 @@ export namespace UIFactory {
       components: [
         subtitleOverlay,
         new BufferingOverlay(),
-        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
+        new PlaybackToggleOverlay(),
         new CastStatusOverlay(),
         controlBar,
         new TitleBar(),
@@ -171,7 +171,7 @@ export namespace UIFactory {
       components: [
         new BufferingOverlay(),
         new AdClickOverlay(),
-        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
+        new PlaybackToggleOverlay(),
         new Container({
           components: [
             new AdMessageLabel({ text: i18n.getLocalizer('ads.remainingTime')}),
@@ -183,7 +183,7 @@ export namespace UIFactory {
           components: [
             new Container({
               components: [
-                new PlaybackToggleButton({ enterFullscreenOnInitialPlayback: false }),
+                new PlaybackToggleButton(),
                 new VolumeToggleButton(),
                 new VolumeSlider(),
                 new Spacer(),
@@ -274,7 +274,7 @@ export namespace UIFactory {
         subtitleOverlay,
         new BufferingOverlay(),
         new CastStatusOverlay(),
-        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
+        new PlaybackToggleOverlay(),
         new RecommendationOverlay(),
         controlBar,
         new TitleBar({
@@ -308,7 +308,7 @@ export namespace UIFactory {
       components: [
         new BufferingOverlay(),
         new AdClickOverlay(),
-        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
+        new PlaybackToggleOverlay(),
         new TitleBar({
           components: [
             // dummy label with no content to move buttons to the right
@@ -352,7 +352,7 @@ export namespace UIFactory {
       components: [
         new SubtitleOverlay(),
         new BufferingOverlay(),
-        new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false }),
+        new PlaybackToggleOverlay(),
         new Watermark(),
         controlBar,
         new TitleBar({ keepHiddenWithoutMetadata: true }),
@@ -447,7 +447,7 @@ export namespace UIFactory {
     });
 
     const seekBar = new SeekBar({ label: new SeekBarLabel() });
-    const playbackToggleOverlay = new PlaybackToggleOverlay({ enterFullscreenOnInitialPlayback: false });
+    const playbackToggleOverlay = new PlaybackToggleOverlay();
     const subtitleToggleButton = new SettingsToggleButton({
       settingsPanel: subtitleListPanel,
       autoHideWhenNoActiveSettings: true,


### PR DESCRIPTION
Inspired by https://community.bitmovin.com/t/setting-full-screen-with-the-configuration-in-javascript/1658/6 this PR adds a configuration to `PlaybackToggleButton`, `HugePlaybackToggleButton` and `PlaybackToggleOverlay` to enter fullscreen on the first attempt to initiate playback via one of those components.

The default value is set to `false`, so no behavior is changed automatically when users update the UI.