### PR TITLE
Upgrade github actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
     steps:
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
       - name: Cache node modules
         id: cache-nodemodules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -46,7 +46,7 @@ jobs:
         run: tar -czvf artifact.tar.gz dist
         shell: bash
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             ${{ github.workspace }}/artifact.tar.gz


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Fixes build error:

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
```

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [/] `CHANGELOG` entry not needed
