### PR TITLE
Fix seek preview thumbnails exceeding UI dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Seek preview thumbnails exceeding the UI dimensions when default size is increased
+
 ## [3.75.0] - 2024-11-19
 
 ### Fixed

--- a/spec/components/seekbar.spec.ts
+++ b/spec/components/seekbar.spec.ts
@@ -114,7 +114,7 @@ describe('SeekBar', () => {
 
         jest.spyOn(playerMock, 'getSeekableRange').mockImplementation(() => ({start: 26, end: 30}));
 
-        seekbar['onSeekPreviewEvent'](40, true)
+        seekbar['onSeekPreviewEvent'](40, 100, true);
 
         playerMock.eventEmitter.fireSegmentRequestFinished();
 
@@ -127,19 +127,19 @@ describe('SeekBar', () => {
       it('will update the scrubber location after a successful segment request download and the user is not scrubbing', () => {
         jest.spyOn(playerMock, 'getSeekableRange').mockImplementation(() => ({start: 26, end: 30}));
 
-        seekbar['onSeekPreviewEvent'](18, false)
+        seekbar['onSeekPreviewEvent'](18, 100, false);
 
         playerMock.eventEmitter.fireSegmentRequestFinished();
 
         expect(setPlaybackPositionSpy).toHaveBeenLastCalledWith(18);
-        expect(setBufferPositionSpy).toHaveBeenLastCalledWith(18)
+        expect(setBufferPositionSpy).toHaveBeenLastCalledWith(18);
       });
     });
   });
 
   describe('group playback', () => {
     beforeEach(() => {
-      jest.spyOn(playerMock, 'getDuration').mockReturnValue(0)
+      jest.spyOn(playerMock, 'getDuration').mockReturnValue(0);
       seekbar.configure(playerMock, uiInstanceManagerMock);
     });
 

--- a/spec/components/seekbarlabel.spec.ts
+++ b/spec/components/seekbarlabel.spec.ts
@@ -94,4 +94,97 @@ describe('SeekBarLabel', () => {
       });
     });
   });
+
+  describe("calculates correct values for thumbnail positioning", () => {
+    const uiContainerBoundingRect = {
+      x: 200,
+      y: 150,
+      width: 1600,
+      height: 900,
+      top: 150,
+      right: 1800,
+      bottom: 1050,
+      left: 200,
+    } as DOMRect;
+
+    let containerGetDomElementMock: () => jest.Mocked<DOM>;
+    let caretGetDomElementMock: () => jest.Mocked<DOM>;
+
+    beforeEach(() => {
+      containerGetDomElementMock = jest
+        .fn()
+        .mockReturnValue(MockHelper.generateDOMMock());
+
+      containerGetDomElementMock().get = jest.fn().mockReturnValue({
+        parentElement: jest.fn().mockReturnValue({
+          getBoundingClientRect: jest.fn(),
+        }),
+      });
+
+      caretGetDomElementMock = jest.fn().mockReturnValue(MockHelper.generateDOMMock());
+
+      seekbarLabel["container"].getDomElement = containerGetDomElementMock;
+      seekbarLabel["caret"].getDomElement = caretGetDomElementMock;
+    });
+
+    it("when thumbnail within UI container bounds", () => {
+      const labelRect = {
+        x: 400,
+        y: 700,
+        width: 200,
+        height: 120,
+        top: 700,
+        right: 600,
+        bottom: 820,
+        left: 400,
+      } as DOMRect;
+
+      containerGetDomElementMock().get(0).parentElement!.getBoundingClientRect =
+        jest.fn().mockReturnValue(labelRect);
+
+      seekbarLabel.setPositionInBounds(100, uiContainerBoundingRect);
+
+      expect(caretGetDomElementMock().css).toHaveBeenCalledWith('transform', null);
+    });
+
+    it("when thumbnail would overflow UI container leftside", () => {
+      const labelRect = {
+        x: 180,
+        y: 700,
+        width: 200,
+        height: 120,
+        top: 700,
+        right: 380,
+        bottom: 820,
+        left: 180,
+      } as DOMRect;
+
+      containerGetDomElementMock().get(0).parentElement!.getBoundingClientRect =
+        jest.fn().mockReturnValue(labelRect);
+
+      seekbarLabel.setPositionInBounds(100, uiContainerBoundingRect);
+
+      expect(seekbarLabel.getDomElement().css).toHaveBeenCalledWith('left', '120px');
+    });
+
+    it("when thumbnail would overflow UI container rightside", () => {
+      const labelRect = {
+        x: 1650,
+        y: 700,
+        width: 200,
+        height: 120,
+        top: 700,
+        right: 1850,
+        bottom: 820,
+        left: 1650,
+      } as DOMRect;
+
+      containerGetDomElementMock().get(0).parentElement!.getBoundingClientRect =
+        jest.fn().mockReturnValue(labelRect);
+
+      seekbarLabel.setPositionInBounds(100, uiContainerBoundingRect);
+
+      expect(seekbarLabel.getDomElement().css).toHaveBeenCalledWith('left', '50px');
+    });
+  });
 });

