### PR TITLE
Subtitle font color customization not working on Comcast STBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+## Fixed
+- Setting font color in subtitle customization settings not working on Comcast X1 Set-Top Boxes and other older WebKit-based platforms
+
 ## [3.84.0] - 2025-01-15
 
 ### Added

--- a/src/scss/skin-modern/components/subtitlesettings/_subtitleoverlay-settings.scss
+++ b/src/scss/skin-modern/components/subtitlesettings/_subtitleoverlay-settings.scss
@@ -45,6 +45,7 @@
       &.#{$prefix}-fontcolor-#{$color-name}#{$opacity-name} {
         .#{$prefix}-ui-subtitle-label {
           color: transparentize($color-value, 1 - $opacity-value);
+          -WebKit-text-fill-color: transparentize($color-value, 1 - $opacity-value);
         }
       }
     }


### PR DESCRIPTION
## Description
Setting the font color in the subtitle customization settings did not work on Comcast Set-Top Boxes and older platforms using old WebKit versions.

This PR adds the use of `-WebKit-text-fill-color` for these platforms, which resolves the problem.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
