### PR TITLE
Stop release early when no changelog entry is added

### DIFF
--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -12,6 +12,9 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure Changelog
+        run: gh pr view ${{github.event.pull_request.number}} --json files -q '.files[].path' | grep CHANGELOG.md
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Ensure Changelog
       shell: bash
       run: |
-        if gh pr view ${{github.event.pull_request.number}} --json files -q '.files[].path' | grep CHANGELOG.md; then
+        changes=$(gh pr view ${{github.event.pull_request.number}} --json files -q '.files[].path')
+        if echo $changes | grep -q CHANGELOG.md; then
           echo "CHANGELOG.md has been updated"
           echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -8,13 +8,27 @@ on:
       - develop
 
 jobs:
-  trigger-ui-release:
+  verify-changelog:
     if: github.event.pull_request.merged == true
+    outputs:
+      HAS_CHANGELOG: ${{ steps.ensure-changelog.outputs.HAS_CHANGELOG }}
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure Changelog
-        run: gh pr view ${{github.event.pull_request.number}} --json files -q '.files[].path' | grep CHANGELOG.md
+    - name: Ensure Changelog
+      shell: bash
+      run: |
+        if gh pr view ${{github.event.pull_request.number}} --json files -q '.files[].path' | grep CHANGELOG.md; then
+          echo "CHANGELOG.md has been updated"
+          echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT
+        else
+          echo "CHANGELOG.md has not been updated, skipping release"
+        fi
 
+  trigger-ui-release:
+    needs: verify-changelog
+    if: ${{ needs.verify-changelog.outputs.HAS_CHANGELOG }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Chore: Skip releasing a new version when no changelog entry was added
+
 ## [3.87.0] - 2025-02-20
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.87.0] - 2025-02-20
 
-## Fixed
+### Fixed
 - Setting font color in subtitle customization settings not working on Comcast X1 Set-Top Boxes and other older WebKit-based platforms
 
 ## [3.86.0] - 2025-02-20


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Merging a PR without a changelog entry could get us into an inconsistent state, as we will still push a tag and try to release, but eventually fail trying to update the version in the Changelog file.

This change allows us to merge "chore" type PRs without a changelog, skipping a release.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
