### PR TITLE
Active UI tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Added
+- `onActiveUiChanged` event on the `UIManager` that is dispatched when the UI manager switches to a different UI variant
+- Readonly `currentUi` field on the `UIManager` that exposes the active `UIInstanceManager`
+
 ## [3.48.0]
 
 ### Fixed

--- a/spec/uimanager.spec.ts
+++ b/spec/uimanager.spec.ts
@@ -1,6 +1,6 @@
 import {
   InternalUIConfig,
-  PlayerWrapper,
+  PlayerWrapper, UIInstanceManager,
   UIManager,
   UIVariant,
 } from '../src/ts/uimanager';
@@ -150,6 +150,16 @@ describe('UIManager', () => {
       uiManager.switchToUiVariant(secondUI);
 
       expect(onUiChanged).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('activeUi', () => {
+    it('should return the active UI instance manager', () => {
+      const playerMock = MockHelper.getPlayerMock();
+      const uiVariant = { ui: new UIContainer({ components: [new Container({})]}) };
+      const uiManager = new UIManager(playerMock, [uiVariant]);
+
+      expect(uiManager.activeUi).toBeInstanceOf(UIInstanceManager);
     });
   });
 

--- a/spec/uimanager.spec.ts
+++ b/spec/uimanager.spec.ts
@@ -112,6 +112,45 @@ describe('UIManager', () => {
       expect(secondUI.ui.isHidden()).toBeTruthy()
       expect(defaultUI.ui.isHidden()).toBeTruthy()
     });
+
+    it('should dispatch the onActiveUiChanged event', () => {
+      const onUiChanged = jest.fn();
+      const uiManager = new UIManager(playerMock, [firstUi, secondUI, defaultUI]);
+
+      uiManager.switchToUiVariant(firstUi);
+      uiManager.onActiveUiChanged.subscribe(onUiChanged);
+      uiManager.switchToUiVariant(secondUI);
+
+      expect(onUiChanged).toHaveBeenCalledWith(
+        uiManager,
+        {
+          previousUi: uiManager['uiInstanceManagers'][0],
+          currentUi: uiManager['uiInstanceManagers'][1],
+        },
+      );
+    });
+
+    it('should not dispatch the onActiveUiChanged event if the selected variant is already active', () => {
+      const onUiChanged = jest.fn();
+      const uiManager = new UIManager(playerMock, [firstUi, secondUI, defaultUI]);
+
+      uiManager.switchToUiVariant(firstUi);
+      uiManager.onActiveUiChanged.subscribe(onUiChanged);
+      uiManager.switchToUiVariant(firstUi);
+
+      expect(onUiChanged).not.toHaveBeenCalled();
+    });
+
+    it('should not dispatch the onActiveUiChanged event if the selected variant is not yet set up', () => {
+      const onUiChanged = jest.fn();
+      const uiManager = new UIManager(playerMock, [firstUi, defaultUI]);
+
+      uiManager.switchToUiVariant(firstUi);
+      uiManager.onActiveUiChanged.subscribe(onUiChanged);
+      uiManager.switchToUiVariant(secondUI);
+
+      expect(onUiChanged).not.toHaveBeenCalled();
+    });
   });
 
   describe('mobile v3 handling', () => {

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -522,6 +522,13 @@ export class UIManager {
   }
 
   /**
+   * The current active {@link UIInstanceManager}.
+   */
+  get activeUi(): UIInstanceManager {
+    return this.currentUi;
+  }
+
+  /**
    * Returns the list of all added markers in undefined order.
    */
   getTimelineMarkers(): TimelineMarker[] {

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -90,6 +90,17 @@ export interface UIVariant {
   spatialNavigation?: SpatialNavigation;
 }
 
+export interface ActiveUiChangedArgs extends NoArgs {
+  /**
+   * The previously active {@link UIInstanceManager} prior to the {@link UIManager} switching to a different UI variant.
+   */
+  previousUi: UIInstanceManager;
+  /**
+   * The currently active {@link UIInstanceManager}.
+   */
+  currentUi: UIInstanceManager;
+}
+
 export class UIManager {
 
   private player: PlayerAPI;
@@ -103,6 +114,7 @@ export class UIManager {
 
   private events = {
     onUiVariantResolve: new EventDispatcher<UIManager, UIConditionContext>(),
+    onActiveUiChanged: new EventDispatcher<UIManager, ActiveUiChangedArgs>(),
   };
 
   /**
@@ -383,6 +395,7 @@ export class UIManager {
   switchToUiVariant(uiVariant: UIVariant, onShow?: () => void): void {
     let uiVariantIndex = this.uiVariants.indexOf(uiVariant);
 
+    const previousUi = this.currentUi;
     const nextUi: InternalUIInstanceManager = this.uiInstanceManagers[uiVariantIndex];
     // Determine if the UI variant is changing
     // Only if the UI variant is changing, we need to do some stuff. Else we just leave everything as-is.
@@ -417,6 +430,7 @@ export class UIManager {
       onShow();
     }
     this.currentUi.getUI().show();
+    this.events.onActiveUiChanged.dispatch(this, { previousUi, currentUi: nextUi });
   }
 
   /**
@@ -519,6 +533,14 @@ export class UIManager {
    */
   get onUiVariantResolve(): EventDispatcher<UIManager, UIConditionContext> {
     return this.events.onUiVariantResolve;
+  }
+
+  /**
+   * Fires after the UIManager has switched to a different UI variant.
+   * @returns {EventDispatcher<UIManager, ActiveUiChangedArgs>}
+   */
+  get onActiveUiChanged(): EventDispatcher<UIManager, ActiveUiChangedArgs> {
+    return this.events.onActiveUiChanged;
   }
 
   /**


### PR DESCRIPTION
Currently, when wanting to subscribe to the events exposed by a `UIInstanceManager` (like `onControlsShow`), the only way to do that is through the `currentUi` on the `UIManager`. However, the `currentUi` changes whenever the `UIManager` switches to a different UI variant, and there is currently no event that would allow to detect that.

This PR therefore introduces the `onActiveUiChanged` event which is dispatched whenever the `UIManager` switches from one UI variant to another. The arguments of that event expose both the previously active `UIInstanceManager`, should there be one, and the current one that the UI manager has just switched to.

Additionally, a public `activeUi` field was added that exposes the `UIInstanceManager` of the active UI variant.