### PR TITLE
Upgrade release workflow to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             const { version } = require('./package.json')
             core.setOutput('packageJsonVersion', version)
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Chores
+- Update github actions to v4
+
 ## [3.84.0] - 2025-01-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1073,7 +1073,6 @@ Version 2.0 of the UI framework is built for player 7.1. If absolutely necessary
 ## 1.0.0 (2017-02-03)
 - First release
 
-[3.86.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.84.0...v3.86.0
 [3.85.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.84.0...v3.85.0
 [3.84.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.83.0...v3.84.0
 [3.83.0]: https://github.com/bitmovin/bitmovin-player-ui/compare/v3.82.0...v3.83.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Chores
 - Update github actions to v4
 
+## [3.85.0] - 2025-01-16
+
+### Chores
+- Update
+
 ## [3.84.0] - 2025-01-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.85.0] - 2025-01-16
 
 ### Chores
-- Update
+- Update assets to Bitmovin CDN
 
 ## [3.84.0] - 2025-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Chores
-- Update github actions to v4
+### Changed
+- Chore: Update github actions to v4
 
 ## [3.85.0] - 2025-01-16
 
-### Chores
-- Update assets to Bitmovin CDN
+### Changed
+- Chore: Update assets to use Bitmovin CDN
 
 ## [3.84.0] - 2025-01-15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "3.86.0",
+  "version": "3.85.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmovin-player-ui",
-      "version": "3.86.0",
+      "version": "3.85.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "3.86.0",
+  "version": "3.85.0",
   "description": "Bitmovin Player UI Framework",
   "main": "./dist/js/framework/main.js",
   "types": "./dist/js/framework/main.d.ts",


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
The previous [PR](https://github.com/bitmovin/bitmovin-player-ui/pull/686) updated the actions for the CI build workflow, but the release workflow is still failing.
Since the release failed, we have an inconsistent release version, so we need to downgrade the package version again and remove the tag.
Furthermore, it looks like a release without changelog causes an inconsistent changelog, so we need to fix that as well as another PR was also recently merged without any entries: https://github.com/bitmovin/bitmovin-player-ui/pull/680.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
