### PR TITLE
Improve demopage

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -272,11 +272,17 @@
       updateApiMethods();
     });
 
-    // Add UI
-    uiManager = bitmovin.playerui.UIFactory.buildDefaultUI(player, uiConfig);
+    const playgroundConfig = getConfigFromStorage();
 
-    player.load(sources.fullyFeatured).then(function() {
+    // Add UI
+    uiManager = bitmovin.playerui.UIFactory[playgroundConfig.uiOption || 'buildDefaultUI'](player, uiConfig);
+
+    player.load(sources[playgroundConfig.source || 'fullyFeatured']).then(function() {
       console.log('source successfully loaded');
+
+      if (playgroundConfig.adsEnabled) {
+        scheduleAds();
+      }
     }, function(errorEvent) {
       console.log('error while loading source', errorEvent);
     });
@@ -290,6 +296,7 @@
   $('#config-source').change(function() {
     player.unload();
     player.load(sources[$(this).val()]);
+    storeConfigInStorage();
   });
 
   var printResult = function(result, method) {
@@ -718,6 +725,7 @@
     } else {
       uiManager = bitmovin.playerui.UIFactory[factoryMethod](player, uiConfig);
     }
+    storeConfigInStorage();
   });
 
   var scheduleAdsCheckbox = $('#config-ads');
@@ -725,20 +733,69 @@
     const isChecked = $(this).is(':checked');
 
     if (isChecked) {
-      adBreaks.forEach(function(adBreak) {
-        player.ads.schedule(adBreak);
-      });
+      scheduleAds();
     } else {
       const ads = player.ads.list();
       ads.forEach(function(ad) {
         player.ads.discardAdBreak(ad.id);
       })
     }
+
+    storeConfigInStorage();
   });
+
+  function scheduleAds() {
+    adBreaks.forEach(function(adBreak) {
+      player.ads.schedule(adBreak);
+    });
+  }
 
   // Populate stats
   $('#userAgent').html(navigator.userAgent);
 
+  function storeConfigInStorage() {
+    var data = {
+      adsEnabled: $('#config-ads').is(':checked'),
+      source: $('#config-source').val(),
+      uiOption: $('#config-ui').val(),
+    };
+
+    try {
+      window.localStorage.setItem('bmpui-playground-config', JSON.stringify(data));
+    } catch (e) {
+      console.error('Local storage access denied', e);
+    }
+  }
+
+  function getConfigFromStorage() {
+    let config = {};
+    try {
+      const loadedEntry = window.localStorage.getItem('bmpui-playground-config');
+      if (!loadedEntry) {
+        console.log('No local storage entry found');
+        return;
+      }
+      config = JSON.parse(loadedEntry);
+    } catch (e) {
+      console.error('Problem loading playground config from localStorage', e);
+    }
+
+    return config || {};
+  }
+
+  (function applyInitialConfiguration() {
+    const config = getConfigFromStorage();
+
+    if ($('#config-source') && config.source) {
+      $('#config-source').val(config.source);
+    }
+    if ($('#config-ui') && config.uiOption) {
+      $('#config-ui').val(config.uiOption);
+    }
+    if ($('#config-ads') && config.adsEnabled !== undefined) {
+      $('#config-ads').prop('checked', config.adsEnabled);
+    }
+  })();
 </script>
 </body>
 </html>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -773,7 +773,7 @@
       const loadedEntry = window.localStorage.getItem('bmpui-playground-config');
       if (!loadedEntry) {
         console.log('No local storage entry found');
-        return;
+        return {};
       }
       config = JSON.parse(loadedEntry);
     } catch (e) {

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -41,6 +41,14 @@
                 </div>
                 <span class="col-sm-4 form-text">The UI skin or skin type to display.</span>
             </div>
+
+            <div class="form-group form-check row">
+              <label for="config-ads" class="col-sm-4 form-check-label" for="config-ads">Ads</label>
+              <div class="col-sm-4 form-check">
+                  <input type="checkbox" id="config-ads">
+              </div>
+              <span class="col-sm-4 form-text">Schedule client-side ads.</span>
+            </div>
         </div>
 
         <div class="card-block">
@@ -97,6 +105,7 @@
 </div>
 
 <script src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer.js"></script>
+<script src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-advertising-bitmovin.js"></script>
 <script src="js/bitmovinplayer-ui.js"></script>
 <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
 <script type="text/javascript">
@@ -183,27 +192,24 @@
     }
   };
 
-  var advertisingConfig = {
-    adBreaks: [
-      {
-        tag: {
-          // skippable
-          url: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]',
-          type: 'vast',
-        },
-        position: 'pre',
+  var adBreaks = [
+    {
+      tag: {
+        // skippable
+        url: 'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=[random]',
+        type: 'vast',
       },
-      {
-        tag: {
-          // nonskippable
-          url: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/2nd_test_ad_unit&ciu_szs=300x100&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&url=[referrer_url]&description_url=[description_url]&correlator=[random]',
-          type: 'vast',
-        },
-        position: '10',
-      }
-    ]
-  };
-  var adsEnabled = false;
+      position: 'pre',
+    },
+    {
+      tag: {
+        // nonskippable
+        url: 'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=[random]',
+        type: 'vast',
+      },
+      position: '10',
+    }
+  ];
 
   var config = {
     key: 'YOUR KEY HERE',
@@ -211,7 +217,7 @@
     remotecontrol: {
       type: 'googlecast',
     },
-    advertising: adsEnabled ? advertisingConfig : null
+    advertising: {},
   };
 
   var uiConfig = {
@@ -255,6 +261,8 @@
   var player;
   var uiManager;
   bitmovin.playerui.UIManager.setLocalizationConfig({ language: 'en', browserLanguageDetection: false });
+
+  bitmovin.player.Player.addModule(bitmovin.player["advertising-bitmovin"].default);
 
   var playerSetup = function(config) {
     player = new bitmovin.player.Player(document.getElementById('player'), config);
@@ -709,6 +717,22 @@
       uiManager = bitmovin.playerui.DemoFactory[factoryMethod](player, uiConfig);
     } else {
       uiManager = bitmovin.playerui.UIFactory[factoryMethod](player, uiConfig);
+    }
+  });
+
+  var scheduleAdsCheckbox = $('#config-ads');
+  scheduleAdsCheckbox.change(function() {
+    const isChecked = $(this).is(':checked');
+
+    if (isChecked) {
+      adBreaks.forEach(function(adBreak) {
+        player.ads.schedule(adBreak);
+      });
+    } else {
+      const ads = player.ads.list();
+      ads.forEach(function(ad) {
+        player.ads.discardAdBreak(ad.id);
+      })
     }
   });
 


### PR DESCRIPTION
## Description
Two small but hopefully useful improvements of the playground demo page:
1. A checkbox to enable/disable ads on the fly in the demo page UI as shown below. Previously, this needed to be done somewhere in the demo page's code.
    ![image](https://github.com/bitmovin/bitmovin-player-ui/assets/4820162/e82c2493-7570-4b5c-9862-6c8933ba39fe)
2. Store the basic configuration of the playground (video source, UI, ads enabled) in localStorage of the browser and load on page load

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [ ] `CHANGELOG` entry 