### PR TITLE
Add config to allow default action for first touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `UIContainerConfig.allowDefaultActionOnFirstTouch` to configure whether the default action should be executed for first touches when the UI is hidden
+
+### Fixed
+- "Skip ad" button and ad click-through URL cannot be triggered with a single touch when modern small screen ad UI is used
+
 ## [3.62.0] - 2024-05-06
 
 ### Fixed

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -17,10 +17,12 @@ export interface UIContainerConfig extends ContainerConfig {
    * Default: 5 seconds (5000)
    */
   hideDelay?: number;
+  
   /**
    * An array of player states in which the UI will not be hidden, no matter what the {@link hideDelay} is.
    */
   hidePlayerStateExceptions?: PlayerUtils.PlayerState[];
+  
   /**
    * The HTML element on which user interaction events (e.g. mouse and touch events) will be tracked to detect
    * interaction with the UI. These basically trigger showing and hiding of the UI.
@@ -29,11 +31,23 @@ export interface UIContainerConfig extends ContainerConfig {
   userInteractionEventSource?: HTMLElement;
 
   /**
-   * Specify whether the UI should be hidden immediatly if the mouse leaves the userInteractionEventSource.
+   * Specify whether the UI should be hidden immediately if the mouse leaves the userInteractionEventSource.
    * If false or not set it will wait for the hideDelay.
    * Default: false
    */
   hideImmediatelyOnMouseLeave?: boolean;
+
+  /**
+   * On touch enabled devices, when the UI is hidden, the first touch shows the UI again. This flag specifies whether 
+   * to allow the default action (e.g. button interaction) in addition to showing the UI for first touches. 
+   * If set to false, only the UI will show. If set to true, the UI will show and the default action will be executed.
+   * 
+   * Note: The play() action will always be executed on first touch if the player is paused and is excluded from this 
+   * config flag.
+   * 
+   * Default: false
+   */
+  allowDefaultActionOnFirstTouch?: boolean;
 }
 
 /**
@@ -147,7 +161,9 @@ export class UIContainer extends Container<UIContainerConfig> {
           // instead. The first touch is not prevented to let other listeners receive the event and trigger an
           // initial action, e.g. the huge playback button can directly start playback instead of requiring a double
           // tap which 1. reveals the UI and 2. starts playback.
-          if (isFirstTouch && !player.isPlaying()) {
+          let allowDefaultOnFirstTouch = !player.isPlaying() || config.allowDefaultActionOnFirstTouch == true;
+          if (isFirstTouch && allowDefaultOnFirstTouch) {
+            console.log('First touch');
             isFirstTouch = false;
           } else {
             e.preventDefault();

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -156,10 +156,10 @@ export class UIContainer extends Container<UIContainerConfig> {
       name: 'touchend',
       handler: (e) => {
         if (!isUiShown) {
-          // If the UI is hidden, we prevent other actions and reveal the UI instead. 
-          // Exceptions are when we are not playing or when the config specifically allows the default action. This is 
+          // If the UI is hidden, we prevent other actions and reveal the UI instead.
+          // Exceptions are when we are not playing or when the config specifically allows the default action. This is
           // e.g. needed so that the huge playback button can directly start playback instead of requiring a double
-          // tap which 1. reveals the UI and 2. starts playback. The same holds for the ad click-through and the skip-ad 
+          // tap which 1. reveals the UI and 2. starts playback. The same holds for the ad click-through and the skip-ad
           // button, where we do not want double taps to be required.
           let allowDefaultOnFirstTouch = !player.isPlaying() || config.allowDefaultActionOnFirstTouch === true;
           if (!allowDefaultOnFirstTouch) {

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -17,12 +17,12 @@ export interface UIContainerConfig extends ContainerConfig {
    * Default: 5 seconds (5000)
    */
   hideDelay?: number;
-  
+
   /**
    * An array of player states in which the UI will not be hidden, no matter what the {@link hideDelay} is.
    */
   hidePlayerStateExceptions?: PlayerUtils.PlayerState[];
-  
+
   /**
    * The HTML element on which user interaction events (e.g. mouse and touch events) will be tracked to detect
    * interaction with the UI. These basically trigger showing and hiding of the UI.
@@ -38,13 +38,13 @@ export interface UIContainerConfig extends ContainerConfig {
   hideImmediatelyOnMouseLeave?: boolean;
 
   /**
-   * On touch enabled devices, when the UI is hidden, the first touch shows the UI again. This flag specifies whether 
-   * to allow the default action (e.g. button interaction) in addition to showing the UI for first touches. 
+   * On touch enabled devices, when the UI is hidden, the first touch shows the UI again. This flag specifies whether
+   * to allow the default action (e.g. button interaction) in addition to showing the UI for first touches.
    * If set to false, only the UI will show. If set to true, the UI will show and the default action will be executed.
-   * 
-   * Note: The play() action will always be executed on first touch if the player is paused and is excluded from this 
+   *
+   * Note: The play() action will always be executed on first touch if the player is paused and is excluded from this
    * config flag.
-   * 
+   *
    * Default: false
    */
   allowDefaultActionOnFirstTouch?: boolean;
