### PR TITLE
Also reset seekbar on `blur`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- `seekbar` not resetting seek position when losing focus on certain TVs
+
 ## [3.73.0] - 2024-09-06
 
 ### Added

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -780,8 +780,8 @@ export class SeekBar extends Component<SeekBarConfig> {
       }
     });
 
-    // Hide seek target indicator when mouse or finger leaves seekbar
-    seekBar.on('touchend mouseleave', (e: MouseEvent | TouchEvent) => {
+    // Hide seek target indicator when mouse or finger leaves seekbar or seekbar loses focus
+    seekBar.on('touchend mouseleave blur', (e: MouseEvent | TouchEvent) => {
       e.preventDefault();
 
       this.setSeekPosition(0);


### PR DESCRIPTION
## Description
Certain devices / some TVs don't seem to emit a `mouseleave` event when navigating with a remote-control or keyboard, causing the seekbar state to not get reset when it loses focus. Adding the `blur` event to the seekbar reset event-listener fixes the issue.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
