### PR TITLE
Fix JS exception when disabling smooth playback position updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+## Fixed
+- Exception when disabling smooth playback position updating by setting `SeekbarConfig.smoothPlaybackPositionUpdateIntervalMs` to `-1`
+
 ## [3.82.0] - 2025-01-13
 
 ### Added

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -246,7 +246,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     uimanager.onControlsShow.subscribe(() => {
       this.isUiShown = true;
-      if (!player.isLive() && !this.smoothPlaybackPositionUpdater.isActive()) {
+      if (this.smoothPlaybackPositionUpdater && !player.isLive() && !this.smoothPlaybackPositionUpdater.isActive()) {
         playbackPositionHandler(null, true);
         this.smoothPlaybackPositionUpdater.start();
       }
@@ -254,7 +254,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     uimanager.onControlsHide.subscribe(() => {
       this.isUiShown = false;
-      if (this.smoothPlaybackPositionUpdater.isActive()) {
+      if (this.smoothPlaybackPositionUpdater && this.smoothPlaybackPositionUpdater.isActive()) {
         this.smoothPlaybackPositionUpdater.clear();
       }
     });


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
When disabling the SmoothPlaybackPositionUpdater by setting the `SeekbarConfig.smoothPlaybackPositionUpdateIntervalMs` to `-1` the UI breaks due to a JS exception. This is used per default in the cast receiver variant.

## Manually Testing
You can easily manually test this by selecting the cast receiver UI in the playground.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
