### PR TITLE
Fix an exception when receiving a `SourceLoaded` event during scrubbing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [development]
 
 ### Fixed
 - Crash when receiving a `SourceLoaded` event during scrubbing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Crash when receiving a `SourceLoaded` event during scrubbing
+
 ## [3.52.0] - 2023-09-25
 
 ### Fixed

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -254,7 +254,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       // At the same time when the user is scrubbing, we also move the position of the seekbar to display a preview during scrubbing.
       // When the user is scrubbing we do not record this as a user seek operation, as the user has yet to finish their seek,
       // but we should not move the playback position to not create a jumping behaviour.
-      if (scrubbing && event.type === player.exports.PlayerEvent.SegmentRequestFinished && playbackPositionPercentage !== this.playbackPositionPercentage) {
+      if (scrubbing && event && event.type === player.exports.PlayerEvent.SegmentRequestFinished && playbackPositionPercentage !== this.playbackPositionPercentage) {
         playbackPositionPercentage = this.playbackPositionPercentage;
       }
 


### PR DESCRIPTION
### Problem
When the `playbackPositionHandler` inside the `Seekbar` is called without an event (i.e., with `null`), such as during the reception of a `SourceLoaded` event, the application crashes. This leads to an undefined UI state where the `seekbar` is partially updated to the player state, and the play button may be missing.

### Changes
Adding the missing `null` check for the optional event parameter.