### PR TITLE
Export UIVariant interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Type export for `UIVariant` interface
+
 ## [3.59.0] - 2024-04-12
 
 ### Added

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1,6 +1,6 @@
 export const version: string = '{{VERSION}}';
 // Management
-export { UIManager, UIInstanceManager } from './uimanager';
+export { UIManager, UIInstanceManager, UIVariant } from './uimanager';
 // Factories
 export { UIFactory } from './uifactory';
 export { DemoFactory } from './demofactory';


### PR DESCRIPTION
## Description
An Array of `UIVariant` objects can be used to instantiate the `UIManager`, but the `UIVariant` interface is not exported.

This means it needs to be imported weirdy:
```ts
import { UIVariant } from "bitmovin-player-ui/dist/js/framework/uimanager";
```

This PR exports the interface so it can be imported normally.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
