### PR TITLE
Make seeking to beginning of Timeline marker with duration configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `UIConfig#seekbarShouldSeekToMarkerStartPosition` config property to configure seek behaviour for `TimelineMarker` with duration 
 
-## [3.56.0] - 2024-03-26
+## [3.57.0] - 2024-03-26
 
 ### Added
 - `disableStorageApi` config option
 
 ### Fixed
 - Subtitle settings not being retained when the UI variant switches
+
+## [3.56.0] - 2024-03-26
 
 ### Changed
 - `localStorage` availability check to not create a test-entry anymore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.57.0] - 2024-03-28
+## [Unreleased]
 
 ### Added
 - `UIConfig#seekbarShouldSeekToMarkerStartPosition` config property to configure seek behaviour for `TimelineMarker` with duration 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `UIConfig#seekbarShouldSeekToMarkerStartPosition` config property to configure seek behaviour for `TimelineMarker` with duration 
 
-## [3.57.0] - 2024-03-26
+## [3.57.0] - 2024-03-28
 
 ### Added
 - `disableStorageApi` config option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [3.57.0] - 2024-03-28
 
 ### Added
 - `UIConfig#seekbarShouldSeekToMarkerStartPosition` config property to configure seek behaviour for `TimelineMarker` with duration 
@@ -924,6 +924,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
+[3.57.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.56.0...v3.57.0
 [3.56.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.55.0...v3.56.0
 [3.55.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.54.0...v3.55.0
 [3.54.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.53.0...v3.54.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `UIConfig#seekbarShouldSeekToMarkerStartPosition` config property to configure seek behaviour for `TimelineMarker` with duration 
+
 ## [3.56.0] - 2024-03-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.56.0] - 2024-03-26
 
+### Added
+- `disableStorageApi` config option
+
+### Fixed
+- Subtitle settings not being retained when the UI variant switches
+
 ### Changed
 - `localStorage` availability check to not create a test-entry anymore
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "3.56.0",
+  "version": "3.57.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmovin-player-ui",
-      "version": "3.56.0",
+      "version": "3.57.0",
       "license": "MIT",
       "devDependencies": {
         "@inrupt/jest-jsdom-polyfills": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "3.56.0",
+  "version": "3.57.0",
   "description": "Bitmovin Player UI Framework",
   "main": "./dist/js/framework/main.js",
   "types": "./dist/js/framework/main.d.ts",

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -52,6 +52,11 @@ export interface SeekBarConfig extends ComponentConfig {
    * Used to enable/disable seek preview
    */
   enableSeekPreview?: boolean;
+
+  /**
+   * Used to enable/disable seeking to start of marker position
+   */
+  shouldSeekToMarkerStartPosition?: boolean;
 }
 
 /**
@@ -151,6 +156,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       tabIndex: 0,
       snappingRange: 1,
       enableSeekPreview: true,
+      shouldSeekToMarkerStartPosition: true,
     }, this.config);
 
     this.label = this.config.label;
@@ -452,6 +458,11 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.config.snappingRange = uimanager.getConfig().seekbarSnappingRange;
     }
 
+    // Set the shouldSeekToMarkerStartPosition if set in the uimanager config
+    if (typeof uimanager.getConfig().seekbarShouldSeekToMarkerStartPosition === 'boolean') {
+      this.config.shouldSeekToMarkerStartPosition = uimanager.getConfig().seekbarShouldSeekToMarkerStartPosition;
+    }
+
     // Initialize seekbar
     playbackPositionHandler(); // Set the playback position
     this.setBufferPosition(0);
@@ -468,6 +479,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     const timelineMarkerConfig = {
       cssPrefix: this.config.cssPrefix,
       snappingRange: this.config.snappingRange,
+      shouldSeekToMarkerStartPosition: this.config.shouldSeekToMarkerStartPosition
     };
     this.timelineMarkersHandler = new TimelineMarkersHandler(timelineMarkerConfig, () => this.seekBar.width(), this.seekBarMarkersContainer);
     this.timelineMarkersHandler.initialize(player, uimanager);
@@ -705,7 +717,10 @@ export class SeekBar extends Component<SeekBarConfig> {
       new DOM(document).off('touchend mouseup', mouseTouchUpHandler);
 
       let targetPercentage = 100 * this.getOffset(e);
-      let snappedChapter = this.timelineMarkersHandler && this.timelineMarkersHandler.getMarkerAtPosition(targetPercentage);
+      let snappedChapter = null ;
+      if (this.config.shouldSeekToMarkerStartPosition ===  true) {
+        snappedChapter = this.timelineMarkersHandler && this.timelineMarkersHandler.getMarkerAtPosition(targetPercentage);
+      }
 
       this.setSeeking(false);
       seeking = false;

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -479,7 +479,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     const timelineMarkerConfig = {
       cssPrefix: this.config.cssPrefix,
       snappingRange: this.config.snappingRange,
-      shouldSeekToMarkerStartPosition: this.config.shouldSeekToMarkerStartPosition
+      shouldSeekToMarkerStartPosition: this.config.shouldSeekToMarkerStartPosition,
     };
     this.timelineMarkersHandler = new TimelineMarkersHandler(timelineMarkerConfig, () => this.seekBar.width(), this.seekBarMarkersContainer);
     this.timelineMarkersHandler.initialize(player, uimanager);

--- a/src/ts/components/subtitlesettings/subtitlesettingselectbox.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingselectbox.ts
@@ -14,7 +14,7 @@ export interface SubtitleSettingSelectBoxConfig extends ListSelectorConfig {
  **/
 export class SubtitleSettingSelectBox extends SelectBox {
 
-  protected settingsManager: SubtitleSettingsManager;
+  protected settingsManager?: SubtitleSettingsManager;
   protected overlay: SubtitleOverlay;
   private currentCssClass: string;
 
@@ -43,6 +43,6 @@ export class SubtitleSettingSelectBox extends SelectBox {
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
-      this.settingsManager = uimanager.subtitleSettingsManager;
+      this.settingsManager = uimanager.getSubtitleSettingsManager();
   }
 }

--- a/src/ts/components/subtitlesettings/subtitlesettingselectbox.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingselectbox.ts
@@ -2,10 +2,11 @@ import {SubtitleOverlay} from '../subtitleoverlay';
 import {ListSelectorConfig} from '../listselector';
 import {SelectBox} from '../selectbox';
 import {SubtitleSettingsManager} from './subtitlesettingsmanager';
+import { PlayerAPI } from 'bitmovin-player';
+import { UIInstanceManager } from '../../uimanager';
 
 export interface SubtitleSettingSelectBoxConfig extends ListSelectorConfig {
   overlay: SubtitleOverlay;
-  settingsManager: SubtitleSettingsManager;
 }
 
 /**
@@ -20,7 +21,6 @@ export class SubtitleSettingSelectBox extends SelectBox {
   constructor(config: SubtitleSettingSelectBoxConfig) {
     super(config);
 
-    this.settingsManager = config.settingsManager;
     this.overlay = config.overlay;
   }
 
@@ -40,5 +40,9 @@ export class SubtitleSettingSelectBox extends SelectBox {
       this.currentCssClass = this.prefixCss(cssClass);
       this.overlay.getDomElement().addClass(this.currentCssClass);
     }
+  }
+
+  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
+      this.settingsManager = uimanager.subtitleSettingsManager;
   }
 }

--- a/src/ts/components/subtitlesettings/subtitlesettingsmanager.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingsmanager.ts
@@ -1,6 +1,6 @@
-import { StorageUtils } from "../../storageutils";
-import { Component, ComponentConfig } from "../component";
-import { EventDispatcher, Event } from "../../eventdispatcher";
+import { StorageUtils } from '../../storageutils';
+import { Component, ComponentConfig } from '../component';
+import { EventDispatcher, Event } from '../../eventdispatcher';
 
 interface SubtitleSettings {
   fontColor?: string;
@@ -37,7 +37,7 @@ export class SubtitleSettingsManager {
   constructor() {
     this.userSettings = {};
     this.localStorageKey =
-      DummyComponent.instance().prefixCss("subtitlesettings");
+      DummyComponent.instance().prefixCss('subtitlesettings');
   }
 
   public reset(): void {
@@ -171,7 +171,7 @@ export class SubtitleSettingsProperty<T> {
   }
 
   public set value(value: T) {
-    if (typeof value === "string" && value === "null") {
+    if (typeof value === 'string' && value === 'null') {
       value = null;
     }
 

--- a/src/ts/components/subtitlesettings/subtitlesettingsmanager.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingsmanager.ts
@@ -1,6 +1,6 @@
-import {StorageUtils} from '../../storageutils';
-import {Component, ComponentConfig} from '../component';
-import {EventDispatcher, Event} from '../../eventdispatcher';
+import { StorageUtils } from "../../storageutils";
+import { Component, ComponentConfig } from "../component";
+import { EventDispatcher, Event } from "../../eventdispatcher";
 
 interface SubtitleSettings {
   fontColor?: string;
@@ -19,7 +19,6 @@ interface Properties {
 }
 
 export class SubtitleSettingsManager {
-
   private userSettings: SubtitleSettings;
   private localStorageKey: string;
 
@@ -37,23 +36,8 @@ export class SubtitleSettingsManager {
 
   constructor() {
     this.userSettings = {};
-    this.localStorageKey = DummyComponent.instance().prefixCss('subtitlesettings');
-
-    for (let propertyName in this._properties) {
-      this._properties[propertyName].onChanged.subscribe((sender, property) => {
-        if (property.isSet()) {
-          (<any>this.userSettings)[propertyName] = property.value;
-        } else {
-          // Delete the property from the settings object if unset to avoid serialization of null values
-          delete (<any>this.userSettings)[propertyName];
-        }
-
-        // Save the settings object when a property has changed
-        this.save();
-      });
-    }
-
-    this.load();
+    this.localStorageKey =
+      DummyComponent.instance().prefixCss("subtitlesettings");
   }
 
   public reset(): void {
@@ -98,6 +82,24 @@ export class SubtitleSettingsManager {
     return this._properties.windowOpacity;
   }
 
+  public initialize() {
+    for (let propertyName in this._properties) {
+      this._properties[propertyName].onChanged.subscribe((sender, property) => {
+        if (property.isSet()) {
+          (<any>this.userSettings)[propertyName] = property.value;
+        } else {
+          // Delete the property from the settings object if unset to avoid serialization of null values
+          delete (<any>this.userSettings)[propertyName];
+        }
+
+        // Save the settings object when a property has changed
+        this.save();
+      });
+    }
+
+    this.load();
+  }
+
   /**
    * Saves the settings to local storage.
    */
@@ -109,7 +111,8 @@ export class SubtitleSettingsManager {
    * Loads the settings from local storage
    */
   public load(): void {
-    this.userSettings = StorageUtils.getObject<SubtitleSettings>(this.localStorageKey) || {};
+    this.userSettings =
+      StorageUtils.getObject<SubtitleSettings>(this.localStorageKey) || {};
 
     // Apply the loaded settings
     for (let property in this.userSettings) {
@@ -123,7 +126,6 @@ export class SubtitleSettingsManager {
  * {@link SubtitleSettingsManager}.
  */
 class DummyComponent extends Component<ComponentConfig> {
-
   private static _instance: DummyComponent;
 
   public static instance(): DummyComponent {
@@ -140,14 +142,19 @@ class DummyComponent extends Component<ComponentConfig> {
 }
 
 export class SubtitleSettingsProperty<T> {
-
   private _manager: SubtitleSettingsManager;
-  private _onChanged: EventDispatcher<SubtitleSettingsManager, SubtitleSettingsProperty<T>>;
+  private _onChanged: EventDispatcher<
+    SubtitleSettingsManager,
+    SubtitleSettingsProperty<T>
+  >;
   private _value: T;
 
   constructor(manager: SubtitleSettingsManager) {
     this._manager = manager;
-    this._onChanged = new EventDispatcher<SubtitleSettingsManager, SubtitleSettingsProperty<T>>();
+    this._onChanged = new EventDispatcher<
+      SubtitleSettingsManager,
+      SubtitleSettingsProperty<T>
+    >();
   }
 
   public isSet(): boolean {
@@ -164,7 +171,7 @@ export class SubtitleSettingsProperty<T> {
   }
 
   public set value(value: T) {
-    if (typeof value === 'string' && value === 'null') {
+    if (typeof value === "string" && value === "null") {
       value = null;
     }
 
@@ -176,7 +183,10 @@ export class SubtitleSettingsProperty<T> {
     this._onChanged.dispatch(this._manager, this);
   }
 
-  public get onChanged(): Event<SubtitleSettingsManager, SubtitleSettingsProperty<T>> {
+  public get onChanged(): Event<
+    SubtitleSettingsManager,
+    SubtitleSettingsProperty<T>
+  > {
     return this._onChanged.getEvent();
   }
 }

--- a/src/ts/components/subtitlesettings/subtitlesettingspanelpage.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingspanelpage.ts
@@ -36,43 +36,40 @@ export class SubtitleSettingsPanelPage extends SettingsPanelPage {
     this.overlay = config.overlay;
     this.settingsPanel = config.settingsPanel;
 
-    let manager = new SubtitleSettingsManager();
 
     this.config = this.mergeConfig(config, {
       components: <Component<ComponentConfig>[]>[
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.font.size'), new FontSizeSelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.font.family'), new FontFamilySelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.font.color'), new FontColorSelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.font.opacity'), new FontOpacitySelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.characterEdge'), new CharacterEdgeSelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.background.color'), new BackgroundColorSelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.background.opacity'), new BackgroundOpacitySelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.window.color'), new WindowColorSelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.window.opacity'), new WindowOpacitySelectBox({
-          overlay: this.overlay, settingsManager: manager,
+          overlay: this.overlay,
         })),
         new SettingsPanelItem(new SettingsPanelPageBackButton({
           container: this.settingsPanel,
           text: i18n.getLocalizer('back'),
-        }), new SubtitleSettingsResetButton({
-          settingsManager: manager,
-        }), {
+        }), new SubtitleSettingsResetButton({}), {
           role: 'menubar',
         }),
       ],

--- a/src/ts/components/subtitlesettings/subtitlesettingsresetbutton.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingsresetbutton.ts
@@ -4,16 +4,14 @@ import {Button, ButtonConfig} from '../button';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../../localization/i18n';
 
-export interface SubtitleSettingsResetButtonConfig extends ButtonConfig {
-  settingsManager: SubtitleSettingsManager;
-}
-
 /**
  * A button that resets all subtitle settings to their defaults.
  */
 export class SubtitleSettingsResetButton extends Button<ButtonConfig> {
 
-  constructor(config: SubtitleSettingsResetButtonConfig) {
+  private settingsManager: SubtitleSettingsManager;
+
+  constructor(config: ButtonConfig) {
     super(config);
 
     this.config = this.mergeConfig(config, {
@@ -24,9 +22,10 @@ export class SubtitleSettingsResetButton extends Button<ButtonConfig> {
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
+    this.settingsManager = uimanager.subtitleSettingsManager;
 
     this.onClick.subscribe(() => {
-      (<SubtitleSettingsResetButtonConfig>this.config).settingsManager.reset();
+      this.settingsManager.reset();
     });
   }
 }

--- a/src/ts/components/subtitlesettings/subtitlesettingsresetbutton.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingsresetbutton.ts
@@ -22,7 +22,7 @@ export class SubtitleSettingsResetButton extends Button<ButtonConfig> {
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
-    this.settingsManager = uimanager.subtitleSettingsManager;
+    this.settingsManager = uimanager.getSubtitleSettingsManager();
 
     this.onClick.subscribe(() => {
       this.settingsManager.reset();

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -12,6 +12,11 @@ export interface MarkersConfig extends ComponentConfig {
    * Used for seekBar marker snapping range percentage
    */
   snappingRange?: number;
+
+  /**
+   * Used to enable/disable seeking to start of Marker position
+   */
+  shouldSeekToMarkerStartPosition?: boolean;
 }
 
 export class TimelineMarkersHandler {

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,8 +1,7 @@
 export namespace StorageUtils {
   let disableStorageApi: boolean;
 
-
-  function isLocalStorageAvailable(): boolean {
+  function shouldUseLocalStorage(): boolean {
     try {
       return (
         !disableStorageApi &&
@@ -21,7 +20,7 @@ export namespace StorageUtils {
    * @param data the item's data
    */
   export function setItem(key: string, data: string): void {
-    if (isLocalStorageAvailable()) {
+    if (shouldUseLocalStorage()) {
       try {
         window.localStorage.setItem(key, data);
       } catch (e) {
@@ -36,7 +35,7 @@ export namespace StorageUtils {
    * @return {string | null} Returns the string if found, null if there is no data stored for the key
    */
   export function getItem(key: string): string | null {
-    if (isLocalStorageAvailable()) {
+    if (shouldUseLocalStorage()) {
       try {
         return window.localStorage.getItem(key);
       } catch (e) {

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,5 +1,11 @@
+import { UIConfig } from "./uiconfig";
+
 export namespace StorageUtils {
-  let disableStorageApi: boolean;
+ let disableStorageApi: boolean;
+
+  export function setStorageApiDisabled(uiConfig: UIConfig) {
+    disableStorageApi = uiConfig.disableStorageApi;
+  }
 
   function shouldUseLocalStorage(): boolean {
     try {

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,4 +1,4 @@
-import { UIConfig } from "./uiconfig";
+import { UIConfig } from './uiconfig';
 
 export namespace StorageUtils {
  let disableStorageApi: boolean;

--- a/src/ts/storageutils.ts
+++ b/src/ts/storageutils.ts
@@ -1,7 +1,11 @@
 export namespace StorageUtils {
+  let disableStorageApi: boolean;
+
+
   function isLocalStorageAvailable(): boolean {
     try {
       return (
+        !disableStorageApi &&
         window.localStorage &&
         typeof localStorage.getItem === 'function' &&
         typeof localStorage.setItem === 'function'

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -102,6 +102,11 @@ export interface UIConfig {
   forceSubtitlesIntoViewContainer?: boolean;
 
   /**
+   * If set to true, prevents the UI from using `localStorage`.
+   */
+  disableStorageApi: boolean;
+
+  /**
    * Used to enable/disable seeking to start of marker position. Default is true
    */
   seekbarShouldSeekToMarkerStartPosition?: boolean;

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -100,4 +100,9 @@ export interface UIConfig {
    * Forces subtitle-labels back into their respective container if they overflow and are therefore cropped.
    */
   forceSubtitlesIntoViewContainer?: boolean;
+
+  /**
+   * Used to enable/disable seeking to start of marker position. Default is true
+   */
+  seekbarShouldSeekToMarkerStartPosition?: boolean;
 }

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -14,6 +14,7 @@ import { i18n, CustomVocabulary, Vocabularies } from './localization/i18n';
 import { FocusVisibilityTracker } from './focusvisibilitytracker';
 import { isMobileV3PlayerAPI, MobileV3PlayerAPI, MobileV3PlayerEvent } from './mobilev3playerapi';
 import { SpatialNavigation } from './spatialnavigation/spatialnavigation';
+import { SubtitleSettingsManager } from './components/subtitlesettings/subtitlesettingsmanager';
 
 export interface LocalizationConfig {
   /**
@@ -111,6 +112,7 @@ export class UIManager {
   private config: InternalUIConfig; // Conjunction of provided uiConfig and sourceConfig from the player
   private managerPlayerWrapper: PlayerWrapper;
   private focusVisibilityTracker: FocusVisibilityTracker;
+  private _subtitleSettingsManager: SubtitleSettingsManager;
 
   private events = {
     onUiVariantResolve: new EventDispatcher<UIManager, UIConditionContext>(),
@@ -154,6 +156,7 @@ export class UIManager {
       this.uiVariants = <UIVariant[]>playerUiOrUiVariants;
     }
 
+    this._subtitleSettingsManager = new SubtitleSettingsManager();
     this.player = player;
     this.managerPlayerWrapper = new PlayerWrapper(player);
 
@@ -242,6 +245,7 @@ export class UIManager {
         player,
         uiVariant.ui,
         this.config,
+        this.subtitleSettingsManager,
         uiVariant.spatialNavigation,
       ));
     }
@@ -375,6 +379,10 @@ export class UIManager {
     i18n.setConfig(localizationConfig);
   }
 
+  get subtitleSettingsManager(){
+    return this._subtitleSettingsManager;
+  }
+
   getConfig(): UIConfig {
     return this.config;
   }
@@ -493,6 +501,7 @@ export class UIManager {
     // When the UI is loaded after a source was loaded, we need to tell the components to initialize themselves
     if (player.getSource()) {
       this.config.events.onUpdated.dispatch(this);
+
     }
 
     // Fire onConfigured after UI DOM elements are successfully added. When fired immediately, the DOM elements
@@ -598,6 +607,7 @@ export class UIInstanceManager {
   private playerWrapper: PlayerWrapper;
   private ui: UIContainer;
   private config: InternalUIConfig;
+  private _subtitleSettingsManager: SubtitleSettingsManager;
   protected spatialNavigation?: SpatialNavigation;
 
   private events = {
@@ -613,11 +623,16 @@ export class UIInstanceManager {
     onRelease: new EventDispatcher<UIContainer, NoArgs>(),
   };
 
-  constructor(player: PlayerAPI, ui: UIContainer, config: InternalUIConfig, spatialNavigation?: SpatialNavigation) {
+  constructor(player: PlayerAPI, ui: UIContainer, config: InternalUIConfig, subtitleSettingsManager: SubtitleSettingsManager, spatialNavigation?: SpatialNavigation) {
     this.playerWrapper = new PlayerWrapper(player);
     this.ui = ui;
     this.config = config;
+    this._subtitleSettingsManager = subtitleSettingsManager;
     this.spatialNavigation = spatialNavigation;
+  }
+
+  get subtitleSettingsManager() {
+    return this._subtitleSettingsManager;
   }
 
   getConfig(): InternalUIConfig {

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -383,7 +383,7 @@ export class UIManager {
     i18n.setConfig(localizationConfig);
   }
 
-  get subtitleSettingsManager(){
+  get subtitleSettingsManager() {
     return this._subtitleSettingsManager;
   }
 

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -113,7 +113,7 @@ export class UIManager {
   private config: InternalUIConfig; // Conjunction of provided uiConfig and sourceConfig from the player
   private managerPlayerWrapper: PlayerWrapper;
   private focusVisibilityTracker: FocusVisibilityTracker;
-  private _subtitleSettingsManager: SubtitleSettingsManager;
+  private subtitleSettingsManager: SubtitleSettingsManager;
 
   private events = {
     onUiVariantResolve: new EventDispatcher<UIManager, UIConditionContext>(),
@@ -157,7 +157,7 @@ export class UIManager {
       this.uiVariants = <UIVariant[]>playerUiOrUiVariants;
     }
 
-    this._subtitleSettingsManager = new SubtitleSettingsManager();
+    this.subtitleSettingsManager = new SubtitleSettingsManager();
     this.player = player;
     this.managerPlayerWrapper = new PlayerWrapper(player);
 
@@ -207,7 +207,7 @@ export class UIManager {
     };
 
     updateConfig();
-    this._subtitleSettingsManager.initialize();
+    this.subtitleSettingsManager.initialize();
 
     // Update the source configuration when a new source is loaded and dispatch onUpdated
     const updateSource = () => {
@@ -383,8 +383,8 @@ export class UIManager {
     i18n.setConfig(localizationConfig);
   }
 
-  get subtitleSettingsManager() {
-    return this._subtitleSettingsManager;
+  getSubtitleSettingsManager() {
+    return this.subtitleSettingsManager;
   }
 
   getConfig(): UIConfig {
@@ -611,7 +611,7 @@ export class UIInstanceManager {
   private playerWrapper: PlayerWrapper;
   private ui: UIContainer;
   private config: InternalUIConfig;
-  private _subtitleSettingsManager: SubtitleSettingsManager;
+  private subtitleSettingsManager: SubtitleSettingsManager;
   protected spatialNavigation?: SpatialNavigation;
 
   private events = {
@@ -631,12 +631,12 @@ export class UIInstanceManager {
     this.playerWrapper = new PlayerWrapper(player);
     this.ui = ui;
     this.config = config;
-    this._subtitleSettingsManager = subtitleSettingsManager;
+    this.subtitleSettingsManager = subtitleSettingsManager;
     this.spatialNavigation = spatialNavigation;
   }
 
-  get subtitleSettingsManager() {
-    return this._subtitleSettingsManager;
+  getSubtitleSettingsManager() {
+    return this.subtitleSettingsManager;
   }
 
   getConfig(): InternalUIConfig {

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -15,6 +15,7 @@ import { FocusVisibilityTracker } from './focusvisibilitytracker';
 import { isMobileV3PlayerAPI, MobileV3PlayerAPI, MobileV3PlayerEvent } from './mobilev3playerapi';
 import { SpatialNavigation } from './spatialnavigation/spatialnavigation';
 import { SubtitleSettingsManager } from './components/subtitlesettings/subtitlesettingsmanager';
+import { StorageUtils } from './storageutils';
 
 export interface LocalizationConfig {
   /**
@@ -201,6 +202,8 @@ export class UIManager {
       this.config.metadata.description = playerSourceUiConfig.metadata.description || uiconfig.metadata.description;
       this.config.metadata.markers = playerSourceUiConfig.metadata.markers || uiconfig.metadata.markers || [];
       this.config.recommendations = playerSourceUiConfig.recommendations || uiconfig.recommendations || [];
+
+      StorageUtils.setStorageApiDisabled(uiconfig);
     };
 
     updateConfig();

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -207,6 +207,7 @@ export class UIManager {
     };
 
     updateConfig();
+    this._subtitleSettingsManager.initialize();
 
     // Update the source configuration when a new source is loaded and dispatch onUpdated
     const updateSource = () => {


### PR DESCRIPTION
## Description
Currently seeking anywhere between start position and duration of a timeline marker forces seek position to be beginning of the marker. The changes in this PR attempt to make this behaviour configurable so that integrators can disable this behaviour and allow seeking to a position inside timeline marker's duration. 

## Checklist (for PR submitter and reviewers)
- [X] `CHANGELOG` entry
