### PR TITLE
Fix release - again

### DIFF
--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -16,21 +16,19 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: Ensure Changelog
       shell: bash
       run: |
-        git config --global user.name 'Automated Release'
-        git config --global user.email 'release-automation@bitmovin.com'
-        changes=$(git diff --name-only ${{github.event.pull_request.base.ref}})
+        changes=$(gh pr view 680 --json files -q '.files[].path')
         if echo $changes | grep -q CHANGELOG.md; then
           echo "CHANGELOG.md has been updated"
           echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT
         else
           echo "CHANGELOG.md has not been updated, skipping release"
         fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   trigger-ui-release:
     needs: verify-changelog

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Ensure Changelog
       shell: bash
       run: |
-        changes=$(gh pr view 680 --json files -q '.files[].path')
+        changes=$(gh pr view ${{github.event.pull_request.number}} --json files -q '.files[].path')
         if echo $changes | grep -q CHANGELOG.md; then
           echo "CHANGELOG.md has been updated"
           echo "HAS_CHANGELOG=true" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Chore: Skip releasing a new version when no changelog entry was added
 - Chore: Fix release workflow
+- Chore: Fix release workflow again
 
 ## [3.87.0] - 2025-02-20
 


### PR DESCRIPTION


## Description
<!-- Add a short description about the changes -->

### Problem
https://github.com/bitmovin/bitmovin-player-ui/pull/688 broke the release workflow and https://github.com/bitmovin/bitmovin-player-ui/pull/689 didn't fix it.

The issue is that the workflow runs _after_ the PR is merged, meaning `git diff` cannot be used to determine which files have changed.

### Changes
Switch back to using `gh`, which accesses GitHub via API to get the data.

The token is a default token that is available in workflows: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

### Tests
This was tested on a separate branch with the same step, in the `CI` workflow:
- https://github.com/bitmovin/bitmovin-player-ui/actions/runs/13518733904
- https://github.com/bitmovin/bitmovin-player-ui/actions/runs/13518746502

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
