### PR TITLE
Assign components to their `HTMLElements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `Component` instances are now assigned to their `HTMLElements` for easier accessing
+
 ## [3.63.0] - 2024-05-17
 
 ### Added

--- a/src/ts/components/button.ts
+++ b/src/ts/components/button.ts
@@ -54,7 +54,7 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
     }
 
     // Create the button element with the text label
-    let buttonElement = new DOM('button', buttonElementAttributes).append(new DOM('span', {
+    let buttonElement = new DOM('button', buttonElementAttributes, this).append(new DOM('span', {
       'class': this.prefixCss('label'),
     }).html(i18n.performLocalization(this.config.text)));
 

--- a/src/ts/components/component.ts
+++ b/src/ts/components/component.ts
@@ -272,7 +272,7 @@ export class Component<Config extends ComponentConfig> {
       'id': this.config.id,
       'class': this.getCssClasses(),
       'role': this.config.role,
-    });
+    }, this);
 
     return element;
   }

--- a/src/ts/components/container.ts
+++ b/src/ts/components/container.ts
@@ -121,7 +121,7 @@ export class Container<Config extends ContainerConfig> extends Component<Config>
       'class': this.getCssClasses(),
       'role': this.config.role,
       'aria-label': i18n.performLocalization(this.config.ariaLabel),
-    });
+    }, this);
 
     // Create the inner container element (the inner <div>) that will contain the components
     let innerContainer = new DOM(this.config.tag, {

--- a/src/ts/components/itemselectionlist.ts
+++ b/src/ts/components/itemselectionlist.ts
@@ -25,7 +25,7 @@ export class ItemSelectionList extends ListSelector<ListSelectorConfig> {
     let listElement = new DOM('ul', {
       'id': this.config.id,
       'class': this.getCssClasses(),
-    });
+    }, this);
 
     this.listElement = listElement;
     this.updateDomItems();

--- a/src/ts/components/label.ts
+++ b/src/ts/components/label.ts
@@ -51,7 +51,7 @@ export class Label<Config extends LabelConfig> extends Component<Config> {
       'id': this.config.id,
       'for': this.config.for,
       'class': this.getCssClasses(),
-    }).html(i18n.performLocalization(this.text));
+    }, this).html(i18n.performLocalization(this.text));
 
     labelElement.on('click', () => {
       this.onClickEvent();

--- a/src/ts/components/listbox.ts
+++ b/src/ts/components/listbox.ts
@@ -44,7 +44,7 @@ export class ListBox extends ListSelector<ListSelectorConfig> {
     let listBoxElement = new DOM('div', {
       'id': this.config.id,
       'class': this.getCssClasses(),
-    });
+    }, this);
 
     this.listBoxElement = listBoxElement;
     this.createListBoxDomItems();

--- a/src/ts/components/recommendationoverlay.ts
+++ b/src/ts/components/recommendationoverlay.ts
@@ -106,7 +106,7 @@ class RecommendationItem extends Component<RecommendationItemConfig> {
       'id': this.config.id,
       'class': this.getCssClasses(),
       'href': config.url,
-    }).css({ 'background-image': `url(${config.thumbnail})` });
+    }, this).css({ 'background-image': `url(${config.thumbnail})` });
 
     let bgElement = new DOM('div', {
       'class': this.prefixCss('background'),

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -647,7 +647,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       'role': 'slider',
       'aria-label': i18n.performLocalization(this.config.ariaLabel),
       'tabindex': this.config.tabIndex.toString(),
-    });
+    }, this);
 
     let seekBar = new DOM('div', {
       'class': this.prefixCss('seekbar'),

--- a/src/ts/components/selectbox.ts
+++ b/src/ts/components/selectbox.ts
@@ -31,7 +31,7 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
       'id': this.config.id,
       'class': this.getCssClasses(),
       'aria-label': i18n.performLocalization(this.config.ariaLabel),
-    });
+    }, this);
 
     this.selectElement = selectElement;
     this.updateDomItems();

--- a/src/ts/components/subtitlesettings/subtitlesettingslabel.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingslabel.ts
@@ -36,7 +36,7 @@ export class SubtitleSettingsLabel extends Container<ContainerConfig> {
       'id': this.config.id,
       'class': this.getCssClasses(),
       'for': this.for,
-    }).append(
+    }, this).append(
       new DOM('span', {}).html(i18n.performLocalization(this.text)),
       this.opener.getDomElement(),
     );

--- a/src/ts/components/tvnoisecanvas.ts
+++ b/src/ts/components/tvnoisecanvas.ts
@@ -28,7 +28,7 @@ export class TvNoiseCanvas extends Component<ComponentConfig> {
   }
 
   protected toDomElement(): DOM {
-    return this.canvas = new DOM('canvas', { 'class': this.getCssClasses() });
+    return this.canvas = new DOM('canvas', { 'class': this.getCssClasses() }, this);
   }
 
   start(): void {

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -1,4 +1,4 @@
-import {Component, ComponentConfig} from './components/component';
+import { Component, ComponentConfig } from './components/component';
 
 export interface Offset {
   left: number;

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -14,6 +14,9 @@ export interface CssProperties {
   [propertyName: string]: string;
 }
 
+/**
+ * Extends the {@link HTMLElement} interface with a component attribute to store the associated component.
+ */
 export interface HTMLElementWithComponent extends HTMLElement {
   component?: Component<ComponentConfig>;
 }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
### Problem
We are trying to fix an issue on touch devices that certain elements, which are always visible, need to be touched twice in order to trigger the desired click action. This affects the `AdSkipButton` and the `AdClickOverlay`.

See this PR for more details on the problem and the solution: #627

### Changes
As preparation for fixing the problem in a feasible way, this PR attaches the `Component` instances to their corresponding `DOM` / `HTMLElements` for easier access. This removes the need to traverse all components and find the correct instance e.g. in a `touchend` listener.

#### Details
- A new type (`HTMLElementWithComponent`) was introduced to prevent `any` casts. This type adds an optional `component` attribute to the `HTMLElement` for setting and accessing of it.
The `DOM` constructor was extended to allow passing the `Component` on `DOM` element creation.
- Only the root DOM element of Components gets the instance attached. This means that child components from elements (e.g. a `Label`, which is a child element of `Button`) do not have any component attached to it. A parent lookup needs to be performed to get the component from those elements. This was done to prevent confusion about where to get the instance and where not.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
