### PR TITLE
Fix no subtitle on switching tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- No subtitle is shown when switching between different tracks
+
 ## [3.61.0] - 2024-04-23
 
 ### Fixed

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -129,7 +129,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     };
 
     player.on(player.exports.PlayerEvent.AudioChanged, subtitleClearHandler);
-    player.on(player.exports.PlayerEvent.SubtitleEnabled, subtitleClearHandler);
     player.on(player.exports.PlayerEvent.SubtitleDisabled, subtitleClearHandler);
     player.on(player.exports.PlayerEvent.Seeked, clearInactiveCues);
     player.on(player.exports.PlayerEvent.TimeShifted, clearInactiveCues);


### PR DESCRIPTION
## Description

When switching between different subtitle track, sometime it does not show the subtitle cue anymore.

We are clearing subtitle label component on `SubtitleEnabled` and `SubtitleDisabled`. This should be added again on `CueEnter` event.

The event sequence coming from Player is sometime off. When enabling subtitle, the sequence of event looks like, `SubtitleEnable`, `CueEnter` and `SubtitleEnabled`. This makes the Label component added and removed again, causing no subtitle being shown.

We are now not removing the component on `SubtitleEnabled` but just on `SubtitleDisabled`. This should be enough as a previous subtitle is disabled when a new one is enabled.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
