### PR TITLE
Fix double touch needed in Ads UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `Component` instances are now assigned to their `HTMLElements` for easier accessing
 
+### Fixed
+- Two touch interactions needed to skip an ad or open the click through link
+
 ## [3.63.0] - 2024-05-17
 
 ### Added

--- a/src/ts/components/adclickoverlay.ts
+++ b/src/ts/components/adclickoverlay.ts
@@ -1,4 +1,4 @@
-import { ClickOverlay } from './clickoverlay';
+import { ClickOverlay, ClickOverlayConfig } from './clickoverlay';
 import { UIInstanceManager } from '../uimanager';
 import { Ad, AdEvent, PlayerAPI } from 'bitmovin-player';
 
@@ -6,6 +6,13 @@ import { Ad, AdEvent, PlayerAPI } from 'bitmovin-player';
  * A simple click capture overlay for clickThroughUrls of ads.
  */
 export class AdClickOverlay extends ClickOverlay {
+  constructor(config: ClickOverlayConfig = {}) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      acceptsTouchWithUiHidden: true,
+    }, this.config);
+  }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);

--- a/src/ts/components/adskipbutton.ts
+++ b/src/ts/components/adskipbutton.ts
@@ -31,6 +31,7 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       cssClass: 'ui-button-ad-skip',
       untilSkippableMessage: 'Skip ad in {remainingTime}',
       skippableMessage: 'Skip ad',
+      acceptsTouchWithUiHidden: true,
     }, this.config);
   }
 

--- a/src/ts/components/button.ts
+++ b/src/ts/components/button.ts
@@ -15,6 +15,13 @@ export interface ButtonConfig extends ComponentConfig {
    * WCAG20 standard for defining info about the component (usually the name)
    */
   ariaLabel?: LocalizableText;
+
+  /**
+   * Specifies whether the first touch event received by the {@link UIContainer} should be prevented or not.
+   *
+   * Default: false
+   */
+  acceptsTouchWithUiHidden?: boolean;
 }
 
 /**
@@ -33,6 +40,7 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
       cssClass: 'ui-button',
       role: 'button',
       tabIndex: 0,
+      acceptsTouchWithUiHidden: false,
     } as Config, this.config);
   }
 

--- a/src/ts/components/uicontainer.ts
+++ b/src/ts/components/uicontainer.ts
@@ -161,7 +161,6 @@ export class UIContainer extends Container<UIContainerConfig> {
           });
 
           const buttonComponent = findButtonComponent(e.target as HTMLElementWithComponent);
-
           return !(buttonComponent && buttonComponent.getConfig().acceptsTouchWithUiHidden);
         });
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
### Problem
When BAM (Bitmovin Advertising Module) is used on touch devices, two touch interactions are necessary to skip an ad or open the ad click-through URL.

On touch input devices, the first touch is expected to display the UI controls and not be propagated to other components. When buttons are always visible, such as the `AdSkipButton`, the first touch seems as if it's not 'recognized'.

<details>
  <summary>Possible approaches which we elaborated</summary>
  
#### Always show the Ads UI
#622 

Was not considered as the solution as other elements which should not be there are also always visible.

#### Global setting to allow default touch on first touch
#624

Was not considered as the solution as non visible elements, e.g. the fullscreen button, would receive the click and perform their actions.

#### Using `display: none`
Most likely the cleanest solution would be to switch from `opacity: 0;` to `display: none` which would prevent any click listners completely. However, `display: none` is not animatable. Technically there are still ways to achieve a `display: none` approach but we did not want to do such a 'core' change for this.

#### Respecting the visibility of elements
In a POC I implemented an approach to traverse the view hierarchy and detect the visibility of the target element of the touch event. However, this yield other problems. Mainly with the `PlaybackToggleOverlay` which is strictly speaking not visible but technically still there in the DOM tree (there are other elements too). Those would need changes in their visibility handling which was considered out of scope for this fix.
</details>

### Changes
- #626 acts as pre-work for this PR.

A new attribute was added to the `ButtonConfig` (`acceptsTouchWithUiHidden`) which indicates if a button wants to receive the first touch input even if the UI is currently not visible. _This follows the idea from @hawk23 as outlined in #624 (section `1)`) but with an inverted dependency._
The idea is that every `Button` component can decide if it wants to receive the `click` (`touchend`) even if the UI is hidden.
Ths setting is then respected in the `UIContainer` on the first touch input if the `touchend` event should be stop bubbling or not.

The `AdSkipButton` and the `AdClickOverlay` set this new property to `true`

### Manual Testing
- Include the BAM module and configure the Player to use BAM.

```diff
+ <script src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-advertising-bitmovin.js"></script>

// Before instantiating a Player instance register the BAM module
+ bitmovin.player.Player.addModule(window.bitmovin.player['advertising-bitmovin'].default);
```

- Enable ads:
```diff
- var adsEnabled = false;
+ var adsEnabled = true;
```

- Run the playground on a touch device (or a browser with touch input simulated)
- Make sure you are testing the `SmallScreenUI`
- Try to skip the Ad before and after the changes

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