--- a/spec/components/seekbarlabel.spec.ts
+++ b/spec/components/seekbarlabel.spec.ts
@@ -2,6 +2,7 @@ import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 import { UIInstanceManager } from '../../src/ts/uimanager';
 import { SeekBarLabel } from '../../src/ts/components/seekbarlabel';
 import { SeekPreviewEventArgs } from '../../src/ts/components/seekbar';
+import { DOM } from '../../src/ts/dom';
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;

--- a/src/scss/skin-modern/components/_seekbarlabel.scss
+++ b/src/scss/skin-modern/components/_seekbarlabel.scss
@@ -30,7 +30,7 @@
     border-top-color: $color-primary;
     border-width: .5em;
     height: 0;
-    margin-left: -1em;
+    margin-left: -.5em;
     pointer-events: none;
     position: absolute;
     top: 100%;

--- a/src/scss/skin-modern/components/_seekbarlabel.scss
+++ b/src/scss/skin-modern/components/_seekbarlabel.scss
@@ -21,6 +21,9 @@
 
   > .#{$prefix}-container-wrapper {
     @extend %center-on-left-edge;
+
+    padding-left: 1em;
+    padding-right: 1em;
   }
 
   // bottom arrow from http://www.cssarrowplease.com/

--- a/src/scss/skin-modern/components/_seekbarlabel.scss
+++ b/src/scss/skin-modern/components/_seekbarlabel.scss
@@ -23,24 +23,22 @@
     @extend %center-on-left-edge;
   }
 
+  // bottom arrow from http://www.cssarrowplease.com/
+  .#{$prefix}-seekbar-label-caret {
+    border: solid transparent;
+    border-color: transparent;
+    border-top-color: $color-primary;
+    border-width: .5em;
+    height: 0;
+    margin-left: -1em;
+    pointer-events: none;
+    position: absolute;
+    top: 100%;
+    width: 0;
+  }
+
   .#{$prefix}-seekbar-label-inner {
     border-bottom: .2em solid $color-primary;
-
-    // bottom arrow from http://www.cssarrowplease.com/
-    &::after {
-      border: solid transparent;
-      border-color: transparent;
-      border-top-color: $color-primary;
-      border-width: .5em;
-      content: ' ';
-      height: 0;
-      left: 50%;
-      margin-left: -.5em;
-      pointer-events: none;
-      position: absolute;
-      top: 100%;
-      width: 0;
-    }
 
     > .#{$prefix}-container-wrapper {
       position: relative;

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -137,9 +137,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
   };
 
   public setPositionInBounds(seekPositionPx: number, bounds: DOMRect) {
-    this.getDomElement().css({
-      'left': seekPositionPx + 'px',
-    });
+    this.getDomElement().css('left', seekPositionPx + 'px');
 
     // Check parent container as it has a padding that needs to be considered
     const labelBounding = this.container.getDomElement().get(0).parentElement.getBoundingClientRect();

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -152,17 +152,11 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     }
 
     if (preventOverflowOffset !== 0) {
-      this.getDomElement().css({
-        left: seekPositionPx - preventOverflowOffset + 'px',
-      });
+      this.getDomElement().css('left', seekPositionPx - preventOverflowOffset + 'px');
 
-      this.caret.getDomElement().css({
-        transform: `translateX(${preventOverflowOffset}px)`,
-      });
+      this.caret.getDomElement().css('transform', `translateX(${preventOverflowOffset}px)`);
     } else {
-      this.caret.getDomElement().css({
-        transform: `translateX(${0}px)`,
-      });
+      this.caret.getDomElement().css('transform', null);
     }
   }
 

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -141,16 +141,14 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       'left': seekPositionPx + 'px',
     });
 
-    // TODO move into CSS
-    const overflowMargin = 8;
-
-    const labelBounding = this.container.getDomElement().get(0).getBoundingClientRect();
+    // Check parent container as it has a padding that needs to be considered
+    const labelBounding = this.container.getDomElement().get(0).parentElement.getBoundingClientRect();
 
     let preventOverflowOffset = 0;
