### PR TITLE
[PW-11902] Improve auto-hide behavior with active dropdown menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `Component` now has a `ViewMode` that can either be `Persistent` or `Temporary`
+
+### Fixed
+- `selectbox` dropdown not closing in Safari when the UI is hidden
+
+### Changed
+- `selectbox` now sets its `ViewMode` to `Persistent` whenever and as long as the select-dropdown is shown
+- `uicontainer` and `settingspanel` will no longer auto-hide if there are any components that are in the `Persistent` view mode
+
 ## [3.72.0] - 2024-08-30
 
 ### Added

--- a/spec/components/selectbox.spec.ts
+++ b/spec/components/selectbox.spec.ts
@@ -1,0 +1,325 @@
+import type { PlayerAPI } from 'bitmovin-player';
+
+import type { Component, ViewModeChangedEventArgs } from '../../src/ts/components/component';
+import { ViewMode } from '../../src/ts/components/component';
+import type { ListSelectorConfig } from '../../src/ts/components/listselector';
+import { SelectBox } from '../../src/ts/components/selectbox';
+import type { Event } from '../../src/ts/eventdispatcher';
+import { PlayerUtils } from '../../src/ts/playerutils';
+import type { UIInstanceManager } from '../../src/ts/uimanager';
+import { MockHelper } from '../helper/MockHelper';
+import getUiInstanceManagerMock = MockHelper.getUiInstanceManagerMock;
+import getPlayerMock = MockHelper.getPlayerMock;
+import generateDOMMock = MockHelper.generateDOMMock;
+import PlayerState = PlayerUtils.PlayerState;
+import type { DOM } from '../../src/ts/dom';
+
+jest.mock('../../src/ts/dom', generateDOMMock);
+
+describe('SelectBox', () => {
+  let selectBox: SelectBox;
+  let playerMock: PlayerAPI;
+  let uiManagerMock: UIInstanceManager;
+
+  beforeEach(() => {
+    selectBox = new SelectBox();
+    playerMock = getPlayerMock();
+    uiManagerMock = getUiInstanceManagerMock();
+  });
+
+  describe('viewMode', () => {
+    it('should initialize the `ViewMode` to `Temporary`', () => {
+      expect(selectBox['viewMode']).toEqual(ViewMode.Temporary);
+    });
+  });
+
+  describe('configure', () => {
+    test.each`
+      event
+      ${'onShow'}
+      ${'onHide'}
+      ${'onViewModeChanged'}
+    `('should subscribe to "$event"', ({ event }) => {
+      const subscribeSpy = jest.spyOn(selectBox[event as keyof SelectBox] as Event<unknown, unknown>, 'subscribe');
+
+      selectBox.configure(playerMock, uiManagerMock);
+
+      expect(subscribeSpy).toHaveBeenCalled();
+    });
+
+    test.each`
+      event
+      ${'mouseenter'}
+      ${'mouseleave'}
+    `('should add a "$event" listener to the DOM element', ({ event }) => {
+      const onSpy = jest.spyOn(selectBox.getDomElement(), 'on');
+
+      selectBox.configure(playerMock, uiManagerMock);
+
+      expect(onSpy).toHaveBeenCalledWith(event, expect.any(Function));
+    });
+  });
+
+  describe('onViewModeChangedEvent', () => {
+    let viewModeChangedSpy: jest.Mock<void, [Component<ListSelectorConfig>, ViewModeChangedEventArgs]>;
+
+    beforeEach(() => {
+      viewModeChangedSpy = jest.fn();
+      selectBox.onViewModeChanged.subscribe(viewModeChangedSpy);
+    });
+
+    it('should dispatch the onViewModeChanged event', () => {
+      selectBox['onViewModeChangedEvent'](ViewMode.Persistent);
+
+      expect(viewModeChangedSpy).toHaveBeenCalledWith(expect.any(SelectBox), { mode: ViewMode.Persistent });
+    });
+
+    it('should not dispatch the onViewModeChanged event if the view mode did not change', () => {
+      selectBox['onViewModeChangedEvent'](ViewMode.Temporary);
+
+      expect(viewModeChangedSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toDomElement', () => {
+    test.each`
+      event
+      ${'onDisabled'}
+      ${'onHide'}
+    `('should subscribe to "$event" to close the dropdown', ({ event }) => {
+      const subscribeSpy = jest.spyOn(selectBox[event as keyof SelectBox] as Event<unknown, unknown>, 'subscribe');
+
+      selectBox.getDomElement();
+
+      expect(subscribeSpy).toHaveBeenCalledWith(selectBox.closeDropdown);
+    });
+
+    it('should add event dropdown open event listeners', () => {
+      const domElement = selectBox.getDomElement();
+
+      expect(domElement.on).toHaveBeenCalled();
+    });
+  });
+
+  describe('configure', () => {
+    it('should subscribe to player state changes', () => {
+      const uiContainer = uiManagerMock.getUI();
+
+      selectBox.configure(playerMock, uiManagerMock);
+
+      expect(uiContainer.onPlayerStateChange().subscribe).toHaveBeenCalledWith(selectBox['onPlayerStateChange']);
+    });
+  });
+
+  describe('closeDropdown', () => {
+    it('should call blur on the DOM select element', () => {
+      const element = document.createElement('select');
+      const blurSpy = jest.spyOn(element, 'blur');
+
+      jest.spyOn(selectBox as any, 'getSelectElement').mockReturnValue(element);
+      selectBox.closeDropdown();
+
+      expect(blurSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onPlayerStateChange', () => {
+    test.each`
+      playerState             | shouldClose
+      ${PlayerState.Idle}     | ${true}
+      ${PlayerState.Finished} | ${true}
+      ${PlayerState.Paused}   | ${false}
+      ${PlayerState.Playing}  | ${false}
+      ${PlayerState.Prepared} | ${false}
+    `(
+      `should close the dropdown=$shouldClose when the player state changes to $playerState`,
+      ({ playerState, shouldClose }) => {
+        const closeDropdownSpy = jest.spyOn(selectBox, 'closeDropdown');
+
+        selectBox['onPlayerStateChange'](uiManagerMock.getUI(), playerState);
+
+        if (shouldClose) {
+          expect(closeDropdownSpy).toHaveBeenCalled();
+        } else {
+          expect(closeDropdownSpy).not.toHaveBeenCalled();
+        }
+      },
+    );
+  });
+
+  describe('onDropdownOpened', () => {
+    it('should clear the existing closed event listener addition timeout', () => {
+      const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+      selectBox['onDropdownOpened']();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it('should start a timeout to add closed event listeners', () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+
+      selectBox['onDropdownOpened']();
+
+      expect(setTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it('should change the view mode to `Persistent`', () => {
+      const onViewModeChangedSpy = jest.fn();
+
+      selectBox.onViewModeChanged.subscribe(onViewModeChangedSpy);
+      selectBox['onDropdownOpened']();
+
+      expect(onViewModeChangedSpy).toHaveBeenCalledWith(expect.any(SelectBox), { mode: ViewMode.Persistent });
+    });
+  });
+
+  describe('onDropdownClosed', () => {
+    it('should clear the closed event listener addition timeout', () => {
+      const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+      selectBox['onDropdownClosed']();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it('should remove the close event listeners', () => {
+      const removeDropdownCloseListenersSpy = jest.fn();
+
+      selectBox['removeDropdownCloseListeners'] = removeDropdownCloseListenersSpy;
+      selectBox['onDropdownClosed']();
+
+      expect(removeDropdownCloseListenersSpy).toHaveBeenCalled();
+    });
+
+    it('should change the view mode to `Temporary`', () => {
+      const onViewModeChangedSpy = jest.fn();
+
+      selectBox['viewMode'] = ViewMode.Persistent;
+      selectBox.onViewModeChanged.subscribe(onViewModeChangedSpy);
+      selectBox['onDropdownClosed']();
+
+      expect(onViewModeChangedSpy).toHaveBeenCalledWith(expect.any(SelectBox), { mode: ViewMode.Temporary });
+    });
+  });
+
+  describe('addDropdownCloseListeners', () => {
+    let selectElement: DOM;
+
+    beforeEach(() => {
+      selectElement = { on: jest.fn(), off: jest.fn() } as unknown as DOM;
+      selectBox['selectElement'] = selectElement;
+    });
+
+    it('should remove existing close listeners', () => {
+      const removeDropdownCloseListenersSpy = jest.fn();
+
+      selectBox['removeDropdownCloseListeners'] = removeDropdownCloseListenersSpy;
+      selectBox['addDropdownCloseListeners']();
+
+      expect(removeDropdownCloseListenersSpy).toHaveBeenCalled();
+    });
+
+    it('should clear the closed event listener addition timeout', () => {
+      const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+      selectBox['addDropdownCloseListeners']();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it('should add close event listeners to the document', () => {
+      const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+
+      selectBox['addDropdownCloseListeners']();
+
+      expect(addEventListenerSpy).toHaveBeenCalled();
+    });
+
+    it('should add close event listeners to the select element', () => {
+      selectBox['addDropdownCloseListeners']();
+
+      expect(selectElement.on).toHaveBeenCalled();
+    });
+
+    it('should set the removeDropdownCloseListeners', () => {
+      const initialRemoveDropdownCloseListenersFunction = selectBox['removeDropdownCloseListeners'];
+
+      selectBox['addDropdownCloseListeners']();
+
+      const newRemoveDropdownCloseListenersFunction = selectBox['removeDropdownCloseListeners'];
+
+      expect(initialRemoveDropdownCloseListenersFunction).not.toEqual(newRemoveDropdownCloseListenersFunction);
+    });
+  });
+
+  describe('removeDropdownCloseListeners', () => {
+    let selectElement: DOM;
+
+    beforeEach(() => {
+      selectElement = { on: jest.fn(), off: jest.fn() } as unknown as DOM;
+      selectBox['selectElement'] = selectElement;
+      selectBox['addDropdownCloseListeners']();
+    });
+
+    it('should remove close event listeners to the document', () => {
+      const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+
+      selectBox['removeDropdownCloseListeners']();
+
+      expect(removeEventListenerSpy).toHaveBeenCalled();
+    });
+
+    it('should remove close event listeners from the select element', () => {
+      selectBox['removeDropdownCloseListeners']();
+
+      expect(selectElement.off).toHaveBeenCalled();
+    });
+  });
+
+  describe('addDropdownOpenedListeners', () => {
+    let selectElement: DOM;
+
+    beforeEach(() => {
+      selectElement = { on: jest.fn(), off: jest.fn() } as unknown as DOM;
+      selectBox['selectElement'] = selectElement;
+    });
+
+    it('should remove existing open listeners', () => {
+      const removeDropdownOpenedListenersSpy = jest.fn();
+
+      selectBox['removeDropdownOpenedListeners'] = removeDropdownOpenedListenersSpy;
+      selectBox['addDropdownOpenedListeners']();
+
+      expect(removeDropdownOpenedListenersSpy).toHaveBeenCalled();
+    });
+
+    it('should add event listener on the select element', () => {
+      selectBox['addDropdownOpenedListeners']();
+
+      expect(selectElement.on).toHaveBeenCalled();
+    });
+
+    it('should set the removeDropdownOpenedListeners', () => {
+      const initialRemoveDropdownOpenedListenersFunction = selectBox['removeDropdownOpenedListeners'];
+
+      selectBox['addDropdownOpenedListeners']();
+
+      const newRemoveDropdownOpenedListenersFunction = selectBox['removeDropdownOpenedListeners'];
+
+      expect(initialRemoveDropdownOpenedListenersFunction).not.toEqual(newRemoveDropdownOpenedListenersFunction);
+    });
+  });
+
+  describe('removeDropdownOpenedListeners', () => {
+    it('should remove opened event listeners from the select element', () => {
+      const selectElement = { on: jest.fn(), off: jest.fn() } as unknown as DOM;
+      selectBox['selectElement'] = selectElement;
+      selectBox['addDropdownOpenedListeners']();
+
+      selectBox['removeDropdownOpenedListeners']();
+
+      expect(selectElement.off).toHaveBeenCalled();
+    });
+  });
+});

--- a/spec/components/uicontainer.spec.ts
+++ b/spec/components/uicontainer.spec.ts
@@ -3,6 +3,11 @@ import { PlayerUtils } from '../../src/ts/playerutils';
 import type { UIInstanceManager } from '../../src/ts/uimanager';
 import type { TestingPlayerAPI } from '../helper/MockHelper';
 import { MockHelper } from '../helper/MockHelper';
+import generateDOMMock = MockHelper.generateDOMMock;
+import getUiInstanceManagerMock = MockHelper.getUiInstanceManagerMock;
+import getPlayerMock = MockHelper.getPlayerMock;
+
+jest.mock('../../src/ts/dom', generateDOMMock);
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;
@@ -10,8 +15,8 @@ let uiInstanceManagerMock: UIInstanceManager;
 describe('UIContainer', () => {
   let uiContainer: UIContainer;
   beforeEach(() => {
-    playerMock = MockHelper.getPlayerMock();
-    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+    playerMock = getPlayerMock();
+    uiInstanceManagerMock = getUiInstanceManagerMock();
   });
 
   describe('release', () => {

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -37,6 +37,7 @@ export namespace MockHelper {
       onSeek: getEventDispatcherMock(),
       onSeeked: getEventDispatcherMock(),
       onRelease: getEventDispatcherMock(),
+      onComponentViewModeChanged: getEventDispatcherMock(),
     }));
 
     return new UiInstanceManagerMockClass();

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -2,6 +2,7 @@ import { PlayerAPI, PlayerEvent } from 'bitmovin-player';
 import { UIInstanceManager } from '../../src/ts/uimanager';
 import { DOM } from '../../src/ts/dom';
 import { PlayerEventEmitter } from './PlayerEventEmitter';
+import { UIContainer } from '../../src/ts/components/uicontainer';
 
 jest.mock('../../src/ts/dom');
 
@@ -18,7 +19,14 @@ export namespace MockHelper {
     };
   }
 
+  export function getUiMock(): UIContainer {
+    return {
+      onPlayerStateChange: jest.fn().mockReturnValue({ subscribe: jest.fn() }),
+    } as unknown as UIContainer;
+  }
+
   export function getUiInstanceManagerMock(): UIInstanceManager {
+    const uiMock = getUiMock();
     const UiInstanceManagerMockClass: jest.Mock<UIInstanceManager> = jest.fn().mockImplementation(() => ({
       onConfigured: getEventDispatcherMock(),
       getConfig: jest.fn().mockReturnValue({
@@ -29,6 +37,7 @@ export namespace MockHelper {
           markers: [],
         },
       }),
+      getUI: () => uiMock,
       onControlsShow: getEventDispatcherMock(),
       onControlsHide: getEventDispatcherMock(),
       onComponentHide: getEventDispatcherMock(),

--- a/src/ts/components/component.ts
+++ b/src/ts/components/component.ts
@@ -139,7 +139,7 @@ export class Component<Config extends ComponentConfig> {
   private hovered: boolean;
 
   /**
-   * Tge current view mode of the component.
+   * The current view mode of the component.
    */
   private viewMode: ViewMode;
 

--- a/src/ts/components/component.ts
+++ b/src/ts/components/component.ts
@@ -266,20 +266,13 @@ export class Component<Config extends ComponentConfig> {
    * @param uimanager the UIInstanceManager that manages this component
    */
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
-    this.onShow.subscribe(() => {
-      uimanager.onComponentShow.dispatch(this);
-    });
-    this.onHide.subscribe(() => {
-      uimanager.onComponentHide.dispatch(this);
-    });
+    this.onShow.subscribe(() => uimanager.onComponentShow.dispatch(this));
+    this.onHide.subscribe(() => uimanager.onComponentHide.dispatch(this));
+    this.onViewModeChanged.subscribe((_, args) => uimanager.onComponentViewModeChanged.dispatch(this, args));
 
     // Track the hovered state of the element
-    this.getDomElement().on('mouseenter', () => {
-      this.onHoverChangedEvent(true);
-    });
-    this.getDomElement().on('mouseleave', () => {
-      this.onHoverChangedEvent(false);
-    });
+    this.getDomElement().on('mouseenter', () => this.onHoverChangedEvent(true));
+    this.getDomElement().on('mouseleave', () => this.onHoverChangedEvent(false));
   }
 
   /**

--- a/src/ts/components/component.ts
+++ b/src/ts/components/component.ts
@@ -73,6 +73,26 @@ export interface ComponentHoverChangedEventArgs extends NoArgs {
   hovered: boolean;
 }
 
+export enum ViewMode {
+  /**
+   * Indicates that the component has entered a view mode where it must stay visible. Auto-hiding of this component
+   * must be disabled as long as it resides in this state.
+   */
+  Persistent = 'persistent',
+
+  /**
+   * The control can be hidden at any time.
+   */
+  Temporary = 'temporary',
+}
+
+export interface ViewModeChangedEventArgs extends NoArgs {
+  /**
+   * The `ViewMode` the control is currently in.
+   */
+  mode: ViewMode;
+}
+
 /**
  * The base class of the UI framework.
  * Each component must extend this class and optionally the config interface.
@@ -117,6 +137,11 @@ export class Component<Config extends ComponentConfig> {
    * Flag that keeps track of the hover state.
    */
   private hovered: boolean;
+
+  /**
+   * Tge current view mode of the component.
+   */
+  private viewMode: ViewMode;
 
   /**
    * The list of events that this component offers. These events should always be private and only directly
@@ -179,6 +204,7 @@ export class Component<Config extends ComponentConfig> {
   private componentEvents = {
     onShow: new EventDispatcher<Component<Config>, NoArgs>(),
     onHide: new EventDispatcher<Component<Config>, NoArgs>(),
+    onViewModeChanged: new EventDispatcher<Component<Config>, ViewModeChangedEventArgs>(),
     onHoverChanged: new EventDispatcher<Component<Config>, ComponentHoverChangedEventArgs>(),
     onEnabled: new EventDispatcher<Component<Config>, NoArgs>(),
     onDisabled: new EventDispatcher<Component<Config>, NoArgs>(),
@@ -200,6 +226,7 @@ export class Component<Config extends ComponentConfig> {
       hidden: false,
       disabled: false,
     }, {});
+    this.viewMode = ViewMode.Temporary;
   }
 
   /**
@@ -490,6 +517,19 @@ export class Component<Config extends ComponentConfig> {
   }
 
   /**
+   * Fires the onViewModeChanged event.
+   * See the detailed explanation on event architecture on the {@link #componentEvents events list}.
+   */
+  protected onViewModeChangedEvent(mode: ViewMode): void {
+    if (this.viewMode === mode) {
+      return;
+    }
+
+    this.viewMode = mode;
+    this.componentEvents.onViewModeChanged.dispatch(this, { mode });
+  }
+
+  /**
    * Fires the onHoverChanged event.
    * See the detailed explanation on event architecture on the {@link #componentEvents events list}.
    */
@@ -540,5 +580,13 @@ export class Component<Config extends ComponentConfig> {
    */
   get onHoverChanged(): Event<Component<Config>, ComponentHoverChangedEventArgs> {
     return this.componentEvents.onHoverChanged.getEvent();
+  }
+
+  /**
+   * Gets the event that is fired when the `ViewMode` of this component has changed.
+   * @returns {Event<Component<Config>, ViewModeChangedEventArgs>}
+   */
+  get onViewModeChanged(): Event<Component<Config>, ViewModeChangedEventArgs> {
+    return this.componentEvents.onViewModeChanged.getEvent();
   }
 }

--- a/src/ts/components/container.ts
+++ b/src/ts/components/container.ts
@@ -160,8 +160,6 @@ export class Container<Config extends ContainerConfig> extends Component<Config>
       this.componentsInPersistentViewMode = Math.max(this.componentsInPersistentViewMode - 1, 0);
     }
 
-    console.error(this, this.componentsInPersistentViewMode);
-
     if (this.componentsInPersistentViewMode > 0) {
       // There is at least one component that must not be hidden,
       // therefore the hide timeout must be suspended

--- a/src/ts/components/container.ts
+++ b/src/ts/components/container.ts
@@ -1,4 +1,4 @@
-import {ComponentConfig, Component} from './component';
+import { ComponentConfig, Component, ViewModeChangedEventArgs, ViewMode } from './component';
 import {DOM} from '../dom';
 import {ArrayUtils} from '../arrayutils';
 import { i18n } from '../localization/i18n';
@@ -44,6 +44,7 @@ export class Container<Config extends ContainerConfig> extends Component<Config>
   private innerContainerElement: DOM;
   private componentsToAdd: Component<ComponentConfig>[];
   private componentsToRemove: Component<ComponentConfig>[];
+  private componentsInPersistentViewMode: number;
 
   constructor(config: Config) {
     super(config);
@@ -55,6 +56,7 @@ export class Container<Config extends ContainerConfig> extends Component<Config>
 
     this.componentsToAdd = [];
     this.componentsToRemove = [];
+    this.componentsInPersistentViewMode = 0;
   }
 
   /**
@@ -141,5 +143,31 @@ export class Container<Config extends ContainerConfig> extends Component<Config>
     containerElement.append(innerContainer);
 
     return containerElement;
+  }
+
+  protected suspendHideTimeout(): void {
+    // to be implemented in subclass
+  }
+
+  protected resumeHideTimeout(): void {
+    // to be implemented in subclass
+  }
+
+  protected trackComponentViewMode(mode: ViewMode) {
+    if (mode === ViewMode.Persistent) {
+      this.componentsInPersistentViewMode++;
+    } else if (mode === ViewMode.Temporary) {
+      this.componentsInPersistentViewMode = Math.max(this.componentsInPersistentViewMode - 1, 0);
+    }
+
+    console.error(this, this.componentsInPersistentViewMode);
+
+    if (this.componentsInPersistentViewMode > 0) {
+      // There is at least one component that must not be hidden,
+      // therefore the hide timeout must be suspended
+      this.suspendHideTimeout();
+    } else {
+      this.resumeHideTimeout();
+    }
   }
 }

--- a/src/ts/components/selectbox.ts
+++ b/src/ts/components/selectbox.ts
@@ -7,7 +7,7 @@ import { UIContainer } from './uicontainer';
 import { PlayerUtils } from '../playerutils';
 import { ViewMode } from './component';
 
-const DocumentCancellingEvents = [
+const DocumentDropdownClosedEvents = [
   'mousemove',
   'mouseenter',
   'mouseleave',
@@ -22,13 +22,13 @@ const DocumentCancellingEvents = [
   'blur',
 ];
 
-const SelectCancellingEvents = [
+const SelectDropdownClosedEvents = [
   'change',
   'keyup',
   'mouseup',
 ];
 
-const EnteringEvents: [string, (event: Event) => boolean][] = [
+const DropdownOpenedEvents: [string, (event: Event) => boolean][] = [
   ['click', () => true],
   ['keydown', (event: KeyboardEvent) => [' ', 'ArrowUp', 'ArrowDown'].includes(event.key)],
   ['mousedown', () => true],
@@ -171,19 +171,21 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
 
     clearTimeout(this.dropdownCloseListenerTimeoutId);
 
-    DocumentCancellingEvents.forEach(event => document.addEventListener(event, this.onDropdownClosed, true));
-    SelectCancellingEvents.forEach(event => this.selectElement.on(event, this.onDropdownClosed, true));
+    DocumentDropdownClosedEvents.forEach(event => document.addEventListener(event, this.onDropdownClosed, true));
+    SelectDropdownClosedEvents.forEach(event => this.selectElement.on(event, this.onDropdownClosed, true));
 
     this.removeDropdownCloseListeners = () => {
-      DocumentCancellingEvents.forEach(event => document.removeEventListener(event, this.onDropdownClosed, true));
-      SelectCancellingEvents.forEach(event => this.selectElement.off(event, this.onDropdownClosed, true));
+      DocumentDropdownClosedEvents.forEach(event => document.removeEventListener(event, this.onDropdownClosed, true));
+      SelectDropdownClosedEvents.forEach(event => this.selectElement.off(event, this.onDropdownClosed, true));
     };
   }
 
   private addDropdownOpenedListeners() {
     const removeListenerFunctions: (() => void)[] = [];
 
-    for (const [event, filter] of EnteringEvents) {
+    this.removeDropdownOpenedListeners();
+
+    for (const [event, filter] of DropdownOpenedEvents) {
       const listener = (event: Event) => {
         if (filter(event)) {
           this.onDropdownOpened();
@@ -194,7 +196,6 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
       this.selectElement.on(event, listener, true);
     }
 
-    this.removeDropdownOpenedListeners();
     this.removeDropdownOpenedListeners = () => {
       for (const remove of removeListenerFunctions) {
         remove();

--- a/src/ts/components/selectbox.ts
+++ b/src/ts/components/selectbox.ts
@@ -159,7 +159,7 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
     this.onViewModeChangedEvent(ViewMode.Persistent);
   };
 
-  private onDropdownClosed = (e: any) => {
+  private onDropdownClosed = () => {
     clearTimeout(this.dropdownCloseListenerTimeoutId);
 
     this.removeDropdownCloseListeners();

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -247,6 +247,15 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
       this.activePage = component;
     }
     super.addComponent(component);
+    component.onViewModeChanged.subscribe((_, { mode }) => this.trackComponentViewMode(mode));
+  }
+
+  protected suspendHideTimeout() {
+    this.hideTimeout.suspend();
+  }
+
+  protected resumeHideTimeout() {
+    this.hideTimeout.resume(true);
   }
 
   private updateActivePageClass(): void {

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -90,6 +90,7 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
     let config = this.getConfig();
 
     uimanager.onControlsHide.subscribe(() => this.hideHoveredSelectBoxes());
+    uimanager.onComponentViewModeChanged.subscribe((_, { mode }) => this.trackComponentViewMode(mode));
 
     if (config.hideDelay > -1) {
       this.hideTimeout = new Timeout(config.hideDelay, () => {
@@ -247,7 +248,6 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
       this.activePage = component;
     }
     super.addComponent(component);
-    component.onViewModeChanged.subscribe((_, { mode }) => this.trackComponentViewMode(mode));
   }
 
   protected suspendHideTimeout() {

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -371,36 +371,15 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
   }
 
   /**
-   * Hack for IE + Firefox
+   * Workaround for IE, Firefox and Safari
    * when the settings panel fades out while an item of a select box is still hovered, the select box will not fade out
    * while the settings panel does. This would leave a floating select box, which is just weird
    */
   private hideHoveredSelectBoxes(): void {
-    this.getComputedItems().forEach((item: SettingsPanelItem) => {
-      if (item.isActive() && (item as any).setting instanceof SelectBox) {
-        const selectBox = (item as any).setting as SelectBox;
-        const oldDisplay = selectBox.getDomElement().css('display');
-        if (oldDisplay === 'none') {
-          // if oldDisplay is already 'none', no need to set to 'none' again. It could lead to race condition
-          // wherein the display is irreversibly set to 'none' when browser tab/window is not active because
-          // requestAnimationFrame is either delayed or paused in some browsers in inactive state
-          return;
-        }
-
-        // updating the display to none marks the select-box as inactive, so it will be hidden with the rest
-        // we just have to make sure to reset this as soon as possible
-        selectBox.getDomElement().css('display', 'none');
-        if (window.requestAnimationFrame) {
-          requestAnimationFrame(() => {
-            selectBox.getDomElement().css('display', oldDisplay);
-          });
-        } else {
-          // IE9 has no requestAnimationFrame, set the value directly. It has no optimization about ignoring DOM-changes
-          // between animationFrames
-          selectBox.getDomElement().css('display', oldDisplay);
-        }
-      }
-    });
+    this.getComputedItems()
+      .map(item => item['setting'])
+      .filter(component => component instanceof SelectBox)
+      .forEach((selectBox: SelectBox) => selectBox.closeDropdown());
   }
 
   // collect all items from all pages (see hideHoveredSelectBoxes)

--- a/src/ts/dom.ts
+++ b/src/ts/dom.ts
@@ -431,18 +431,19 @@ export class DOM {
    * Attaches an event handler to one or more events on all elements.
    * @param eventName the event name (or multiple names separated by space) to listen to
    * @param eventHandler the event handler to call when the event fires
+   * @param options the options for this event handler
    * @returns {DOM}
    */
-  on(eventName: string, eventHandler: EventListenerOrEventListenerObject): DOM {
+  on(eventName: string, eventHandler: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): DOM {
     let events = eventName.split(' ');
 
     events.forEach((event) => {
       if (this.elements == null) {
-        this.document.addEventListener(event, eventHandler);
+        this.document.addEventListener(event, eventHandler, options);
       }
       else {
         this.forEach((element) => {
-          element.addEventListener(event, eventHandler);
+          element.addEventListener(event, eventHandler, options);
         });
       }
     });
@@ -454,18 +455,19 @@ export class DOM {
    * Removes an event handler from one or more events on all elements.
    * @param eventName the event name (or multiple names separated by space) to remove the handler from
    * @param eventHandler the event handler to remove
+   * @param options the options for this event handler
    * @returns {DOM}
    */
-  off(eventName: string, eventHandler: EventListenerOrEventListenerObject): DOM {
+  off(eventName: string, eventHandler: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): DOM {
     let events = eventName.split(' ');
 
     events.forEach((event) => {
       if (this.elements == null) {
-        this.document.removeEventListener(event, eventHandler);
+        this.document.removeEventListener(event, eventHandler, options);
       }
       else {
         this.forEach((element) => {
-          element.removeEventListener(event, eventHandler);
+          element.removeEventListener(event, eventHandler, options);
         });
       }
     });

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -1,6 +1,6 @@
 import {UIContainer} from './components/uicontainer';
 import {DOM} from './dom';
-import {Component, ComponentConfig} from './components/component';
+import { Component, ComponentConfig, ViewModeChangedEventArgs } from './components/component';
 import {Container} from './components/container';
 import { SeekBar, SeekBarMarker } from './components/seekbar';
 import {NoArgs, EventDispatcher, CancelEventArgs} from './eventdispatcher';
@@ -627,6 +627,7 @@ export class UIInstanceManager {
     onSeeked: new EventDispatcher<SeekBar, NoArgs>(),
     onComponentShow: new EventDispatcher<Component<ComponentConfig>, NoArgs>(),
     onComponentHide: new EventDispatcher<Component<ComponentConfig>, NoArgs>(),
+    onComponentViewModeChanged: new EventDispatcher<Component<ComponentConfig>, ViewModeChangedEventArgs>(),
     onControlsShow: new EventDispatcher<UIContainer, NoArgs>(),
     onPreviewControlsHide: new EventDispatcher<UIContainer, CancelEventArgs>(),
     onControlsHide: new EventDispatcher<UIContainer, NoArgs>(),
@@ -735,6 +736,10 @@ export class UIInstanceManager {
    */
   get onRelease(): EventDispatcher<UIContainer, NoArgs> {
     return this.events.onRelease;
+  }
+
+  get onComponentViewModeChanged(): EventDispatcher<Component<ComponentConfig>, ViewModeChangedEventArgs> {
+    return this.events.onComponentViewModeChanged;
   }
 
   protected clearEventHandlers(): void {


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
This PR improves the auto-hide behavior of the UI when the dropdown menu of a `SelectBox` is shown.

Before the UI would auto-hide after the specified timeout regardless of whether a dropdown menu was currently shown or not. With the changes introduced in this PR, the UI will now stay visible and auto-hiding will be disabled whenever a dropdown is shown.

In order to do so, the following changes were implemented:
- allowed `Timeout` execution to be suspended, meaning all calls to `start` and `reset` will be ignored until timeout execution is resumed
- added a `ViewMode` to `Component` with the following values:
  -  `Persistent`: the component shall be visible at all times and UI auto-hiding shall be disabled
  - `Temporary`: the component may be hidden at any time
- modified the `SelectBox` to set its `ViewMode` to `Persistent` whenever and as long as the dropdown of the associated `select` tag is shown
- modified both `UIContainer` and `SettingsPanel` to suspend hide-timeout execution as long as there is at least one component with a `Persistent` view mode
- fixed a bug in Safari were the dropdown menu of a `SelectBox` would stay visible when the UI is hidden

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
