### PR TITLE
Use develop instead of Unreleased in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [develop]
 
 ## [3.52.2] - 2023-11-23
 


### PR DESCRIPTION
In changelog file `Untracked` is used instead of `develop` for changes merged in develop branch.

This PR fixes that.