### PR TITLE
Disable linting violations

### DIFF
--- a/src/scss/skin-modern/_mixins.scss
+++ b/src/scss/skin-modern/_mixins.scss
@@ -139,6 +139,7 @@
     outline: none;
   }
 
+  // sass-lint:disable force-pseudo-nesting
   &:focus:not(.#{$prefix}-focus-visible) {
     box-shadow: none;
     outline: none;

--- a/src/scss/skin-modern/_skin-tv.scss
+++ b/src/scss/skin-modern/_skin-tv.scss
@@ -78,7 +78,7 @@
     font-size: $medium-large-size;
 
     > .#{$prefix}-container-wrapper {
-      // Increase margin area around the UI but spread the dark shadow still 
+      // Increase margin area around the UI but spread the dark shadow still
       // to the edge of the video by applying it to only the container-wrapper
 
       margin: $overscan-margin 0;
@@ -95,6 +95,7 @@
     box-shadow: $focus-element-box-shadow;
     filter: drop-shadow(0 0 .3em $color-highlight);
     outline: none;
+    // sass-lint:disable no-transition-all
     transition: all .05s ease-in-out;
   }
 }

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -1,3 +1,5 @@
+@import '../variables';
+
 .#{$prefix}-ui-subtitle-overlay {
   &.#{$prefix}-cea608 {
 
@@ -6,6 +8,7 @@
     right: 3em;
     top: 2em;
 
+    // sass-lint:disable force-element-nesting
     .#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-position-default {
       bottom: 0;
       left: 0;

--- a/src/scss/skin-modern/components/_uicontainer.scss
+++ b/src/scss/skin-modern/components/_uicontainer.scss
@@ -35,6 +35,7 @@
         box-shadow: inset -4px -3px 2px 9px $color-focus;
       }
 
+      // sass-lint:disable force-pseudo-nesting
       &:focus:not(.#{$prefix}-focus-visible) {
         box-shadow: none;
       }

--- a/src/scss/skin-modern/components/subtitlesettings/_subtitleoverlay-settings.scss
+++ b/src/scss/skin-modern/components/subtitlesettings/_subtitleoverlay-settings.scss
@@ -53,6 +53,7 @@
   // Background color + opacity
   @each $color-name, $color-value in $colors {
     @each $opacity-name, $opacity-value in $opacities {
+      // sass-lint:disable force-element-nesting
       &.#{$prefix}-bgcolor-#{$color-name}#{$opacity-name} .#{$prefix}-subtitle-region-container {
         .#{$prefix}-ui-subtitle-label {
           background-color: transparentize($color-value, 1 - $opacity-value);


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
There are some linter violations since quite some time which were never fixed. Similar violations were disabled already before.

The violations were:
- `force-pseudo-nesting`: already disabled in several other places
- `force-element-nesting`: already disabled in several other places
- `no-transition-all`: to not break existing functionality

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [ ] `CHANGELOG` entry