-    if (labelBounding.right + overflowMargin > bounds.right) {
-      preventOverflowOffset = labelBounding.right - bounds.right + overflowMargin;
-    } else if (labelBounding.left - overflowMargin < bounds.left) {
-      preventOverflowOffset = labelBounding.left - bounds.left - overflowMargin;
+    if (labelBounding.right > bounds.right) {
+      preventOverflowOffset = labelBounding.right - bounds.right;
+    } else if (labelBounding.left < bounds.left) {
+      preventOverflowOffset = labelBounding.left - bounds.left;
     }
 
     if (preventOverflowOffset !== 0) {

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -136,7 +136,11 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     }
   };
 
-  public ensureWithinBounds = (bounds: DOMRect) => {
+  public setPositionInBounds(seekPositionPx: number, bounds: DOMRect) {
+    this.getDomElement().css({
+      'left': seekPositionPx + 'px',
+    });
+
     // TODO move into CSS
     const overflowMargin = 8;
 
@@ -151,7 +155,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
 
     if (preventOverflowOffset !== 0) {
       this.getDomElement().css({
-        transform: `translateX(${-preventOverflowOffset}px)`,
+        left: seekPositionPx - preventOverflowOffset + 'px',
       });
 
       this.caret.getDomElement().css({

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -136,6 +136,34 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     }
   };
 
+  public ensureWithinBounds = (bounds: DOMRect) => {
+    // TODO move into CSS
+    const overflowMargin = 8;
+
+    const labelBounding = this.container.getDomElement().get(0).getBoundingClientRect();
+
+    let preventOverflowOffset = 0;
+    if (labelBounding.right + overflowMargin > bounds.right) {
+      preventOverflowOffset = labelBounding.right - bounds.right + overflowMargin;
+    } else if (labelBounding.left - overflowMargin < bounds.left) {
+      preventOverflowOffset = labelBounding.left - bounds.left - overflowMargin;
+    }
+
+    if (preventOverflowOffset !== 0) {
+      this.getDomElement().css({
+        transform: `translateX(${-preventOverflowOffset}px)`,
+      });
+
+      this.caret.getDomElement().css({
+        transform: `translateX(${preventOverflowOffset}px)`,
+      });
+    } else {
+      this.caret.getDomElement().css({
+        transform: `translateX(${0}px)`,
+      });
+    }
+  }
+
   /**
    * Sets arbitrary text on the label.
    * @param text the text to show on the label

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -36,6 +36,8 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
   private appliedMarkerCssClasses: string[] = [];
   private player: PlayerAPI;
   private uiManager: UIInstanceManager;
+  private readonly container: Container<ContainerConfig>;
+  private readonly caret: Label<LabelConfig>;
 
   constructor(config: SeekBarLabelConfig = {}) {
     super(config);
@@ -45,17 +47,22 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     this.thumbnail = new Component({ cssClasses: ['seekbar-thumbnail'], role: 'img' });
     this.thumbnailImageLoader = new ImageLoader();
 
+    this.container = new Container({
+      components: [
+        this.thumbnail,
+        new Container({
+          components: [this.titleLabel, this.timeLabel],
+          cssClass: 'seekbar-label-metadata',
+        }),
+      ],
+      cssClass: 'seekbar-label-inner',
+    });
+
+    this.caret = new Label({ cssClasses: ['seekbar-label-caret'] });
+
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-seekbar-label',
-      components: [new Container({
-        components: [
-          this.thumbnail,
-          new Container({
-            components: [this.titleLabel, this.timeLabel],
-            cssClass: 'seekbar-label-metadata',
-          })],
-        cssClass: 'seekbar-label-inner',
-      })],
+      components: [this.container, this.caret],
       hidden: true,
     }, this.config);
   }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Fix seek preview thumbnails exceeding the UI dimensions.

Fixes https://github.com/bitmovin/bitmovin-player-ui/issues/569

## Changes
- set the seekPreview position inside of the label, and pass the value in px (instead of %)
- check if the seekprevew label overflows the UI, and if so, limit its movement
- add a padding around the seekbarlabel wrapper, to keep the thumbnail a certain distance from the UI edges
- use span element instead of ::after for caret. This was required to "fix" the caret position to the cursor

Note: These changes cause a "Forced Reflow" (layout re-evaluation) when seek preview is active. However, the performance impact seems to be minimal, as only a small part of the layout tree needs to be re-evaluated.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
