### PR TITLE
`ControlBar` not auto-hiding on some touch screen devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- `ControlBar` not auto-hiding when `UIConfig.disableAutoHideWhenHovered` is set to `true` on some touch screen devices
+
 ## [3.60.0] - 2024-04-16
 
 ### Added

--- a/src/ts/components/controlbar.ts
+++ b/src/ts/components/controlbar.ts
@@ -39,10 +39,11 @@ export class ControlBar extends Container<ControlBarConfig> {
     let hoverStackCount = 0;
     let isSettingsPanelShown = false;
 
-    // only enabling this for non-mobile platforms without touch input. enabling this
-    // for touch devices causes the UI to not disappear after hideDelay seconds.
+    // Only enabling this for platforms without touch input.
+    // Enabling this for touch devices causes the UI to not disappear after hideDelay seconds,
+    // because `mouseleave` event is not emitted.
     // Instead, it will stay visible until another manual interaction is performed.
-    if (uimanager.getConfig().disableAutoHideWhenHovered && !BrowserUtils.isMobile) {
+    if (uimanager.getConfig().disableAutoHideWhenHovered && !BrowserUtils.isTouchSupported) {
       // Track hover status of child components
       UIUtils.traverseTree(this, (component) => {
         // Do not track hover status of child containers or spacers, only of 'real' controls

--- a/src/ts/uiconfig.ts
+++ b/src/ts/uiconfig.ts
@@ -70,8 +70,8 @@ export interface UIConfig {
   playbackSpeedSelectionEnabled?: boolean;
   /**
    * Specifies if the player controls including `SettingsPanel` should auto hide when still hovered. This
-   * configuration does not apply to mobile platforms. On mobile platforms the `SettingsPanel` is by default
-   * configured to not auto-hide and the behaviour cannot be changed using this configuration.
+   * configuration does not apply to devices using a touch screen. On touch screen devices the `SettingsPanel`
+   * is by default configured to not auto-hide and the behaviour cannot be changed using this configuration.
    * Default: false
    */
   disableAutoHideWhenHovered?: boolean;


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Jira ticket: https://bitmovin.atlassian.net/browse/PA-2232

[Based on this comment](https://github.com/bitmovin/bitmovin-player-ui/blob/develop/src/ts/components/controlbar.ts#L43), the `UIConfig.disableAutoHideWhenHovered` flag is meant to be used only on non touch screen devices. 
The code that applied the config checked for `BrowserUtils.isMobile`, which returns false on some Android tablets. This caused the ControlBar to not hide on some Android tablets when `disableAutoHideWhenHovered` is set to `true`.

To fix the issue the `BrowserUtils.isMobile` check has been replaced with `BrowserUtils.isTouchSupported` which also covers tablets and generally better fits the use-case.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
