### PR TITLE
Add missing changelog entries for last release versions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,5 @@
 
 ## Checklist (for PR submitter and reviewers)
 <!-- A PR with CHANGELOG entry will be released automatically -->
+<!-- This is required and should be added in every case -->
 - [ ] `CHANGELOG` entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Missing changelog entries of `3.65.0` and `3.66.0` release versions
+
+## [3.66.0] - 2024-07-01
+
+### Changed
+- Playground demo page to include checkbox to enable/disbale ads
+- Store basic configuration of playground demo page in localStorage
+
+## [3.65.0] - 2024-06-24
+
+### Added
+- Eco Mode toggle button
+
 ## [3.64.0] - 2024-05-28
 
 ### Added
@@ -960,7 +976,7 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
-[3.66.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.64.0...v3.66.0
+[3.66.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.65.0...v3.66.0
 [3.65.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.64.0...v3.65.0
 [3.64.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.63.0...v3.64.0
 [3.63.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.62.0...v3.63.0


### PR DESCRIPTION
## Description
We are missing changelog entries for last 2 released versions due to a problem in the release workflow

This PR adds those changelog entries.

Also, the PR template is updated to mention that a Changelog entry is required for all PRs

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
- [x] `CHANGELOG` entry
