### PR TITLE
Fix font family selectbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
+
 ### Fixed
-- Fix issue where in the FCC subtitle settings menu, two options were returning the same value
+- FCC subtitle settings menu showing two options with the same value
 
 ## [3.53.0] - 2024-01-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop]
+### Fixed
+- Fix issue where in the FCC subtitle settings menu, two options were returning the same value
 
 ### Added
 - Automate release on every PR merge to develop

--- a/src/ts/components/subtitlesettings/fontfamilyselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontfamilyselectbox.ts
@@ -23,7 +23,7 @@ export class FontFamilySelectBox extends SubtitleSettingSelectBox {
     this.addItem('monospacedserif', i18n.getLocalizer('settings.subtitles.font.family.monospacedserif'));
     this.addItem('proportionalserif', i18n.getLocalizer('settings.subtitles.font.family.proportionalserif'));
     this.addItem('monospacedsansserif', i18n.getLocalizer('settings.subtitles.font.family.monospacedsansserif'));
-    this.addItem('proportionalsansserif', i18n.getLocalizer('settings.subtitles.font.family.proportionalserif'));
+    this.addItem('proportionalsansserif', i18n.getLocalizer('settings.subtitles.font.family.proportionalsansserif'));
     this.addItem('casual', i18n.getLocalizer('settings.subtitles.font.family.casual'));
     this.addItem('cursive', i18n.getLocalizer('settings.subtitles.font.family.cursive'));
     this.addItem('smallcapital', i18n.getLocalizer('settings.subtitles.font.family.smallcapital'));


### PR DESCRIPTION
ref PW-13787
In the FCC compliant subtitle styling menu, both  `proportionalsansserif` and `proportionalserif` options returned “proportional serif“, so the same font family was applied in both cases.

The issue lied in the [fontfamilyselectbox.ts](https://github.com/bitmovin/bitmovin-player-ui/compare/feature/fix_font_family_selectbox?expand=1#diff-8eed0baee6517441b40ee52f7e7e0fb0d9e08e196fee607b1a2f010e240029fe) file, where both font family selectors were pointing to `proportionalserif`