### PR TITLE
new option to immediatly hide the UI if the mouse leaves interactionensource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `UIContainerConfig.hideImmediatelyOnMouseLeave` to immediately hide the UI when mouse leaves it
+
 ## [3.54.0] - 2024-02-01
 
 ### Fixed

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -189,7 +189,6 @@ export class UIContainer extends Container<UIContainerConfig> {
           } else {
             this.uiHideTimeout.start();
           }
-
         }
       },
     }];

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -27,6 +27,13 @@ export interface UIContainerConfig extends ContainerConfig {
    * Default: the UI container itself
    */
   userInteractionEventSource?: HTMLElement;
+
+  /**
+   * Specify whether the UI should be hidden immediatly if the mouse leaves the userInteractionEventSource.
+   * If false or not set it will wait for the hideDelay.
+   * Default: false
+   */
+  hideImmediatelyOnMouseLeave?: boolean;
 }
 
 /**
@@ -60,6 +67,7 @@ export class UIContainer extends Container<UIContainerConfig> {
       role: 'region',
       ariaLabel: i18n.getLocalizer('player'),
       hideDelay: 5000,
+      hideImmediatelyOnMouseLeave: false,
     }, this.config);
 
     this.playerStateChange = new EventDispatcher<UIContainer, PlayerUtils.PlayerState>();
@@ -176,7 +184,12 @@ export class UIContainer extends Container<UIContainerConfig> {
         // When a seek is going on, the seek scrub pointer may exit the UI area while still seeking, and we do not
         // hide the UI in such cases
         if (!isSeeking && !hidingPrevented()) {
-          this.uiHideTimeout.start();
+          if (this.config.hideImmediatelyOnMouseLeave) {
+            this.hideUi();
+          } else {
+            this.uiHideTimeout.start();
+          }
+
         }
       },
     }];


### PR DESCRIPTION
see https://github.com/bitmovin/bitmovin-player-ui/issues/608

new option to immediately hide the UI when mouse leaves the UI

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [ ] `CHANGELOG` entry
