### PR TITLE
Fix positioning for multiple cues on the same line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Positioning of CEA-608 caption cues when multiple cues are displayed on the same line
+
 ## [3.80.0] - 2025-01-08
 
 ### Fixed

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -26,6 +26,7 @@
     .#{$prefix}-ui-subtitle-label {
       display: inline-block;
       font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace;
+      position: absolute;
       text-transform: uppercase;
       vertical-align: bottom;
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -325,7 +325,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
 
       label.getDomElement().css({
-        'margin-left': `${event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET}%`,
+        'left': `${event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET}%`,
         'font-size': `${fontSize}px`,
         'letter-spacing': `${fontLetterSpacing}px`,
       });


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Issue: PW-22216

### Problem

When multiple CEA-608 caption cues are displayed on the same line at the same time, the horizontal positioning is wrong: The left-offset is applied from the previous element, instead of the subtitle overlay frame.

This broke in https://github.com/bitmovin/bitmovin-player-ui/pull/665

### Changes
- Re-enable absolute positioning for CEA caption labels
- Apply a `left` offset instead of a `margin-left` for horizontal positioning.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
