### PR TITLE
Fix watch task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Restoring volume on unmute not working when volume was changed through the player API
+- Gulp `watch` task not working
 
 ## [3.49.0]
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -209,26 +209,19 @@ gulp.task('build-prod', gulp.series(function(callback) {
 gulp.task('default', gulp.series('build'));
 
 // Watches files for changes and runs their build tasks
-gulp.task('watch', function() {
+gulp.task('watch', gulp.series('build', function() {
   // Watch for changed html files
   gulp.watch(paths.source.html).on('change', gulp.series('html'));
 
   // Watch SASS files
   gulp.watch(paths.source.sass).on('change', gulp.series('sass'));
 
-  // Watch JSON files 
+  // Watch JSON files
   gulp.watch(paths.source.json).on('change', gulp.series('browserify'));
 
-  // Watch files for changes through Browserify with Watchify
-  catchBrowserifyErrors = true;
-  return browserifyInstance
-  .plugin(watchify)
-  // When a file has changed, rerun the browserify task to create an updated bundle
-  .on('update', function() {
-    gulp.start('browserify');
-  })
-  .bundle();
-});
+  // Watch TypeScript files
+  gulp.watch(paths.source.ts).on('change', gulp.series('browserify'));
+}));
 
 // Serves the project in the browser and updates it automatically on changes
 gulp.task('serve', gulp.series('build', function() {


### PR DESCRIPTION
The `gulp watch` task is not working.

This PR fixes it and aligns the flow with the `serve` task.