### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           git config --global user.name 'Automated Release'
           git config --global user.email 'release-automation@bitmovin.com'
+          git fetch origin develop
           changes=$(git diff --name-only origin/develop...origin/feature/fix-release)
           if echo $changes | grep -q CHANGELOG.md; then
             echo "CHANGELOG.md has been updated"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,24 @@ on:
   workflow_call:
 
 jobs:
+  verify-changelog:
+    outputs:
+      HAS_CHANGELOG: ${{ steps.ensure-changelog.outputs.HAS_CHANGELOG }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure Changelog
+        shell: bash
+        run: |
+          changes=$(git diff --name-only $GITHUB_BASE_REF)
+          if echo $changes | grep -q CHANGELOG.md; then
+            echo "CHANGELOG.md has been updated"
+            echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT
+          else
+            echo "CHANGELOG.md has not been updated, skipping release"
+          fi
+        with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+
   test_and_build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           git config --global user.name 'Automated Release'
           git config --global user.email 'release-automation@bitmovin.com'
-          git fetch origin develop
           changes=$(git diff --name-only origin/develop...origin/feature/fix-release)
           if echo $changes | grep -q CHANGELOG.md; then
             echo "CHANGELOG.md has been updated"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git config --global user.name 'Automated Release'
           git config --global user.email 'release-automation@bitmovin.com'
-          changes=$(git diff --name-only develop...feature/fix-release)
+          changes=$(git diff --name-only origin/develop...origin/feature/fix-release)
           if echo $changes | grep -q CHANGELOG.md; then
             echo "CHANGELOG.md has been updated"
             echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git config --global user.name 'Automated Release'
           git config --global user.email 'release-automation@bitmovin.com'
-          changes=$(git diff --name-only $GITHUB_BASE_REF)
+          changes=$(git diff --name-only develop)
           if echo $changes | grep -q CHANGELOG.md; then
             echo "CHANGELOG.md has been updated"
             echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       HAS_CHANGELOG: ${{ steps.ensure-changelog.outputs.HAS_CHANGELOG }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Ensure Changelog
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Ensure Changelog
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git config --global user.name 'Automated Release'
           git config --global user.email 'release-automation@bitmovin.com'
-          changes=$(git diff --name-only develop)
+          changes=$(git diff --name-only develop...feature/fix-release)
           if echo $changes | grep -q CHANGELOG.md; then
             echo "CHANGELOG.md has been updated"
             echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,29 +10,6 @@ on:
   workflow_call:
 
 jobs:
-  verify-changelog:
-    outputs:
-      HAS_CHANGELOG: ${{ steps.ensure-changelog.outputs.HAS_CHANGELOG }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Ensure Changelog
-        shell: bash
-        run: |
-          git config --global user.name 'Automated Release'
-          git config --global user.email 'release-automation@bitmovin.com'
-          changes=$(git diff --name-only origin/develop...origin/feature/fix-release)
-          if echo $changes | grep -q CHANGELOG.md; then
-            echo "CHANGELOG.md has been updated"
-            echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT
-          else
-            echo "CHANGELOG.md has not been updated, skipping release"
-          fi
-
   test_and_build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Ensure Changelog
         shell: bash
         run: |
+          git config --global user.name 'Automated Release'
+          git config --global user.email 'release-automation@bitmovin.com'
           changes=$(git diff --name-only $GITHUB_BASE_REF)
           if echo $changes | grep -q CHANGELOG.md; then
             echo "CHANGELOG.md has been updated"
@@ -25,8 +27,6 @@ jobs:
           else
             echo "CHANGELOG.md has not been updated, skipping release"
           fi
-        with:
-          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
   test_and_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Ensure Changelog
       shell: bash

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -17,13 +17,15 @@ jobs:
     - name: Ensure Changelog
       shell: bash
       run: |
-        changes=$(gh pr view ${{github.event.pull_request.number}} --json files -q '.files[].path')
+        changes=$(git diff --name-only $GITHUB_BASE_REF)
         if echo $changes | grep -q CHANGELOG.md; then
           echo "CHANGELOG.md has been updated"
           echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT
         else
           echo "CHANGELOG.md has not been updated, skipping release"
         fi
+      with:
+        ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
   trigger-ui-release:
     needs: verify-changelog

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -14,6 +14,9 @@ jobs:
       HAS_CHANGELOG: ${{ steps.ensure-changelog.outputs.HAS_CHANGELOG }}
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Ensure Changelog
       shell: bash
       run: |

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -17,6 +17,8 @@ jobs:
     - name: Ensure Changelog
       shell: bash
       run: |
+        git config --global user.name 'Automated Release'
+        git config --global user.email 'release-automation@bitmovin.com'
         changes=$(git diff --name-only $GITHUB_BASE_REF)
         if echo $changes | grep -q CHANGELOG.md; then
           echo "CHANGELOG.md has been updated"
@@ -24,8 +26,6 @@ jobs:
         else
           echo "CHANGELOG.md has not been updated, skipping release"
         fi
-      with:
-        ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
   trigger-ui-release:
     needs: verify-changelog

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         git config --global user.name 'Automated Release'
         git config --global user.email 'release-automation@bitmovin.com'
-        changes=$(git diff --name-only $GITHUB_BASE_REF)
+        changes=$(git diff --name-only ${{github.event.pull_request.base.ref}})
         if echo $changes | grep -q CHANGELOG.md; then
           echo "CHANGELOG.md has been updated"
           echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Chore: Skip releasing a new version when no changelog entry was added
+- Chore: Fix release workflow
 
 ## [3.87.0] - 2025-02-20
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

The PR https://github.com/bitmovin/bitmovin-player-ui/pull/688 broke the release workflow.

### Changes
Instead of `gh`, use git directly with existing key.

### Tests

Temporarily added the same step to the CI workflow:
- w/o changelog entry: https://github.com/bitmovin/bitmovin-player-ui/actions/runs/13502493628/job/37724151331#step:3:13
- with changelog entry: https://github.com/bitmovin/bitmovin-player-ui/actions/runs/13503723044/job/37728300549#step:3:13


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