@@ -161,7 +161,7 @@ export class UIContainer extends Container<UIContainerConfig> {
           // instead. The first touch is not prevented to let other listeners receive the event and trigger an
           // initial action, e.g. the huge playback button can directly start playback instead of requiring a double
           // tap which 1. reveals the UI and 2. starts playback.
-          let allowDefaultOnFirstTouch = !player.isPlaying() || config.allowDefaultActionOnFirstTouch == true;
+          let allowDefaultOnFirstTouch = !player.isPlaying() || config.allowDefaultActionOnFirstTouch === true;
           if (isFirstTouch && allowDefaultOnFirstTouch) {
             console.log('First touch');
             isFirstTouch = false;

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -112,7 +112,6 @@ export class UIContainer extends Container<UIContainerConfig> {
 
     let isUiShown = false;
     let isSeeking = false;
-    let isFirstTouch = true;
     let playerState: PlayerUtils.PlayerState;
 
     const hidingPrevented = (): boolean => {
@@ -157,15 +156,13 @@ export class UIContainer extends Container<UIContainerConfig> {
       name: 'touchend',
       handler: (e) => {
         if (!isUiShown) {
-          // Only if the UI is hidden, we prevent other actions (except for the first touch) and reveal the UI
-          // instead. The first touch is not prevented to let other listeners receive the event and trigger an
-          // initial action, e.g. the huge playback button can directly start playback instead of requiring a double
-          // tap which 1. reveals the UI and 2. starts playback.
+          // If the UI is hidden, we prevent other actions and reveal the UI instead. 
+          // Exceptions are when we are not playing or when the config specifically allows the default action. This is 
+          // e.g. needed so that the huge playback button can directly start playback instead of requiring a double
+          // tap which 1. reveals the UI and 2. starts playback. The same holds for the ad click-through and the skip-ad 
+          // button, where we do not want double taps to be required.
           let allowDefaultOnFirstTouch = !player.isPlaying() || config.allowDefaultActionOnFirstTouch === true;
-          if (isFirstTouch && allowDefaultOnFirstTouch) {
-            console.log('First touch');
-            isFirstTouch = false;
-          } else {
+          if (!allowDefaultOnFirstTouch) {
             e.preventDefault();
           }
           this.showUi();

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -326,6 +326,7 @@ export namespace UIFactory {
       ],
       cssClasses: ['ui-skin-ads', 'ui-skin-smallscreen'],
       hideDelay: 2000,
+      allowDefaultActionOnFirstTouch: true,
       hidePlayerStateExceptions: [
         PlayerUtils.PlayerState.Prepared,
         PlayerUtils.PlayerState.Paused,


### PR DESCRIPTION
ticket: https://bitmovin.atlassian.net/browse/PI-2655

## Description
Currently, when the small-screen ads UI is used on a touch device, two touches are needed to either hit the "skip ad" button or to open the ad  click-through URL. Especially for the "skip ad" button this is a confusing user experience as it is always visible and one touch should be sufficient to tap it.

To fix this, a new configuration option `allowDefaultActionOnFirstTouch` is introduced on `UIContainerConfig` that can be used to control whether the default action should be executed after showing the hidden UI on a first touch. The `allowDefaultActionOnFirstTouch` flag is now set to `true` for `modernSmallScreenAdsUI`, allowing first touches to trigger the click-through URL and also the "skip ad" button.

## Discussion
A drawback of this approach is that also buttons from the title bar can receive this first touch now during ads. Specifically, the fullscreen button, which is the only one that is visible there during ad playback. 

There would be some ways to improve on this situation:
- (1) Attach a payload to the `onClick` event that determines if it is a first touch. Event receiving components could check for this flag and decide on their own if they want to handle `onClick` in case they are first touches. The "skip ad" button and the ad click overlay would be then implemented in a way that they accept `onClick`s that are first touches and the fullscreen button would ignore such `onClick` events.
- (2) Decide in `UIContainer.touchend` event handler if the default action should be prevented or not based on the event target.

(1) seems a bit more elegant than (2) as the components are allowed to decide for themselves if they want to react to first touches.

## Tests
- Please do manual testing

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
