### PR TITLE
Rewrite `hasLocalStorage` check to not produce `localStorage`-entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- `localStorage` availability check to not create a test-entry anymore
+
 ## [3.55.0] - 2024-03-21
 
 ### Added

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -17,8 +17,12 @@ export namespace StorageUtils {
    * @param data the item's data
    */
   export function setItem(key: string, data: string): void {
-    if (StorageUtils.isLocalStorageAvailable()) {
-      window.localStorage.setItem(key, data);
+    try {
+      if (StorageUtils.isLocalStorageAvailable()) {
+        window.localStorage.setItem(key, data);
+      }
+    } catch (e) {
+      /* Can get triggered e.g. by QuotaExceededError in Safari private mode */
     }
   }
 
@@ -28,9 +32,11 @@ export namespace StorageUtils {
    * @return {string | null} Returns the string if found, null if there is no data stored for the key
    */
   export function getItem(key: string): string | null {
-    if (StorageUtils.isLocalStorageAvailable()) {
-      return window.localStorage.getItem(key);
-    } else {
+    try {
+      if (StorageUtils.isLocalStorageAvailable()) {
+        return window.localStorage.getItem(key);
+      }
+    } catch (e) {
       return null;
     }
   }

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -3,8 +3,8 @@ export namespace StorageUtils {
     try {
       return (
         window.localStorage &&
-        typeof localStorage.getItem === 'function' &&
-        typeof localStorage.setItem === 'function'
+        typeof localStorage.getItem === "function" &&
+        typeof localStorage.setItem === "function"
       );
     } catch (e) {
       return false;
@@ -17,13 +17,8 @@ export namespace StorageUtils {
    * @param data the item's data
    */
   export function setItem(key: string, data: string): void {
-    try {
-      if (StorageUtils.isLocalStorageAvailable()) {
-        window.localStorage.setItem(key, data);
-      }
-    } catch (e) {
-      /* Can get triggered e.g. by QuotaExceededError in Safari private mode */
-      console.warn(`Failed to set storage entry for ${key}`);
+    if (StorageUtils.isLocalStorageAvailable()) {
+      window.localStorage.setItem(key, data);
     }
   }
 
@@ -33,13 +28,10 @@ export namespace StorageUtils {
    * @return {string | null} Returns the string if found, null if there is no data stored for the key
    */
   export function getItem(key: string): string | null {
-    try {
-      if (StorageUtils.isLocalStorageAvailable()) {
-        return window.localStorage.getItem(key);
-      }
-    } catch (e) {
-      console.warn(`Failed to retrieve storage entry for ${key}`);
+    if (StorageUtils.isLocalStorageAvailable()) {
+      return window.localStorage.getItem(key);
     }
+
     return null;
   }
 

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -3,8 +3,8 @@ export namespace StorageUtils {
     try {
       return (
         window.localStorage &&
-        typeof localStorage.getItem === "function" &&
-        typeof localStorage.setItem === "function"
+        typeof localStorage.getItem === 'function' &&
+        typeof localStorage.setItem === 'function'
       );
     } catch (e) {
       return false;

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -18,7 +18,11 @@ export namespace StorageUtils {
    */
   export function setItem(key: string, data: string): void {
     if (isLocalStorageAvailable()) {
-      window.localStorage.setItem(key, data);
+      try {
+        window.localStorage.setItem(key, data);
+      } catch (e) {
+        console.debug(`Failed to set storage item ${key}`, e);
+      }
     }
   }
 
@@ -29,7 +33,11 @@ export namespace StorageUtils {
    */
   export function getItem(key: string): string | null {
     if (isLocalStorageAvailable()) {
-      return window.localStorage.getItem(key);
+      try {
+        return window.localStorage.getItem(key);
+      } catch (e) {
+        console.debug(`Failed to get storage item ${key}`, e);
+      }
     }
 
     return null;

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,5 +1,5 @@
 export namespace StorageUtils {
-  export function isLocalStorageAvailable(): boolean {
+  function isLocalStorageAvailable(): boolean {
     try {
       return (
         window.localStorage &&
@@ -17,7 +17,7 @@ export namespace StorageUtils {
    * @param data the item's data
    */
   export function setItem(key: string, data: string): void {
-    if (StorageUtils.isLocalStorageAvailable()) {
+    if (isLocalStorageAvailable()) {
       window.localStorage.setItem(key, data);
     }
   }
@@ -28,7 +28,7 @@ export namespace StorageUtils {
    * @return {string | null} Returns the string if found, null if there is no data stored for the key
    */
   export function getItem(key: string): string | null {
-    if (StorageUtils.isLocalStorageAvailable()) {
+    if (isLocalStorageAvailable()) {
       return window.localStorage.getItem(key);
     }
 

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,36 +1,14 @@
 export namespace StorageUtils {
-  let hasLocalStorageCache: boolean;
-
   export function hasLocalStorage(): boolean {
-    if (hasLocalStorageCache) {
-      return hasLocalStorageCache;
-    }
-
-    // hasLocalStorage is used to safely ensure we can use localStorage
-    // taken from https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage
-    let storage: any = { length: 0 };
     try {
-      storage = window['localStorage'];
-      let x = '__storage_test__';
-      storage.setItem(x, x);
-      storage.removeItem(x);
-      hasLocalStorageCache = true;
+      return (
+        window.localStorage &&
+        typeof localStorage.getItem === "function" &&
+        typeof localStorage.setItem === "function"
+      );
+    } catch (e) {
+      return false;
     }
-    catch (e) {
-      hasLocalStorageCache = e instanceof DOMException && (
-          // everything except Firefox
-        e.code === 22 ||
-        // Firefox
-        e.code === 1014 ||
-        // test name field too, because code might not be present
-        // everything except Firefox
-        e.name === 'QuotaExceededError' ||
-        // Firefox
-        e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
-        // acknowledge QuotaExceededError only if there's something already stored
-        storage.length !== 0;
-    }
-    return hasLocalStorageCache;
   }
 
   /**

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -23,6 +23,7 @@ export namespace StorageUtils {
       }
     } catch (e) {
       /* Can get triggered e.g. by QuotaExceededError in Safari private mode */
+      console.warn(`Failed to set storage entry for ${key}`);
     }
   }
 
@@ -37,8 +38,9 @@ export namespace StorageUtils {
         return window.localStorage.getItem(key);
       }
     } catch (e) {
-      return null;
+      console.warn(`Failed to retrieve storage entry for ${key}`);
     }
+    return null;
   }
 
   /**
@@ -50,10 +52,8 @@ export namespace StorageUtils {
    * @param data the object to store
    */
   export function setObject<T>(key: string, data: T): void {
-    if (StorageUtils.isLocalStorageAvailable()) {
-      let json = JSON.stringify(data);
-      setItem(key, json);
-    }
+    let json = JSON.stringify(data);
+    setItem(key, json);
   }
 
   /**
@@ -64,14 +64,12 @@ export namespace StorageUtils {
    * @param key the key to look up its associated object
    * @return {any} Returns the object if found, null otherwise
    */
-  export function getObject<T>(key: string): T {
-    if (StorageUtils.isLocalStorageAvailable()) {
-      let json = getItem(key);
+  export function getObject<T>(key: string): T | null {
+    let json = getItem(key);
 
-      if (key) {
-        let object = JSON.parse(json);
-        return <T>object;
-      }
+    if (json) {
+      let object = JSON.parse(json);
+      return <T>object;
     }
     return null;
   }

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,5 +1,5 @@
 export namespace StorageUtils {
-  export function hasLocalStorage(): boolean {
+  export function isLocalStorageAvailable(): boolean {
     try {
       return (
         window.localStorage &&
@@ -17,7 +17,7 @@ export namespace StorageUtils {
    * @param data the item's data
    */
   export function setItem(key: string, data: string): void {
-    if (StorageUtils.hasLocalStorage()) {
+    if (StorageUtils.isLocalStorageAvailable()) {
       window.localStorage.setItem(key, data);
     }
   }
@@ -28,7 +28,7 @@ export namespace StorageUtils {
    * @return {string | null} Returns the string if found, null if there is no data stored for the key
    */
   export function getItem(key: string): string | null {
-    if (StorageUtils.hasLocalStorage()) {
+    if (StorageUtils.isLocalStorageAvailable()) {
       return window.localStorage.getItem(key);
     } else {
       return null;
@@ -44,7 +44,7 @@ export namespace StorageUtils {
    * @param data the object to store
    */
   export function setObject<T>(key: string, data: T): void {
-    if (StorageUtils.hasLocalStorage()) {
+    if (StorageUtils.isLocalStorageAvailable()) {
       let json = JSON.stringify(data);
       setItem(key, json);
     }
@@ -59,7 +59,7 @@ export namespace StorageUtils {
    * @return {any} Returns the object if found, null otherwise
    */
   export function getObject<T>(key: string): T {
-    if (StorageUtils.hasLocalStorage()) {
+    if (StorageUtils.isLocalStorageAvailable()) {
       let json = getItem(key);
 
       if (key) {


### PR DESCRIPTION
## Description
Existence of the `localStorage` API was probed so far by creating (and immediately deleting) a `localStorage`-entry. This is undesirable behaviour in case a page wishes to not have the `localStorage`-API utilized in any way. 

This PR introduces the following changes:

- Determine existence of the `localStorage`-API by checking if `getItem` and `setItem` functions are available instead of setting a storage item
- Handle exceptions directly in the `getItem`/`setItem` wrapper functions (e.g. if access is denied or quota got exceeded)

Anyways, a `localStorage` item would still be set if certain feature of the player-UI are used. PR <PR GOES HERE> is a followup to introduce disabling of `localStorage`.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
