### PR TITLE
Fix settings panel closing issue in the small screen UI (mobile devices)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop]
+
+### Fixed
+- Settings panel does not close on single tap on mobile devices
+
 ## [3.49.0]
 
 ### Added

--- a/src/ts/components/controlbar.ts
+++ b/src/ts/components/controlbar.ts
@@ -81,7 +81,7 @@ export class ControlBar extends Container<ControlBarConfig> {
 
     uimanager.onPreviewControlsHide.subscribe((sender, args) => {
       // Cancel the hide event if hovered child components block hiding or if the settings panel is active on mobile.
-      args.cancel = (hoverStackCount > 0 || isSettingsPanelShown);
+      args.cancel = args.cancel || (hoverStackCount > 0 || isSettingsPanelShown);
     });
 
     uimanager.onControlsHide.subscribe(() => {

--- a/src/ts/components/controlbar.ts
+++ b/src/ts/components/controlbar.ts
@@ -5,6 +5,8 @@ import {Spacer} from './spacer';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
 import { BrowserUtils } from '../browserutils';
+import {Component, ComponentConfig} from './component';
+import {SettingsPanel} from './settingspanel';
 
 /**
  * Configuration interface for the {@link ControlBar}.
@@ -35,6 +37,7 @@ export class ControlBar extends Container<ControlBarConfig> {
 
     // Counts how many components are hovered and block hiding of the control bar
     let hoverStackCount = 0;
+    let isSettingsPanelShown = false;
 
     // only enabling this for non-mobile platforms without touch input. enabling this
     // for touch devices causes the UI to not disappear after hideDelay seconds.
@@ -58,13 +61,27 @@ export class ControlBar extends Container<ControlBarConfig> {
       });
     }
 
+    if (BrowserUtils.isMobile) {
+      uimanager.onComponentShow.subscribe((component: Component<ComponentConfig>) => {
+        if (component instanceof SettingsPanel) {
+          isSettingsPanelShown = true;
+        }
+      });
+
+      uimanager.onComponentHide.subscribe((component: Component<ComponentConfig>) => {
+        if (component instanceof SettingsPanel) {
+          isSettingsPanelShown = false;
+        }
+      });
+    }
+
     uimanager.onControlsShow.subscribe(() => {
       this.show();
     });
 
     uimanager.onPreviewControlsHide.subscribe((sender, args) => {
-      // Cancel the hide event if hovered child components block hiding
-      args.cancel = (hoverStackCount > 0);
+      // Cancel the hide event if hovered child components block hiding or if the settings panel is active on mobile.
+      args.cancel = (hoverStackCount > 0 || isSettingsPanelShown);
     });
 
     uimanager.onControlsHide.subscribe(() => {


### PR DESCRIPTION
Problem: The settings panel requires a double touch to close when the control bar on mobile devices auto-hides (small screen UI). 

Fix: Added change to cancel the auto-hide of control bar when the settings panel is active on mobile devices. Once the user interacts with the Settings panel and closes(x) it, the auto-hide will work as usual.