### PR TITLE
Fix volume restoration when changing it via the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Restoring volume on unmute not working when volume was changed through the player API
+
 ## [3.49.0]
 
 ### Added

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -108,6 +108,7 @@ export namespace MockHelper {
         isCasting: jest.fn(),
         isViewModeAvailable: jest.fn(),
         seek: jest.fn(),
+        isMuted: jest.fn(),
 
         // Event faker
         eventEmitter: eventHelper,

--- a/spec/volumecontroller.spec.ts
+++ b/spec/volumecontroller.spec.ts
@@ -1,0 +1,29 @@
+import { PlayerEvent, VolumeChangedEvent } from 'bitmovin-player';
+import { VolumeController } from '../src/ts/volumecontroller';
+import { MockHelper, TestingPlayerAPI } from './helper/MockHelper';
+
+describe('VolumeController', () => {
+  let playerMock: TestingPlayerAPI;
+  let volumeController: VolumeController;
+
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    volumeController = new VolumeController(playerMock);
+  });
+
+  describe('onChangedEvent', () => {
+
+    it('should update the stored volume on VolumeChanged event', () => {
+      volumeController.storeVolume = jest.fn();
+
+      playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
+        type: PlayerEvent.VolumeChanged,
+        sourceVolume: 0.2,
+        targetVolume: 0.7,
+        timestamp: Date.now(),
+      });
+
+      expect(volumeController.storeVolume).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/ts/volumecontroller.ts
+++ b/src/ts/volumecontroller.ts
@@ -88,6 +88,8 @@ export class VolumeController {
     const uiMuted = playerMuted || playerVolume === 0;
     const uiVolume = playerMuted ? 0 : playerVolume;
 
+    this.storeVolume();
+
     this.events.onChanged.dispatch(this, { volume: uiVolume, muted: uiMuted });
   }
 


### PR DESCRIPTION
When we call the player API directly, such as `player.setVolume(20)` in the browser console, the volume data was not stored in UI. Thus, when trying to restore volume data, (e.g. when unmuting) the value did not get applied.

### Changes
- Store volume on VolumeChanged event
- Unit test for storing the volume