### PR TITLE
Add config option to disable `localStorage` access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Config option `disableLocalStorageApi`
+- Config option `disableStorageApi` to prevent `localStorage` operations
 
 ### Changed
 - `localStorage` availability check to not create a test-entry anymore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Config option `disableLocalStorageApi`
+
 ### Changed
 - `localStorage` availability check to not create a test-entry anymore
 

--- a/src/ts/components/subtitlesettings/subtitlesettingsmanager.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingsmanager.ts
@@ -108,8 +108,8 @@ export class SubtitleSettingsManager {
   /**
    * Loads the settings from local storage
    */
-  public load(): void {
-    this.userSettings = StorageUtils.getObject<SubtitleSettings>(this.localStorageKey) || {};
+  public async load(): Promise<void> {
+    this.userSettings = await StorageUtils.getObject<SubtitleSettings>(this.localStorageKey) || {};
 
     // Apply the loaded settings
     for (let property in this.userSettings) {

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -2,10 +2,8 @@ import { UIConfig } from './uiconfig';
 
 export namespace StorageUtils {
   let res: (uiConfig: UIConfig) => void;
-  let rej;
-  let uiConfigSetPromise = new Promise<UIConfig>((resolve, reject) => {
+  let uiConfigSetPromise = new Promise<UIConfig>((resolve) => {
     res = resolve;
-    rej = reject;
   });
 
   export function resolveStorageAccess(uiConfig: UIConfig) {

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -14,15 +14,16 @@ export namespace StorageUtils {
 
   function isLocalStorageAvailable(): Promise<boolean> {
     return uiConfigSetPromise
-      .then(() => {
+      .then((uiConfig) => {
         return (
+          !uiConfig.disableStorageApi &&
           window.localStorage &&
           typeof localStorage.getItem === "function" &&
           typeof localStorage.setItem === "function"
         );
       })
       .catch((e) => {
-        console.debug('Error while checking localStorage availablility');
+        console.debug("Error while checking localStorage availablility", e);
         return false;
       });
   }

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -12,7 +12,7 @@ export namespace StorageUtils {
     res?.(uiConfig);
   }
 
-  function isLocalStorageAvailable(): Promise<boolean> {
+  function shouldUseLocalStorage(): Promise<boolean> {
     return uiConfigSetPromise
       .then((uiConfig) => {
         return (
@@ -34,7 +34,7 @@ export namespace StorageUtils {
    * @param data the item's data
    */
   export async function setItem(key: string, data: string): Promise<void> {
-    if (await isLocalStorageAvailable()) {
+    if (await shouldUseLocalStorage()) {
       window.localStorage.setItem(key, data);
     }
   }
@@ -45,7 +45,7 @@ export namespace StorageUtils {
    * @return {string | null} Returns the string if found, null if there is no data stored for the key
    */
   export async function getItem(key: string): Promise<string | null> {
-    if (await isLocalStorageAvailable()) {
+    if (await shouldUseLocalStorage()) {
       return window.localStorage.getItem(key);
     }
 

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,13 +1,13 @@
 import { UIConfig } from './uiconfig';
 
 export namespace StorageUtils {
-  let res: (uiConfig: UIConfig) => void;
+  let uiConfigSetResolver: (uiConfig: UIConfig) => void;
   let uiConfigSetPromise = new Promise<UIConfig>((resolve) => {
-    res = resolve;
+    uiConfigSetResolver = resolve;
   });
 
   export function resolveStorageAccess(uiConfig: UIConfig) {
-    res?.(uiConfig);
+    uiConfigSetResolver?.(uiConfig);
   }
 
   function isLocalStorageAvailable(): boolean {

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -12,20 +12,23 @@ export namespace StorageUtils {
     res?.(uiConfig);
   }
 
+  function isLocalStorageAvailable(): boolean {
+    try {
+      return (
+        window.localStorage &&
+        typeof localStorage.getItem === "function" &&
+        typeof localStorage.setItem === "function"
+      );
+    } catch (e) {
+      console.debug("Error while checking localStorage availablility", e);
+      return false;
+    }
+  }
+
   function shouldUseLocalStorage(): Promise<boolean> {
-    return uiConfigSetPromise
-      .then((uiConfig) => {
-        return (
-          !uiConfig.disableStorageApi &&
-          window.localStorage &&
-          typeof localStorage.getItem === "function" &&
-          typeof localStorage.setItem === "function"
-        );
-      })
-      .catch((e) => {
-        console.debug("Error while checking localStorage availablility", e);
-        return false;
-      });
+    return uiConfigSetPromise.then((uiConfig) => {
+      return !uiConfig.disableStorageApi && isLocalStorageAvailable();
+    });
   }
 
   /**

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,4 +1,4 @@
-import { UIConfig } from "./uiconfig";
+import { UIConfig } from './uiconfig';
 
 export namespace StorageUtils {
   let res: (uiConfig: UIConfig) => void;
@@ -16,11 +16,11 @@ export namespace StorageUtils {
     try {
       return (
         window.localStorage &&
-        typeof localStorage.getItem === "function" &&
-        typeof localStorage.setItem === "function"
+        typeof localStorage.getItem === 'function' &&
+        typeof localStorage.setItem === 'function'
       );
     } catch (e) {
-      console.debug("Error while checking localStorage availablility", e);
+      console.debug('Error while checking localStorage availablility', e);
       return false;
     }
   }

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,6 +1,11 @@
 import { UIConfig } from './uiconfig';
 
 export namespace StorageUtils {
+  /*
+    At the time of using `storageutils` inside components, the config isn't yet processed.
+    In order to know if we are allowed to use the `localStorage` API, we wait for the config to be
+    provided.
+  */
   let uiConfigSetResolver: (uiConfig: UIConfig) => void;
   let uiConfigSetPromise = new Promise<UIConfig>((resolve) => {
     uiConfigSetResolver = resolve;
@@ -36,7 +41,11 @@ export namespace StorageUtils {
    */
   export async function setItem(key: string, data: string): Promise<void> {
     if (await shouldUseLocalStorage()) {
-      window.localStorage.setItem(key, data);
+      try {
+        window.localStorage.setItem(key, data);
+      } catch (e) {
+        console.debug(`Failed to set storage item ${key}`, e);
+      }
     }
   }
 
@@ -47,7 +56,11 @@ export namespace StorageUtils {
    */
   export async function getItem(key: string): Promise<string | null> {
     if (await shouldUseLocalStorage()) {
-      return window.localStorage.getItem(key);
+      try {
+        return window.localStorage.getItem(key);
+      } catch (e) {
+        console.debug(`Failed to get storage item ${key}`, e);
+      }
     }
 
     return null;

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -100,4 +100,9 @@ export interface UIConfig {
    * Forces subtitle-labels back into their respective container if they overflow and are therefore cropped.
    */
   forceSubtitlesIntoViewContainer?: boolean;
+
+  /**
+   * When set to true, the ad module will never write anything to the browser's `localStorage`.
+   */
+  disableStorageApi?: boolean;
 }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -14,6 +14,7 @@ import { i18n, CustomVocabulary, Vocabularies } from './localization/i18n';
 import { FocusVisibilityTracker } from './focusvisibilitytracker';
 import { isMobileV3PlayerAPI, MobileV3PlayerAPI, MobileV3PlayerEvent } from './mobilev3playerapi';
 import { SpatialNavigation } from './spatialnavigation/spatialnavigation';
+import { StorageUtils } from './storageutils';
 
 export interface LocalizationConfig {
   /**
@@ -154,6 +155,7 @@ export class UIManager {
       this.uiVariants = <UIVariant[]>playerUiOrUiVariants;
     }
 
+    StorageUtils.resolveStorageAccess(uiconfig);
     this.player = player;
     this.managerPlayerWrapper = new PlayerWrapper(player);
 


### PR DESCRIPTION
## Description
So far, there hasn't been a way to disable `localStorage` access for the `bitmovin-player-ui`. In this PR, following changes are introduced:

- Adds a `disableLocalStorageApi`-flag 
- Respects that flag in the `storageutils.ts` (which are used to interact with the browser's `localStorage` API)

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
