### PR TITLE
Add compare link in changelog file

### DIFF
--- a/.github/scripts/updateChangelog.js
+++ b/.github/scripts/updateChangelog.js
@@ -17,7 +17,7 @@ function updateChangeLog(changelogString, version, releaseDate) {
 
   return changelogString.replace(
     '## 1.0.0 (2017-02-03)\n- First release\n\n',
-    `## 1.0.0 (2017-02-03)\n- First release\n\n[${version}]: https://github.com/bitmovin/bitmovin-player-ui/compare/v${version}...v${lastReleaseVersion}\n`
+    `## 1.0.0 (2017-02-03)\n- First release\n\n[${version}]: https://github.com/bitmovin/bitmovin-player-ui/compare/v${lastReleaseVersion}...v${version}\n`
   );
 }
 

--- a/.github/scripts/updateChangelog.js
+++ b/.github/scripts/updateChangelog.js
@@ -12,7 +12,7 @@ function updateChangeLog(changelogString, version, releaseDate) {
     'gi',
   );
 
-  const lastReleaseVersion = changelogString.match(/\[(\d+.\d+.\d+)\]/)[1];
+  const lastReleaseVersion = changelogString.match(/## \[(\d+.\d+.\d+)\] - \d{4}-\d{2}-\d{2}/)[1];
   const changelogWithReleaseVersionAndDate = changelogString.replace(changelogVersionRegExp, `[${version}] - ${releaseDate}`);
 
   return changelogWithReleaseVersionAndDate.replace(

--- a/.github/scripts/updateChangelog.js
+++ b/.github/scripts/updateChangelog.js
@@ -13,9 +13,9 @@ function updateChangeLog(changelogString, version, releaseDate) {
   );
 
   const lastReleaseVersion = changelogString.match(/\[(\d+.\d+.\d+)\]/)[1];
-  changelogString = changelogString.replace(changelogVersionRegExp, `[${version}] - ${releaseDate}`);
+  const changelogWithReleaseVersionAndDate = changelogString.replace(changelogVersionRegExp, `[${version}] - ${releaseDate}`);
 
-  return changelogString.replace(
+  return changelogWithReleaseVersionAndDate.replace(
     '## 1.0.0 (2017-02-03)\n- First release\n\n',
     `## 1.0.0 (2017-02-03)\n- First release\n\n[${version}]: https://github.com/bitmovin/bitmovin-player-ui/compare/v${lastReleaseVersion}...v${version}\n`
   );

--- a/.github/scripts/updateChangelog.js
+++ b/.github/scripts/updateChangelog.js
@@ -6,12 +6,19 @@
  * @param {string} releaseDate the release date to be written to the changelog
  */
 function updateChangeLog(changelogString, version, releaseDate) {
-    const optionalBetaOrRc = '(-rc.d+)?(-(b|beta).d+)?';
-    const changelogVersionRegExp = new RegExp(
-      `\\[(development|develop|unreleased|${version})${optionalBetaOrRc}.*`,
-      'gi',
-    );
-    return changelogString.replace(changelogVersionRegExp, `[${version}] - ${releaseDate}`);
-  }
-  
-  module.exports.updateChangeLog = updateChangeLog;
+  const optionalBetaOrRc = '(-rc.d+)?(-(b|beta).d+)?';
+  const changelogVersionRegExp = new RegExp(
+    `\\[(development|develop|unreleased|${version})${optionalBetaOrRc}.*`,
+    'gi',
+  );
+
+  const lastReleaseVersion = changelogString.match(/\[(\d+.\d+.\d+)\]/)[1];
+  changelogString = changelogString.replace(changelogVersionRegExp, `[${version}] - ${releaseDate}`);
+
+  return changelogString.replace(
+    '## 1.0.0 (2017-02-03)\n- First release\n\n',
+    `## 1.0.0 (2017-02-03)\n- First release\n\n[${version}]: https://github.com/bitmovin/bitmovin-player-ui/compare/v${version}...v${lastReleaseVersion}\n`
+  );
+}
+
+module.exports.updateChangeLog = updateChangeLog;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Automatically add compare link in changelog file in relase workflow
+
+### Fixed
+- Missing compare link in the changelog file
+
 ## [3.54.0] - 2024-02-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -898,6 +898,8 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[3.54.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.53.0...v3.54.0
+[3.53.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.52.2...v3.53.0
 [3.52.2]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.52.1...v3.52.2
 [3.52.1]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.52.0...v3.52.1
 [3.52.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.51.0...v3.52.0


### PR DESCRIPTION
## Description

When we update the `changelog` file in our release workflow to add release version and date, we are missing the compare link that should be added at the end of file.

This PR fixes that by adding links automatically.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
