### PR TITLE
[release-timelineMarkersHandler] Add release function

### DIFF
--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -623,6 +623,10 @@ export class SeekBar extends Component<SeekBarConfig> {
     if (this.config.enableSeekPreview) {
       this.onSeekPreview.unsubscribe(this.seekWhileScrubbing);
     }
+    
+    if(this.timelineMarkersHandler) {
+      this.timelineMarkersHandler.release()
+    }
   }
 
   protected toDomElement(): DOM {

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -35,7 +35,11 @@ export class TimelineMarkersHandler {
     this.uimanager = uimanager;
     this.configureMarkers();
   }
-
+  
+  public release() {
+    this.pausedTimeshiftUpdater.clear()
+  }
+  
   private configureMarkers(): void {
     // Remove markers when unloaded
     this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => this.clearMarkers());

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -212,7 +212,6 @@ export class TimelineMarkersHandler {
 
     // Stop updater when playback continues (no matter if the updater was started before)
     this.player.on(this.player.exports.PlayerEvent.Play, () => this.pausedTimeshiftUpdater.clear());
-    this.player.on(this.player.exports.PlayerEvent.Destroy, () => this.pausedTimeshiftUpdater.clear());
   }
 
   protected prefixCss(cssClassOrId: string): string {


### PR DESCRIPTION
The timelineMarkersHandler component has a Timeout that is not cleared properly. The Player event `Destroy` is not triggered and this leaves the `pausedTimeshiftUpdater` uncleared. 

Remove the on `Destroy` event and created a public release function on timelineMarkersHandler that is being called on the `release` function of the `Seekbar` component

![image (2)](https://github.com/bitmovin/bitmovin-player-ui/assets/74454053/a287c7a7-7c1a-4162-9242-224baf635ab6)

![image (3)](https://github.com/bitmovin/bitmovin-player-ui/assets/74454053/8768e6e5-62d2-4818-a5dc-347a1ec24e74)

