### PR TITLE
Fix styling for the initially displayed CEA-608 cue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Unexpected styling for the initially displayed cue when enabling CEA-608 captions 
+
 ## [3.79.0] - 2025-01-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Unexpected styling for the initially displayed cue when enabling CEA-608 captions 
+- Unexpected styling for the initially displayed cue when enabling CEA-608 captions
+- Vertical alignment of CEA-608 captions on small player sizes
 
 ## [3.79.0] - 2025-01-08
 

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -27,6 +27,7 @@
       display: inline-block;
       font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace;
       text-transform: uppercase;
+      vertical-align: bottom;
 
       // sass-lint:disable force-pseudo-nesting nesting-depth
       &:nth-child(1n-1)::after {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -347,7 +347,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     });
 
     player.on(player.exports.PlayerEvent.SourceUnloaded, reset);
-    player.on(player.exports.PlayerEvent.SubtitleEnabled, reset);
+    player.on(player.exports.PlayerEvent.SubtitleEnable, reset);
     player.on(player.exports.PlayerEvent.SubtitleDisabled, reset);
   }
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Issue: PW-22216

When enabling CEA captions within the time range of a cue, this cue is not styled as expected.

This is because we reset the CEA caption setup (mainly adding a `cea-608` class to the subtitle overlay that causes caption styling to be applied) on a `subtitleenabled` event. The CEA caption setup gets done on a `cueenter` event, but that one may arrive before.

The event flow is as follows:
1. `subtitleenable`
2. `cueenter`
3. `subtitleenabled`

Thus, we should reset the CEA caption setup on `subtitleenable`, to get a clean slate for whatever subtitle format arrives in the following `cueenter`.

Furthermore, there was a slight issue with vertical alignment of caption cues when the player size was rather small.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
