### PR TITLE
Improve Seekbar mouse handling

### DIFF
--- a/src/scss/skin-super-modern/components/_seekbar.scss
+++ b/src/scss/skin-super-modern/components/_seekbar.scss
@@ -46,14 +46,18 @@ $seekbar-height: .3125em;
     @include hidden;
     @include focusable;
 
-    border-radius: 1em;
     cursor: pointer;
     font-size: 1em;
     height: $seekbar-height;
     margin: calc((1em - $seekbar-height) / 2) 0;
-    overflow: hidden;
     position: relative;
     width: 100%;
+
+    .#{$prefix}-seekbar-bars {
+      @extend %bar;
+      border-radius: 1em;
+      overflow: hidden;
+    }
 
     .#{$prefix}-seekbar-backdrop {
       @extend %bar;

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -32,12 +32,6 @@ export interface SeekBarConfig extends ComponentConfig {
    */
   vertical?: boolean;
   /**
-   * If set to true the seekBarPlaybackPositionMarker will be rendered
-   * directly inside the seekbar container. Necessary when using the super-modern-ui skin
-   * Default: false
-   */
-  renderSeekBarPlaybackPositionMarkerInOuterSeekBar?: boolean;
-  /**
    * The interval in milliseconds in which the playback position on the seek bar will be updated. The shorter the
    * interval, the smoother it looks and the more resource intense it is. The update interval will be kept as steady
    * as possible to avoid jitter.
@@ -171,7 +165,6 @@ export class SeekBar extends Component<SeekBarConfig> {
       snappingRange: 1,
       enableSeekPreview: true,
       snappingEnabled: true,
-      renderSeekBarPlaybackPositionMarkerInOuterSeekBar: false,
     }, this.config);
 
     this.label = this.config.label;
@@ -668,6 +661,10 @@ export class SeekBar extends Component<SeekBarConfig> {
     });
     this.seekBar = seekBar;
 
+    const seekBarBarsContainer = new DOM('div', {
+      'class': this.prefixCss('seekbar-bars'),
+    });
+
     // Indicator that shows the buffer fill level
     let seekBarBufferLevel = new DOM('div', {
       'class': this.prefixCss('seekbar-bufferlevel'),
@@ -703,12 +700,10 @@ export class SeekBar extends Component<SeekBarConfig> {
     });
     this.seekBarMarkersContainer = seekBarChapterMarkersContainer;
 
-    seekBar.append(this.seekBarBackdrop, this.seekBarBufferPosition, this.seekBarSeekPosition,
+    seekBarBarsContainer.append(this.seekBarBackdrop, this.seekBarBufferPosition, this.seekBarSeekPosition,
       this.seekBarPlaybackPosition, this.seekBarMarkersContainer);
 
-    if (!this.config.renderSeekBarPlaybackPositionMarkerInOuterSeekBar) {
-      seekBar.append(this.seekBarPlaybackPositionMarker);
-    }
+    seekBar.append(seekBarBarsContainer, this.seekBarPlaybackPositionMarker);
 
     let seeking = false;
 
@@ -747,14 +742,12 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.onSeekedEvent(targetPercentage);
     };
 
-    let domElementToListen: DOM = this.config.renderSeekBarPlaybackPositionMarkerInOuterSeekBar ? seekBarContainer : seekBar;
-
     // A seek always start with a touchstart or mousedown directly on the seekbar.
     // To track a mouse seek also outside the seekbar (for touch events this works automatically),
     // so the user does not need to take care that the mouse always stays on the seekbar, we attach the mousemove
     // and mouseup handlers to the whole document. A seek is triggered when the user lifts the mouse key.
     // A seek mouse gesture is thus basically a click with a long time frame between down and up events.
-    domElementToListen.on('touchstart mousedown', (e: MouseEvent | TouchEvent) => {
+    seekBar.on('touchstart mousedown', (e: MouseEvent | TouchEvent) => {
       let isTouchEvent = BrowserUtils.isTouchSupported && this.isTouchEvent(e);
 
       // Prevent selection of DOM elements (also prevents mousedown if current event is touchstart)
@@ -776,7 +769,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     });
 
     // Display seek target indicator when mouse hovers or finger slides over seekbar
-    domElementToListen.on('touchmove mousemove', (e: MouseEvent | TouchEvent) => {
+    seekBar.on('touchmove mousemove', (e: MouseEvent | TouchEvent) => {
       e.preventDefault();
 
       if (seeking) {
@@ -794,7 +787,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     });
 
     // Hide seek target indicator when mouse or finger leaves seekbar
-    domElementToListen.on('touchend mouseleave', (e: MouseEvent | TouchEvent) => {
+    seekBar.on('touchend mouseleave', (e: MouseEvent | TouchEvent) => {
       e.preventDefault();
 
       this.setSeekPosition(0);
@@ -808,10 +801,6 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     if (this.label) {
       seekBarContainer.append(this.label.getDomElement());
-    }
-
-    if (this.config.renderSeekBarPlaybackPositionMarkerInOuterSeekBar) {
-      seekBarContainer.append(seekBarPlaybackPositionMarker);
     }
 
     return seekBarContainer;

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -294,7 +294,7 @@ export class SeekBar extends Component<SeekBarConfig> {
         // Update playback position only in paused state or in the initial startup state where player is neither
         // paused nor playing. Playback updates are handled in the Timeout below.
         const isInInitialStartupState = this.config.smoothPlaybackPositionUpdateIntervalMs === SeekBar.SMOOTH_PLAYBACK_POSITION_UPDATE_DISABLED
-            || forceUpdate || player.isPaused();
+          || forceUpdate || player.isPaused();
         const isNeitherPausedNorPlaying = player.isPaused() === player.isPlaying();
 
         if ((isInInitialStartupState || isNeitherPausedNorPlaying) && !this.isSeeking()) {
@@ -1103,7 +1103,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     this.refreshPlaybackPosition();
   }
 
- /**
+  /**
    * Checks if TouchEvent is supported.
    * @returns {boolean} true if TouchEvent not undefined, else false
    */

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -242,10 +242,17 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     uimanager.onControlsShow.subscribe(() => {
       this.isUiShown = true;
+      if (!player.isLive() && !this.smoothPlaybackPositionUpdater.isActive()) {
+        playbackPositionHandler(null, true);
+        this.smoothPlaybackPositionUpdater.start();
+      }
     });
 
     uimanager.onControlsHide.subscribe(() => {
       this.isUiShown = false;
+      if (this.smoothPlaybackPositionUpdater.isActive()) {
+        this.smoothPlaybackPositionUpdater.clear();
+      }
     });
 
     let isPlaying = false;
@@ -323,12 +330,12 @@ export class SeekBar extends Component<SeekBarConfig> {
       scrubbing = false;
     };
 
-    let onPlayerSeeked = (event: PlayerEventBase = null, forceUpdate: boolean = false ) => {
+    let onPlayerSeeked = (event: PlayerEventBase = null) => {
       isPlayerSeeking = false;
       this.setSeeking(false);
 
       // update playback position when a seek has finished
-      playbackPositionHandler(event, forceUpdate);
+      playbackPositionHandler(event, true);
     };
 
     let restorePlayingState = function () {

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -492,7 +492,7 @@ export namespace UIFactory {
               timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
               hideInLivePlayback: true,
             }),
-            new SeekBar({ label: new SeekBarLabel(), renderSeekBarPlaybackPositionMarkerInOuterSeekBar: true }),
+            new SeekBar({ label: new SeekBarLabel() }),
             new PlaybackTimeLabel({
               timeLabelMode: PlaybackTimeLabelMode.TotalTime,
               cssClasses: ['text-right'],
@@ -598,7 +598,7 @@ export namespace UIFactory {
               timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
               hideInLivePlayback: true,
             }),
-            new SeekBar({ label: new SeekBarLabel(), renderSeekBarPlaybackPositionMarkerInOuterSeekBar: true }),
+            new SeekBar({ label: new SeekBarLabel() }),
             new PlaybackTimeLabel({
               timeLabelMode: PlaybackTimeLabelMode.TotalTime,
               cssClasses: ['text-right'],
@@ -610,7 +610,7 @@ export namespace UIFactory {
           components: [
             new PlaybackToggleButton(),
             new VolumeToggleButton(),
-            new VolumeSlider({ renderSeekBarPlaybackPositionMarkerInOuterSeekBar: true }),
+            new VolumeSlider(),
             new Spacer(),
             new PictureInPictureToggleButton(),
             new AirPlayToggleButton(),


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Revert Seekbar to its current state on development and apply new style by adding a new container element for all bars.

### Problem
Currently, the mouse interactions are bound to the container element of the seekbar. This comes with a problem that the mouse events are also applied to the `SeekbarLabel`, which should not be the case. Also, the hitbox for seeking becomes smaller and the playback position marker no longer acts as a seeking handle.

### Changes
To fix this problem while keeping the new design approach, I added another container around all 'bars' inside the seekbar. Therefore the mouse events can stay where they are and this new container can be used for the new styling (mainly for the rounded corners)

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **A general entry will be added at the end**
