### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+## Description
+<!-- Add a short description about the changes -->
+
+## Checklist (for PR submitter and reviewers)
+<!-- A PR with CHANGELOG entry will be released automatically -->
+- [ ] `CHANGELOG` entry


### PR DESCRIPTION
A PR templated is added just to make sure that we have a description of the PR and a `changelog` entry.

With the new automatic release, it will only release if there is a changelog entry, that is also mentioned in the PR template.