### PR TITLE
Force overflowing subtitles back into container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.46.0]
+## [develop]
 
 ### Added
 - Config option `forceSubtitlesIntoViewContainer` to handle overflowing subtitle labels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.46.0]
+
+### Added
+- Config option `forceSubtitlesIntoViewContainer` to handle overflowing subtitle labels
+
 ## [3.45.0] - 2023-03-06
 
 ### Added

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -10,6 +10,13 @@ import { i18n } from '../localization/i18n';
 import { VttUtils } from '../vttutils';
 import { VTTProperties } from 'bitmovin-player/types/subtitles/vtt/API';
 
+interface SubtitleCropDetectionResult {
+  top: boolean;
+  right: boolean;
+  bottom: boolean;
+  left: boolean;
+}
+
 /**
  * Overlays the player to display subtitles.
  */
@@ -128,6 +135,49 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     this.configureCea608Captions(player, uimanager);
     // Init
     subtitleClearHandler();
+  }
+
+  detectCroppedSubtitleLabel(
+    labelElement: HTMLElement,
+  ): SubtitleCropDetectionResult {
+    const parent = this.getDomElement().get(0);
+
+    const childRect = labelElement.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+
+    return {
+      top: childRect.top < parentRect.top,
+      right: childRect.right > parentRect.right,
+      bottom: childRect.bottom > parentRect.bottom,
+      left: childRect.left < parentRect.left,
+    };
+  }
+
+  handleSubtitleCropping(label: SubtitleLabel) {
+    const labelDomElement = label.getDomElement();
+    const cropDetection = this.detectCroppedSubtitleLabel(
+      labelDomElement.get(0),
+    );
+
+    if (cropDetection.top) {
+      labelDomElement.css('top', '0');
+      labelDomElement.css('bottom', 'unset');
+    }
+
+    if (cropDetection.right) {
+      labelDomElement.css('right', '0');
+      labelDomElement.css('left', 'unset');
+    }
+
+    if (cropDetection.bottom) {
+      labelDomElement.css('bottom', '0');
+      labelDomElement.css('top', 'unset');
+    }
+
+    if (cropDetection.left) {
+      labelDomElement.css('left', '0');
+      labelDomElement.css('right', 'unset');
+    }
   }
 
   generateLabel(event: SubtitleCueEvent): SubtitleLabel {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -74,6 +74,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       this.subtitleContainerManager.addLabel(label, this.getDomElement().size());
       this.updateComponents();
+
+      if (uimanager.getConfig().forceSubtitlesIntoViewContainer) {
+        this.handleSubtitleCropping(label);
+      }
     });
 
     player.on(player.exports.PlayerEvent.CueUpdate, (event: SubtitleCueEvent) => {
@@ -84,6 +88,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       if (labelToReplace) {
         this.subtitleContainerManager.replaceLabel(labelToReplace, label);
+      }
+
+      if (uimanager.getConfig().forceSubtitlesIntoViewContainer) {
+        this.handleSubtitleCropping(label);
       }
     });
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -169,22 +169,22 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     if (cropDetection.top) {
       labelDomElement.css('top', '0');
-      labelDomElement.css('bottom', 'unset');
+      labelDomElement.removeInlineCss('bottom');
     }
 
     if (cropDetection.right) {
       labelDomElement.css('right', '0');
-      labelDomElement.css('left', 'unset');
+      labelDomElement.removeInlineCss('left');
     }
 
     if (cropDetection.bottom) {
       labelDomElement.css('bottom', '0');
-      labelDomElement.css('top', 'unset');
+      labelDomElement.removeInlineCss('top');
     }
 
     if (cropDetection.left) {
       labelDomElement.css('left', '0');
-      labelDomElement.css('right', 'unset');
+      labelDomElement.removeInlineCss('right');
     }
   }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -169,22 +169,22 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     if (cropDetection.top) {
       labelDomElement.css('top', '0');
-      labelDomElement.removeInlineCss('bottom');
+      labelDomElement.removeCss('bottom');
     }
 
     if (cropDetection.right) {
       labelDomElement.css('right', '0');
-      labelDomElement.removeInlineCss('left');
+      labelDomElement.removeCss('left');
     }
 
     if (cropDetection.bottom) {
       labelDomElement.css('bottom', '0');
-      labelDomElement.removeInlineCss('top');
+      labelDomElement.removeCss('top');
     }
 
     if (cropDetection.left) {
       labelDomElement.css('left', '0');
-      labelDomElement.removeInlineCss('right');
+      labelDomElement.removeCss('right');
     }
   }
 

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -565,9 +565,10 @@ export class DOM {
   /**
    * Removes an inline CSS property if it exists
    * @param propertyName name of the property to remove
+   * @param elementIndex index of the element whose CSS property should get removed
    */
-  removeCss(propertyName: string): void {
-    this.setCss(propertyName, null);
+  removeCss(propertyName: string, elementIndex = 0): string {
+    return this.elements[elementIndex].style.removeProperty(propertyName);
   }
 
   private getCss(propertyName: string): string | null {

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -566,7 +566,7 @@ export class DOM {
    * Removes an inline CSS property if it exists
    * @param propertyName name of the property to remove
    */
-  removeInlineCss(propertyName: string): void {
+  removeCss(propertyName: string): void {
     this.setCss(propertyName, null);
   }
 

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -562,6 +562,14 @@ export class DOM {
     }
   }
 
+  /**
+   * Removes an inline CSS property if it exists
+   * @param propertyName name of the property to remove
+   */
+  removeInlineCss(propertyName: string): void {
+    this.setCss(propertyName, null);
+  }
+
   private getCss(propertyName: string): string | null {
     return getComputedStyle(this.elements[0])[<any>propertyName];
   }

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -96,4 +96,8 @@ export interface UIConfig {
    * Default: false
    */
   enterFullscreenOnInitialPlayback?: boolean;
+  /**
+  * Forces subtitle-labels back into their respective container if they overflow and are therefore cropped.
+  */
+  forceSubtitlesIntoViewContainer?: boolean;
 }


### PR DESCRIPTION
Certain constellations of VTT properties (see bottom of description for example) can cause the subtitle labels to overflow their container in the UI. Even though the UI handling in this case is spec-conform and expected, it would be convenience-feature to force such subtitles back into the respective container so they are fully visible. 

Could be helpful if users of the UI don't control the source/format of their VTT files or the results of the VTT parser.

For that matter, a config option `forceCroppedSubtitlesIntoViewContainer` is introduced with this PR. It is not `true` by default, as it breaks spec conformity by overriding certain VTT properties.

**Display with** `forceCroppedSubtitlesIntoViewContainer = false`
<img width="450" alt="Screenshot 2023-03-10 at 09 07 12" src="https://user-images.githubusercontent.com/6665565/224263414-e81eff24-8c64-4ab8-b293-28bc2dcb4dc1.png">

**Display with** `forceCroppedSubtitlesIntoViewContainer = true`
<img width="450" alt="Screenshot 2023-03-10 at 09 07 26" src="https://user-images.githubusercontent.com/6665565/224263502-34be94da-a4c9-4e4b-930e-bfbb86ee81aa.png">

**Sample VTT file**
```text
WEBVTT

1
00:01.000 --> 00:30.000 position:80%,line-left line:40% align:start
right side cropped A B C D E F G H I K L M N O P Q R S T V X Y Z

2
00:01.000 --> 00:30.000 position:20%,line-right line:60% align:end
A B C D E F G H I K L M N O P Q R S T V X Y Z left side cropped

3
00:01.000 --> 00:30.000 line:5%,end
-----line 1-----
-----line 2-----
top side cropped
-----line 4-----

4
00:01.000 --> 00:30.000 line:95%,start
-----line 1-----
bottom side cropped
-----line 3-----
-----line 4-----
```