### PR TITLE
[PoC] Spatial Navigation - Arrow key continues closest to mouse position

### DIFF
--- a/src/ts/spatialnavigation/navigationalgorithm.ts
+++ b/src/ts/spatialnavigation/navigationalgorithm.ts
@@ -100,21 +100,21 @@ function calculateAngle(a: Vector, b: Vector, direction: Direction): number {
 export function getElementInDirection(
   activeElement: HTMLElement,
   elements: HTMLElement[],
-  direction: Direction
+  direction: Direction,
 ): HTMLElement | undefined {
   if (!activeElement) return undefined;
 
   return getElementInDirectionFromPoint(
     getElementVector(activeElement),
     elements.filter((elem) => elem !== activeElement),
-    direction
+    direction,
   );
 }
 
 export function getElementInDirectionFromPoint(
   vector: Vector,
   elements: HTMLElement[],
-  direction: Direction
+  direction: Direction,
 ): HTMLElement | undefined {
   const cutoffAngle = 45;
 

--- a/src/ts/spatialnavigation/navigationalgorithm.ts
+++ b/src/ts/spatialnavigation/navigationalgorithm.ts
@@ -100,21 +100,31 @@ function calculateAngle(a: Vector, b: Vector, direction: Direction): number {
 export function getElementInDirection(
   activeElement: HTMLElement,
   elements: HTMLElement[],
-  direction: Direction,
+  direction: Direction
 ): HTMLElement | undefined {
   if (!activeElement) return undefined;
 
+  return getElementInDirectionFromPoint(
+    getElementVector(activeElement),
+    elements.filter((elem) => elem !== activeElement),
+    direction
+  );
+}
+
+export function getElementInDirectionFromPoint(
+  vector: Vector,
+  elements: HTMLElement[],
+  direction: Direction
+): HTMLElement | undefined {
   const cutoffAngle = 45;
-  const activeElemVector = getElementVector(activeElement);
 
   return elements
     // don't take the current element into account
-    .filter(elem => elem !== activeElement)
     // get the angle between, and distance to any other element from the current element
     .map(element => {
       const elementVector = getElementVector(element);
-      const dist = distance(activeElemVector, elementVector);
-      const angle = calculateAngle(activeElemVector, elementVector, direction);
+      const dist = distance(vector, elementVector);
+      const angle = calculateAngle(vector, elementVector, direction);
 
       return { angle, dist, element };
     })

--- a/src/ts/spatialnavigation/navigationgroup.ts
+++ b/src/ts/spatialnavigation/navigationgroup.ts
@@ -123,7 +123,7 @@ export class NavigationGroup {
       const targetElement = getElementInDirectionFromPoint(
         this.mousePosition,
         getHtmlElementsFromComponents(this.components),
-        direction
+        direction,
       );
       if (targetElement) {
         this.focusElement(targetElement);
@@ -132,7 +132,7 @@ export class NavigationGroup {
       this.handleInput(
         direction,
         this.defaultNavigationHandler,
-        this.onNavigation
+        this.onNavigation,
       );
     }
   }
@@ -213,7 +213,7 @@ export class NavigationGroup {
 
     this.removeElementHoverEventListeners = () =>
       removeEventListenerFunctions.forEach((listeners) =>
-        listeners.forEach((fn) => fn())
+        listeners.forEach((fn) => fn()),
       );
   }
 


### PR DESCRIPTION
When using the magic remote of LG TVs, which behave like a mouse we need a way to switch from the remote back to buttons for this we

- remove focus from an element when the mouse leaves it
- when an arrow key is pressed the navigation continues from the last position the mouse was at.