### PR TITLE
Spatial Navigation - Arrow key continues at last element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [development]
+
+### Changed
+- When having a spatial navigation and using a mouselike device, elements will lose focus when the mouse leaves the hovered component. Spatial navigation will continue at the last active element when using arrow keys again.
+
 ## [3.51.0] - 2023-09-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [development]
 
-### Changed
-- When having a spatial navigation and using a mouselike device, elements will lose focus when the mouse leaves the hovered component. Spatial navigation will continue at the last active element when using arrow keys again.
+### Fixed
+- When having a spatial navigation and using a mouselike device, components will lose focus when the mouse leaves the hovered component. Spatial navigation will continue at the last active component when using arrow keys again.
 
 ## [3.51.0] - 2023-09-18
 

--- a/spec/spatialnavigation/navigationgroup.spec.ts
+++ b/spec/spatialnavigation/navigationgroup.spec.ts
@@ -73,8 +73,18 @@ describe('NavigationGroup', () => {
     });
 
     it('should focus element found by algorithm', () => {
+      rootNavigationGroup['activeElement'] = getFirstDomElement(playbackToggleButtonMock);
       rootNavigationGroup.handleNavigation(Direction.DOWN);
 
+      expect(subtitleToggleButtonHTML.focus).toHaveBeenCalled();
+    });
+
+    it('should default to the last selected item when there is no active item', () => {
+      rootNavigationGroup['activeElementBeforeDisable'] = subtitleToggleButtonHTML;
+      rootNavigationGroup['activeElement'] = undefined;
+
+      rootNavigationGroup.handleNavigation(Direction.LEFT);
+      
       expect(subtitleToggleButtonHTML.focus).toHaveBeenCalled();
     });
 

--- a/src/ts/spatialnavigation/navigationgroup.ts
+++ b/src/ts/spatialnavigation/navigationgroup.ts
@@ -111,12 +111,14 @@ export class NavigationGroup {
    */
   public handleNavigation(direction: Direction): void {
     if (!this.activeElement) {
+      // If we do not have an active element, the active element has been disabled by a mouseleave
+      // event. We should continue the navigation at the exact place where we left off.
       if (this.activeElementBeforeDisable) {
         this.focusElement(this.activeElementBeforeDisable);
-        return;
       } else {
         this.focusFirstElement();
       }
+      return;
     }
     this.handleInput(direction, this.defaultNavigationHandler, this.onNavigation);
   }

--- a/src/ts/spatialnavigation/navigationgroup.ts
+++ b/src/ts/spatialnavigation/navigationgroup.ts
@@ -110,6 +110,14 @@ export class NavigationGroup {
    * @param direction The direction of the navigation event
    */
   public handleNavigation(direction: Direction): void {
+    if (!this.activeElement) {
+      if (this.activeElementBeforeDisable) {
+        this.focusElement(this.activeElementBeforeDisable);
+        return;
+      } else {
+        this.focusFirstElement();
+      }
+    }
     this.handleInput(direction, this.defaultNavigationHandler, this.onNavigation);
   }
 
@@ -160,11 +168,16 @@ export class NavigationGroup {
     this.removeElementHoverEventListeners();
 
     const removeEventListenerFunctions = getHtmlElementsFromComponents(this.components).map(htmlElem => {
-      const listener = this.focusElement.bind(this, htmlElem);
+      const enterListener = this.focusElement.bind(this, htmlElem);
+      const exitListener = () => this.disable();
 
-      this.eventSubscriber.on(htmlElem, 'mouseenter', listener);
+      this.eventSubscriber.on(htmlElem, 'mouseenter', enterListener);
+      this.eventSubscriber.on(htmlElem, 'mouseleave', exitListener);
 
-      return () => this.eventSubscriber.off(htmlElem, 'mouseenter', listener);
+      return () => {
+        this.eventSubscriber.off(htmlElem, 'mouseenter', enterListener);
+        this.eventSubscriber.off(htmlElem, 'mouseleave', exitListener);
+      };
     });
 
     this.removeElementHoverEventListeners = () => removeEventListenerFunctions.forEach(fn => fn());


### PR DESCRIPTION
When using the magic remote of LG TVs, which behave like a mouse we need a way to switch from the remote back to arrow button navigation. For this we

- remove the focus when the "mouse" leaves a component
- When an arrow key is pressed, we focus the last component which had focus for the navigation to continue there.