### PR TITLE
build the structure of the new mobile ui with the old ui components

### DIFF
--- a/src/ts/components/metadatalabel.ts
+++ b/src/ts/components/metadatalabel.ts
@@ -11,7 +11,7 @@ export enum MetadataLabelContent {
    */
   Title,
   /**
-   * Description fo the data source.
+   * Description of the data source.
    */
   Description,
 }

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -449,7 +449,120 @@ export function superModernAdsUI(){
 }
 
 export function superModernMobileUI(){
-  return new UIContainer({});
+  let subtitleOverlay = new SubtitleOverlay();
+
+  let mainSettingsPanelPage = new SettingsPanelPage({
+    components: [
+      new SettingsPanelItem(i18n.getLocalizer('settings.video.quality'), new VideoQualitySelectBox()),
+      new SettingsPanelItem(i18n.getLocalizer('speed'), new PlaybackSpeedSelectBox()),
+      new SettingsPanelItem(i18n.getLocalizer('settings.audio.track'), new AudioTrackSelectBox()),
+      new SettingsPanelItem(i18n.getLocalizer('settings.audio.quality'), new AudioQualitySelectBox()),
+    ]
+  });
+
+  let settingsPanel = new SettingsPanel({
+    components: [mainSettingsPanelPage],
+    hidden: true,
+    pageTransitionAnimation: false,
+    hideDelay: -1,
+  });
+
+  let subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({
+    settingsPanel: settingsPanel,
+    overlay: subtitleOverlay,
+  });
+
+  let subtitleSettingsOpenButton = new SettingsPanelPageOpenButton({
+    targetPage: subtitleSettingsPanelPage,
+    container: settingsPanel,
+    ariaLabel: i18n.getLocalizer('settings.subtitles'),
+    text: i18n.getLocalizer('open'),
+  });
+
+  const subtitleSelectBox = new SubtitleSelectBox();
+  
+  //TODO: Remove subtitle settings and instead use that settings page for the subtitles itself
+  mainSettingsPanelPage.addComponent(
+    new SettingsPanelItem(
+      new SubtitleSettingsLabel({
+        text: i18n.getLocalizer('settings.subtitles'),
+        opener: subtitleSettingsOpenButton,
+      }),
+      subtitleSelectBox,
+      {
+        role: 'menubar',
+      },
+    ),
+  );
+
+  settingsPanel.addComponent(subtitleSettingsPanelPage);
+
+  //TODO: we don´t need the CloseButtons anymore(settings page will be closed by tapping inside the view)
+  settingsPanel.addComponent(new CloseButton({ target: settingsPanel }));
+  subtitleSettingsPanelPage.addComponent(new CloseButton({ target: settingsPanel }));
+
+  let controlBar = new ControlBar({
+    components: [
+      new Container({
+        components: [
+          new PlaybackTimeLabel({
+            timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+            hideInLivePlayback: true,
+          }),
+          new SeekBar({ label: new SeekBarLabel() }),
+          new PlaybackTimeLabel({
+            timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+            cssClasses: ['text-right'],
+          }),
+        ],
+        cssClasses: ['controlbar-top'],
+      }),
+      new Container({
+        components: [
+          new PlaybackToggleButton(),
+          new VolumeToggleButton(),
+          new Spacer(),
+          new SettingsToggleButton({ settingsPanel: settingsPanel }),
+          //TODO: make a subtitles toggle button
+          new FullscreenToggleButton(),
+        ],
+        cssClasses: ['controlbar-bottom'],
+      }),
+    ],
+  });
+
+
+  return new UIContainer({
+    components: [
+      subtitleOverlay,
+      new BufferingOverlay(),
+      new CastStatusOverlay(),
+      //TODO: make an overlay for the quickseek buttons/double tab
+      new PlaybackToggleOverlay(),
+      new RecommendationOverlay(),
+      controlBar,
+      new TitleBar({
+        components: [
+          new MetadataLabel({ content: MetadataLabelContent.Title }),
+          new CastToggleButton(),
+          new AirPlayToggleButton(),
+          new VRToggleButton(),
+          //TODO: make a Share button
+          //new PictureInPictureToggleButton(), probably not needed in mobile version
+        ],
+      }),
+      settingsPanel,
+      new Watermark(),
+      new ErrorMessageOverlay(),
+    ],
+    cssClasses: ['ui-skin-smallscreen'],
+    hideDelay: 2000,
+    hidePlayerStateExceptions: [
+      PlayerUtils.PlayerState.Prepared,
+      PlayerUtils.PlayerState.Paused,
+      PlayerUtils.PlayerState.Finished,
+    ],
+  });
 }
 
 export function superModerUI(){

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -551,7 +551,6 @@ export function superModernMobileUI() {
         ],
       }),
       settingsPanel,
