### PR TITLE
Add config option to allow seeking inside timeline marker w/ duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- `UIConfig#seekbarAllowSeekInMarkerDuration` config property to allow seeking inside `TimelineMarker` duration
+- `UIConfig#seekbarSnappingEnabled` config option to enable/disable the play head snapping to markers on the seek bar when seeking near them. Default is `true`.
 
 ## [3.57.0] - 2024-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `UIConfig#seekbarAllowSeekInMarkerDuration` config property to allow seeking inside `TimelineMarker` duration
+
 ## [3.57.0] - 2024-03-28
 
 ### Added

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -44,7 +44,13 @@ export interface SeekBarConfig extends ComponentConfig {
   keyStepIncrements?: { leftRight: number, upDown: number };
 
   /**
-   * Used for seekBar marker snapping range percentage
+   * Used to enable/disable snapping to markers on the seek bar when seeking near them.
+   * Default: true
+   */
+  snappingEnabled?: boolean;
+
+  /**
+   * Defines tolerance for snapping markers, if snapping to seek bar markers is enabled.
    */
   snappingRange?: number;
 
@@ -52,11 +58,6 @@ export interface SeekBarConfig extends ComponentConfig {
    * Used to enable/disable seek preview
    */
   enableSeekPreview?: boolean;
-
-  /**
-   * Used for allowing seeking inside timeline marker duration. Default is false
-   */
-  allowSeekInMarkerDuration?: boolean;
 }
 
 /**
@@ -156,7 +157,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       tabIndex: 0,
       snappingRange: 1,
       enableSeekPreview: true,
-      allowSeekInMarkerDuration: false,
+      snappingEnabled: true,
     }, this.config);
 
     this.label = this.config.label;
@@ -458,9 +459,8 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.config.snappingRange = uimanager.getConfig().seekbarSnappingRange;
     }
 
-    // Set the allowSeekInMarkerDuration if set in the uimanager config
-    if (typeof uimanager.getConfig().seekbarAllowSeekInMarkerDuration === 'boolean') {
-      this.config.allowSeekInMarkerDuration = uimanager.getConfig().seekbarAllowSeekInMarkerDuration;
+    if (typeof uimanager.getConfig().seekbarSnappingEnabled === 'boolean') {
+      this.config.snappingEnabled = uimanager.getConfig().seekbarSnappingEnabled;
     }
 
     // Initialize seekbar
@@ -717,8 +717,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
       let targetPercentage = 100 * this.getOffset(e);
 
-      const shouldSnapToMarkerStartTime = !this.config.allowSeekInMarkerDuration;
-      if (shouldSnapToMarkerStartTime) {
+      if (this.config.snappingEnabled) {
         const matchingMarker = this.timelineMarkersHandler?.getMarkerAtPosition(targetPercentage);
         targetPercentage = matchingMarker ? matchingMarker.position : targetPercentage;
       }

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -50,7 +50,7 @@ export interface SeekBarConfig extends ComponentConfig {
   snappingEnabled?: boolean;
 
   /**
-   * Defines tolerance for snapping markers, if snapping to seek bar markers is enabled.
+   * Defines tolerance for snapping to markers, if snapping to seek bar markers is enabled.
    */
   snappingRange?: number;
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -716,17 +716,18 @@ export class SeekBar extends Component<SeekBarConfig> {
       new DOM(document).off('touchend mouseup', mouseTouchUpHandler);
 
       let targetPercentage = 100 * this.getOffset(e);
-      let snappedChapter = this.timelineMarkersHandler && this.timelineMarkersHandler.getMarkerAtPosition(targetPercentage);
-      if (this.config.allowSeekInMarkerDuration ===  true && (snappedChapter && snappedChapter.duration &&  snappedChapter.duration > 0))  {
-        // do not consider timeline marker position if seek is allowed inside marker duration
-        snappedChapter = null;
+
+      const shouldSnapToMarkerStartTime = !this.config.allowSeekInMarkerDuration;
+      if (shouldSnapToMarkerStartTime) {
+        const matchingMarker = this.timelineMarkersHandler?.getMarkerAtPosition(targetPercentage);
+        targetPercentage = matchingMarker ? matchingMarker.position : targetPercentage;
       }
 
       this.setSeeking(false);
       seeking = false;
 
       // Fire seeked event
-      this.onSeekedEvent(snappedChapter ? snappedChapter.position : targetPercentage);
+      this.onSeekedEvent(targetPercentage);
     };
 
     // A seek always start with a touchstart or mousedown directly on the seekbar.

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -52,6 +52,11 @@ export interface SeekBarConfig extends ComponentConfig {
    * Used to enable/disable seek preview
    */
   enableSeekPreview?: boolean;
+
+  /**
+   * Used for allowing seeking inside timeline marker duration. Default is false
+   */
+  allowSeekInMarkerDuration?: boolean;
 }
 
 /**
@@ -151,6 +156,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       tabIndex: 0,
       snappingRange: 1,
       enableSeekPreview: true,
+      allowSeekInMarkerDuration: false,
     }, this.config);
 
     this.label = this.config.label;
@@ -452,6 +458,11 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.config.snappingRange = uimanager.getConfig().seekbarSnappingRange;
     }
 
+    // Set the allowSeekInMarkerDuration if set in the uimanager config
+    if (typeof uimanager.getConfig().seekbarAllowSeekInMarkerDuration === 'boolean') {
+      this.config.allowSeekInMarkerDuration = uimanager.getConfig().seekbarAllowSeekInMarkerDuration;
+    }
+
     // Initialize seekbar
     playbackPositionHandler(); // Set the playback position
     this.setBufferPosition(0);
@@ -706,6 +717,10 @@ export class SeekBar extends Component<SeekBarConfig> {
 
       let targetPercentage = 100 * this.getOffset(e);
       let snappedChapter = this.timelineMarkersHandler && this.timelineMarkersHandler.getMarkerAtPosition(targetPercentage);
+      if (this.config.allowSeekInMarkerDuration ===  true && (snappedChapter && snappedChapter.duration &&  snappedChapter.duration > 0))  {
+        // do not consider timeline marker position if seek is allowed inside marker duration
+        snappedChapter = null;
+      }
 
       this.setSeeking(false);
       seeking = false;

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -105,4 +105,9 @@ export interface UIConfig {
    * If set to true, prevents the UI from using `localStorage`.
    */
   disableStorageApi?: boolean;
+
+  /**
+   * If set to true, allows seeking inside timeline marker duration. Default is false
+   */
+  seekbarAllowSeekInMarkerDuration?: boolean;
 }

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -76,7 +76,23 @@ export interface UIConfig {
    */
   disableAutoHideWhenHovered?: boolean;
   /**
-   * Specifies the seekbar snapping range in percentage
+   * Whether the play head should snap to markers on the seek bar when seeking sufficiently near them.
+   *
+   * The config option `seekbarSnappingRange` defines the tolerance that is used to determine whether a seek time hits a
+   * marker.
+   *
+   * Note:
+   * - When hitting a point marker (i.e. one without duration), the play head would snap to the exact time of the
+   *   marker.
+   * - Likewise, when hitting a range marker (i.e. one with duration), which effectively snaps to the start of the time
+   *   range that it defines.
+   *
+   * Default: true
+   */
+  seekbarSnappingEnabled?: boolean;
+  /**
+   * Specifies the seek bar marker snapping tolerance in percent. This option has no effect if `seekbarSnappingEnabled`
+   * is set to false.
    * Default: 1
    */
   seekbarSnappingRange?: number;
@@ -105,9 +121,4 @@ export interface UIConfig {
    * If set to true, prevents the UI from using `localStorage`.
    */
   disableStorageApi?: boolean;
-
-  /**
-   * If set to true, allows seeking inside timeline marker duration. Default is false
-   */
-  seekbarAllowSeekInMarkerDuration?: boolean;
 }

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -78,13 +78,13 @@ export interface UIConfig {
   /**
    * Whether the play head should snap to markers on the seek bar when seeking sufficiently near them.
    *
-   * The config option `seekbarSnappingRange` defines the tolerance that is used to determine whether a seek time hits a
-   * marker.
+   * The related config option `seekbarSnappingRange` defines the tolerance that is used to determine whether a seek
+   * time hits a marker.
    *
    * Note:
    * - When hitting a point marker (i.e. one without duration), the play head would snap to the exact time of the
    *   marker.
-   * - Likewise, when hitting a range marker (i.e. one with duration), which effectively snaps to the start of the time
+   * - Likewise, when hitting a range marker (i.e. one with duration) which effectively snaps to the start of the time
    *   range that it defines.
    *
    * Default: true


### PR DESCRIPTION
## Description
Currently seeking anywhere between start position and duration of a timeline marker forces seek position to be beginning of the marker. The changes in this PR attempt to make this behaviour configurable so that integrators can disable this behaviour and allow seeking to a position inside timeline marker's duration.

## Checklist (for PR submitter and reviewers)
- [X] `CHANGELOG` entry
