### PR TITLE
Only remove subtitles which do not encompass the seek target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Changed
+- On seek/timeshift operations the UI will only remove subtitle cues which do not enclose the seek target instead of removing all.
+
 ## [3.50.0]
 
 ### Fixed

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -3,7 +3,7 @@ import { UIInstanceManager } from '../../src/ts/uimanager';
 import { SubtitleOverlay, SubtitleRegionContainerManager } from '../../src/ts/components/subtitleoverlay';
 import { DOM } from '../../src/ts/dom';
 
-let playerMock: TestingPlayerAPI;
+let playerMock: jest.Mocked<TestingPlayerAPI>;
 let uiInstanceManagerMock: UIInstanceManager;
 let subtitleOverlay: SubtitleOverlay;
 
@@ -15,7 +15,7 @@ describe('SubtitleOverlay', () => {
   describe('Subtitle Region Container', () => {
     let mockDomElement: DOM;
     beforeEach(() => {
-      playerMock = MockHelper.getPlayerMock();
+      playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
       uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
 
       subtitleOverlay = new SubtitleOverlay();
@@ -60,6 +60,22 @@ describe('SubtitleOverlay', () => {
 
       playerMock.eventEmitter.fireSubtitleCueUpdateEvent('some different text');
       expect(updateLabelSpy).not.toHaveBeenCalled();
+    });
+
+    it('remove only inactive cues when the player finishes seeking', () => {
+      const removeLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'removeLabel');
+      // create one active cue
+      playerMock.getCurrentTime.mockReturnValue(1);
+      playerMock.eventEmitter.fireSubtitleCueEnterEvent();
+
+      // seek inside the cue and ensure it has not been removed
+      playerMock.eventEmitter.fireSeekedEvent();
+      expect(removeLabelSpy).not.toHaveBeenCalled();
+
+      // seek outside of the cue and ensure it is removed
+      playerMock.getCurrentTime.mockReturnValue(15);
+      playerMock.eventEmitter.fireSeekedEvent();
+      expect(removeLabelSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -482,17 +482,17 @@ class ActiveSubtitleManager {
    * @param time the time for which subtitles should remain
    */
   public clearInactiveCues(time: number): ActiveSubtitleCue[] {
-    const removedEvents: ActiveSubtitleCue[] = [];
+    const removedCues: ActiveSubtitleCue[] = [];
     Object.keys(this.activeSubtitleCueMap).forEach(key => {
       const activeCues = this.activeSubtitleCueMap[key];
-      activeCues.forEach(element => {
-        if (time < element.event.start || time > element.event.end) {
-          this.popCueFromMap(element.event);
-          removedEvents.push(element);
+      activeCues.forEach(cue => {
+        if (time < cue.event.start || time > cue.event.end) {
+          this.popCueFromMap(cue.event);
+          removedCues.push(cue);
         }
       });
     });
-    return removedEvents;
+    return removedCues;
   }
 
   static generateImageTagText(imageData: string): string | undefined {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -121,9 +121,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       this.updateComponents();
     };
 
-    const clearInactiveSubtitles = () => {
-      const removedActiveSubtitles = subtitleManager.clearInactiveCues(player.getCurrentTime());
-      removedActiveSubtitles.forEach(toRemove => {
+    const clearInactiveCues = () => {
+      const removedActiveCues = subtitleManager.clearInactiveCues(player.getCurrentTime());
+      removedActiveCues.forEach(toRemove => {
         this.subtitleContainerManager.removeLabel(toRemove.label);
       });
     };
@@ -131,8 +131,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     player.on(player.exports.PlayerEvent.AudioChanged, subtitleClearHandler);
     player.on(player.exports.PlayerEvent.SubtitleEnabled, subtitleClearHandler);
     player.on(player.exports.PlayerEvent.SubtitleDisabled, subtitleClearHandler);
-    player.on(player.exports.PlayerEvent.Seeked, clearInactiveSubtitles);
-    player.on(player.exports.PlayerEvent.TimeShifted, clearInactiveSubtitles);
+    player.on(player.exports.PlayerEvent.Seeked, clearInactiveCues);
+    player.on(player.exports.PlayerEvent.TimeShifted, clearInactiveCues);
     player.on(player.exports.PlayerEvent.PlaybackFinished, subtitleClearHandler);
     player.on(player.exports.PlayerEvent.SourceUnloaded, subtitleClearHandler);
 


### PR DESCRIPTION
When seeking, we removed all active subtitles, even when we seeking inside the range of the active subtitle. In that case the UI would not display the Cue because the player will only fire a `CueExit` + `CueEnter` when we played outside of the Cue.

So in this PR we check the playback range of all active cues after a Seek / Timeshift operation has been completed and only remove cues which do not enclose the new current time.