### PR TITLE
Fix failing release workflow

### DIFF
--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           script: |
             const { defineReleaseVersion } = require('./.github/scripts/defineVersion.js')
-            return defineReleaseVersion({core}, 'minor', undefined, "${{ steps.define-package-json-version.outputs.packageJsonVersion }}" )
+            return defineReleaseVersion({core}, 'minor', "${{ steps.define-package-json-version.outputs.packageJsonVersion }}" )
 
       - name: Bump package.json version
         run: |

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -12,6 +12,11 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
We removed checkout step when we added the release workflow here https://github.com/bitmovin/bitmovin-player-ui/pull/590 although it is required.

This PR adds the checkout step, and also fixes calling `defineReleaseVersion` function.