-      new Watermark(),
       new ErrorMessageOverlay(),
     ],
     cssClasses: ['ui-skin-smallscreen'],

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -444,11 +444,11 @@ export function superModernMobileAdsUI() {
   return new UIContainer({});
 }
 
-export function superModernAdsUI(){
+export function superModernAdsUI() {
   return new UIContainer({});
 }
 
-export function superModernMobileUI(){
+export function superModernMobileUI() {
   let subtitleOverlay = new SubtitleOverlay();
 
   let mainSettingsPanelPage = new SettingsPanelPage({
@@ -457,7 +457,7 @@ export function superModernMobileUI(){
       new SettingsPanelItem(i18n.getLocalizer('speed'), new PlaybackSpeedSelectBox()),
       new SettingsPanelItem(i18n.getLocalizer('settings.audio.track'), new AudioTrackSelectBox()),
       new SettingsPanelItem(i18n.getLocalizer('settings.audio.quality'), new AudioQualitySelectBox()),
-    ]
+    ],
   });
 
   let settingsPanel = new SettingsPanel({
@@ -480,8 +480,8 @@ export function superModernMobileUI(){
   });
 
   const subtitleSelectBox = new SubtitleSelectBox();
-  
-  //TODO: Remove subtitle settings and instead use that settings page for the subtitles itself
+
+  // TODO: Remove subtitle settings and instead use that settings page for the subtitles itself
   mainSettingsPanelPage.addComponent(
     new SettingsPanelItem(
       new SubtitleSettingsLabel({
@@ -497,7 +497,7 @@ export function superModernMobileUI(){
 
   settingsPanel.addComponent(subtitleSettingsPanelPage);
 
-  //TODO: we don´t need the CloseButtons anymore(settings page will be closed by tapping inside the view)
+  // TODO: we don´t need the CloseButtons anymore(settings page will be closed by tapping inside the view)
   settingsPanel.addComponent(new CloseButton({ target: settingsPanel }));
   subtitleSettingsPanelPage.addComponent(new CloseButton({ target: settingsPanel }));
 
@@ -523,7 +523,7 @@ export function superModernMobileUI(){
           new VolumeToggleButton(),
           new Spacer(),
           new SettingsToggleButton({ settingsPanel: settingsPanel }),
-          //TODO: make a subtitles toggle button
+          // TODO: make a subtitles toggle button
           new FullscreenToggleButton(),
         ],
         cssClasses: ['controlbar-bottom'],
@@ -537,7 +537,7 @@ export function superModernMobileUI(){
       subtitleOverlay,
       new BufferingOverlay(),
       new CastStatusOverlay(),
-      //TODO: make an overlay for the quickseek buttons/double tab
+      // TODO: make an overlay for the quickseek buttons/double tab
       new PlaybackToggleOverlay(),
       new RecommendationOverlay(),
       controlBar,
@@ -547,8 +547,7 @@ export function superModernMobileUI(){
           new CastToggleButton(),
           new AirPlayToggleButton(),
           new VRToggleButton(),
-          //TODO: make a Share button
-          //new PictureInPictureToggleButton(), probably not needed in mobile version
+          // TODO: make a Share button
         ],
       }),
       settingsPanel,

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -563,7 +563,7 @@ export function superModernMobileUI() {
   });
 }
 
-export function superModerUI(){
+export function superModerUI() {
   return new UIContainer({});
 }
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
the layout of the new mobile UI version was build using the old/existing components(with old icons etc.)

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
