### PR TITLE
Fix release on merge from a fork

### DIFF
--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -1,7 +1,7 @@
 name: Trigger release on merge
 run-name: Starting release for ${{ github.actor }} PR merge
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `UIContainerConfig.hideImmediatelyOnMouseLeave` to immediately hide the UI when mouse leaves it
 
+### Fixed
+- Triggering UI release after merging a PR from a fork
+
 ## [3.58.0] - 2024-04-08
 
 ### Added


### PR DESCRIPTION
## Description
Release failed here: https://github.com/bitmovin/bitmovin-player-ui/actions/runs/8614645401?pr=617

Switch the action that triggers creating a tag for the release, so it gets run on the merge commit on the target branch: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
