### PR TITLE
Disable auto-hide to not require two touches for click-through and skipping ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- "Skip ad" button and ad click-through URL cannot be triggered with a single touch when small screen UI is used
+- "Skip ad" button and ad click-through URL cannot be triggered with a single touch when small screen ad UI is used
 
 ## [3.62.0] - 2024-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- "Skip ad" button and ad click-through URL cannot be triggered with a single touch when small screen UI is used
+
 ## [3.62.0] - 2024-05-06
 
 ### Fixed

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -325,7 +325,7 @@ export namespace UIFactory {
         }),
       ],
       cssClasses: ['ui-skin-ads', 'ui-skin-smallscreen'],
-      // Disable auto-hide to not require two touches to skip an ad or trigger the click-through
+      // Disable auto-hide to not require two touches to skip an ad or trigger the click-through URL
       hideDelay: -1,
       hidePlayerStateExceptions: [
         PlayerUtils.PlayerState.Prepared,

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -325,7 +325,8 @@ export namespace UIFactory {
         }),
       ],
       cssClasses: ['ui-skin-ads', 'ui-skin-smallscreen'],
-      hideDelay: 2000,
+      // Disable auto-hide to not require two touches to skip an ad or trigger the click-through
+      hideDelay: -1,
       hidePlayerStateExceptions: [
         PlayerUtils.PlayerState.Prepared,
         PlayerUtils.PlayerState.Paused,


### PR DESCRIPTION
ticket: https://bitmovin.atlassian.net/browse/PI-2655

## Description
Currently, when the small-screen ads UI is used on a touch device, two touches are needed to either hit the "skip ad" button or to open the ad  click-through URL. Especially for the "skip ad" button this is a confusing user experience as it is always visible and one touch should be sufficient to tap it.

To fix this, the auto hide is disabled for the small screen ads UI. After this change, the "skip ad" button can be triggered with a single touch. The same holds for triggering the ad click through URL.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
