### PR TITLE
Change font size also for CEA-608 captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
+### Added
 - Changing font size now also takes an effect in CEA-608 captions with cap from 50% to 200%. Larger than default font size also disables the grid view.
 
 ## [3.88.0] - 2025-02-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Changing font size now also takes an effect in CEA-608 captions with cap from 50% to 200%. Larger than default font size also disables the grid view.
+
 ## [3.88.0] - 2025-02-25
 
 ### Changed

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,8 @@ gulp.task('lint-sass', function() {
   return gulp.src(paths.source.sass)
   .pipe(sassLint({
     rules: {
-      'no-css-comments': 0
+      'no-css-comments': 0,
+      'property-sort-order': 0
     }
   }))
   .pipe(sassLint.format())

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -87,34 +87,30 @@ describe('SubtitleOverlay', () => {
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
     });
 
-    it('correctly applies font size factor within allowed range (0.5 to 2.0)', () => {
-      // Set to minimum allowed factor
-      subtitleOverlay.setFontSizeFactor(0.2);
-      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(0.5); // Should be clamped to 0.5
-
-      // Set to maximum allowed factor
-      subtitleOverlay.setFontSizeFactor(3.0);
-      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(2.0); // Should be clamped to 2.0
-
-      // Set a valid value within range
-      subtitleOverlay.setFontSizeFactor(1.5);
-      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(1.5);
+    // Font size factor clamping
+    test.each([
+      [0.2, 0.5],  // Clamped to minimum
+      [3.0, 2.0],  // Clamped to maximum
+      [1.5, 1.5],  // Within range, no clamping
+      [0.5, 0.5],  // Exact minimum
+      [2.0, 2.0],  // Exact maximum
+      [1.0, 1.0],  // Default value
+    ])('setFontSizeFactor(%f) results in FONT_SIZE_FACTOR = %f', (inputFactor, expectedFactor) => {
+      subtitleOverlay.setFontSizeFactor(inputFactor);
+      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(expectedFactor);
     });
 
-    it('recalculates CEA 608 grid values correctly based on font size factor', () => {
-      subtitleOverlay.setFontSizeFactor(1.0);
+    // Grid recalculations
+    test.each([
+      [1.0, 15 / 1.0, 32 / 1.0],  // Standard grid
+      [2.0, 15 / 2.0, 32 / 2.0],  // Larger factor, smaller grid
+      [0.5, 15 / 1.0, 32 / 0.5],  // Factor <1 → rows stay 15, columns grow
+    ])('setFontSizeFactor(%f) recalculates grid: ROWS = %f, COLUMNS = %f', (factor, expectedRows, expectedColumns) => {
+      subtitleOverlay.setFontSizeFactor(factor);
       subtitleOverlay.recalculateCEAGrid();
 
-      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(15 / 1.0);
-      expect(subtitleOverlay['CEA608_NUM_COLUMNS']).toBe(32 / 1.0);
-
-      // Test with a different font size factor
-      subtitleOverlay.setFontSizeFactor(2.0);
-      subtitleOverlay.recalculateCEAGrid();
-
-      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(15 / 2.0);
-      expect(subtitleOverlay['CEA608_NUM_COLUMNS']).toBe(32 / 2.0);
+      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(expectedRows);
+      expect(subtitleOverlay['CEA608_NUM_COLUMNS']).toBe(expectedColumns);
     });
   });
-
 });

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -78,4 +78,43 @@ describe('SubtitleOverlay', () => {
       expect(removeLabelSpy).toHaveBeenCalled();
     });
   });
+
+  describe('CEA 608 Font Size Factor', () => {
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
+      uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+      subtitleOverlay = new SubtitleOverlay();
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+    });
+
+    it('correctly applies font size factor within allowed range (0.5 to 2.0)', () => {
+      // Set to minimum allowed factor
+      subtitleOverlay.setFontSizeFactor(0.2);
+      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(0.5); // Should be clamped to 0.5
+
+      // Set to maximum allowed factor
+      subtitleOverlay.setFontSizeFactor(3.0);
+      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(2.0); // Should be clamped to 2.0
+
+      // Set a valid value within range
+      subtitleOverlay.setFontSizeFactor(1.5);
+      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(1.5);
+    });
+
+    it('recalculates CEA 608 grid values correctly based on font size factor', () => {
+      subtitleOverlay.setFontSizeFactor(1.0);
+      subtitleOverlay.recalculateCEAGrid();
+
+      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(15 / 1.0);
+      expect(subtitleOverlay['CEA608_NUM_COLUMNS']).toBe(32 / 1.0);
+
+      // Test with a different font size factor
+      subtitleOverlay.setFontSizeFactor(2.0);
+      subtitleOverlay.recalculateCEAGrid();
+
+      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(15 / 2.0);
+      expect(subtitleOverlay['CEA608_NUM_COLUMNS']).toBe(32 / 2.0);
+    });
+  });
+
 });

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -3,6 +3,7 @@ import { UIInstanceManager } from '../../src/ts/uimanager';
 import { DOM } from '../../src/ts/dom';
 import { PlayerEventEmitter } from './PlayerEventEmitter';
 import { UIContainer } from '../../src/ts/components/uicontainer';
+import { SubtitleSettingsManager } from '../../src/ts/components/subtitlesettings/subtitlesettingsmanager';
 
 jest.mock('../../src/ts/dom');
 
@@ -29,6 +30,7 @@ export namespace MockHelper {
     const uiMock = getUiMock();
     const UiInstanceManagerMockClass: jest.Mock<UIInstanceManager> = jest.fn().mockImplementation(() => ({
       onConfigured: getEventDispatcherMock(),
+      getSubtitleSettingsManager: jest.fn().mockReturnValue(new SubtitleSettingsManager()),
       getConfig: jest.fn().mockReturnValue({
         events: {
           onUpdated: getEventDispatcherMock(),

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -1,7 +1,7 @@
 @use 'sass:math';
 
 .#{$prefix}-ui-subtitle-overlay {
-  --cea608-row-height: calc(100% / 15);
+  --cea608-row-height: math.div(100%, 15);
 
   &.#{$prefix}-cea608 {
 

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -1,6 +1,8 @@
 @use 'sass:math';
 
 .#{$prefix}-ui-subtitle-overlay {
+  --cea608-row-height: calc(100% / 15);
+
   &.#{$prefix}-cea608 {
 
     bottom: 2em;
@@ -9,7 +11,7 @@
     top: 2em;
 
     .#{$prefix}-subtitle-region-container {
-      height: math.div(100%, 15);
+      height: var(--cea608-row-height);
       left: 0;
       line-height: 1em;
       right: 0;
@@ -18,7 +20,7 @@
       // Define positions for all 15 rows
       @for $i from 0 through 14 {
         &.#{$prefix}-subtitle-position-cea608-row-#{$i} {
-          top: math.div($i, 15) * 100%;
+          top: calc(var(--cea608-row-height) * #{$i});
         }
       }
     }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -312,14 +312,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       const subtitleOverlayWidth = overlayElement.width() - 10;
       const subtitleOverlayHeight = overlayElement.height();
 
-      // After computing overlay dimensions:
-      const newRowHeight = subtitleOverlayHeight / this.CEA608_NUM_ROWS;
-
-      // Update the CSS custom property on the overlay DOM element
-      overlayElement.get().forEach((el) => {
-        el.style.setProperty("--cea608-row-height", `${newRowHeight}px`);
-      });
-
       // The size ratio of the letter grid
       const fontGridSizeRatio = (dummyLabelCharWidth * this.CEA608_NUM_COLUMNS) /
         (dummyLabelCharHeight * this.CEA608_NUM_ROWS);
@@ -342,6 +334,14 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         fontSize = subtitleOverlayWidth / this.CEA608_NUM_COLUMNS / fontSizeRatio;
         fontLetterSpacing = 0;
       }
+
+      // After computing overlay dimensions:
+      const newRowHeight = fontSize;
+
+      // Update the CSS custom property on the overlay DOM element
+      overlayElement.get().forEach((el) => {
+        el.style.setProperty("--cea608-row-height", `${newRowHeight}px`);
+      });
 
       // Update font-size of all active subtitle labels
       const updateLabel = (label: SubtitleLabel) => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -325,14 +325,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         label.getDomElement().css({
           'font-size': `${fontSize}px`,
           'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
+          'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
+          'left': isLargerFontSize && '0%',
         });
-
-        if (isLargerFontSize) {
-          label.getDomElement().css({
-            'left': '0%',
-            'white-space': 'nowrap',
-          });
-        }
 
         label.regionStyle = `line-height: ${fontSize}px;`;
       }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -243,7 +243,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     // Flag telling if the CEA-608 mode is enabled
     let enabled = false;
 
-
     const settingsManager = uimanager.getSubtitleSettingsManager();
 
     settingsManager.fontSize.onChanged.subscribe((_sender, property) => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -250,6 +250,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     return true
   };
 
+  resolveFontSizeFactor(value: string): number {
+    return parseInt(value) / 100;;
+  }
+
   configureCea608Captions(player: PlayerAPI, uimanager: UIInstanceManager): void {
     // The calculated font size
     let fontSize = 0;
@@ -262,11 +266,13 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
 
     const settingsManager = uimanager.getSubtitleSettingsManager();
+    const fontSizeFactorSettings = this.resolveFontSizeFactor(settingsManager.fontSize.value);
+    this.setFontSizeFactor(fontSizeFactorSettings);
 
     settingsManager.fontSize.onChanged.subscribe((_sender, property) => {
       if (property.isSet()) {
         // We need to convert from percent
-        const factorValue = parseInt(property.value) / 100;
+        const factorValue = this.resolveFontSizeFactor(property.value);
         this.setFontSizeFactor(factorValue);
       } else {
         this.setFontSizeFactor(1);

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -289,10 +289,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       const subtitleOverlayHeight = overlayElement.height();
 
       // After computing overlay dimensions:
-      const newRowHeight = (subtitleOverlayHeight / this.CEA608_NUM_ROWS) * this.FONT_SIZE_FACTOR;
+      const newRowHeight = subtitleOverlayHeight / this.CEA608_NUM_ROWS;
 
       // Update the CSS custom property on the overlay DOM element
-      overlayElement.css("--cea608-row-height", newRowHeight + "px");
       overlayElement.get().forEach((el) => {
         el.style.setProperty("--cea608-row-height", `${newRowHeight}px`);
       });
@@ -363,11 +362,14 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         }
       }
 
+      // We disable the grid and wrapping in case enlarged font size is used to prevent
+      // line and characters overflows
+      const isLargerFontSize = this.FONT_SIZE_FACTOR > 1
       label.getDomElement().css({
-        // We disable the grid if the font factor is greater than 1
-        'left': `${this.FONT_SIZE_FACTOR > 1 ? 0 : event.position.column * this.CEA608_COLUMN_OFFSET}%`,
+        'left': `${isLargerFontSize ? 0 : event.position.column * this.CEA608_COLUMN_OFFSET}%`,
         'font-size': `${fontSize}px`,
-        'letter-spacing': `${this.FONT_SIZE_FACTOR > 1 ? 0 : fontLetterSpacing}px`,
+        'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
+        'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
       });
 
       label.regionStyle = `line-height: ${fontSize}px;`;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -320,14 +320,32 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
 
       // Update font-size of all active subtitle labels
-      for (let label of this.getComponents()) {
-        if (label instanceof SubtitleLabel) {
-          label.getDomElement().css({
-            'font-size': `${fontSize}px`,
-            'letter-spacing': `${fontLetterSpacing}px`,
-          });
+      const updateLabel = (label: SubtitleLabel) => {
+        const isLargerFontSize = this.FONT_SIZE_FACTOR > 1
+        label.getDomElement().css({
+          'font-size': `${fontSize}px`,
+          'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
+        });
 
-          label.regionStyle = `line-height: ${fontSize}px;`;
+        if (isLargerFontSize) {
+          label.getDomElement().css({
+            'left': '0%',
+            'white-space': 'nowrap',
+          });
+        }
+
+        label.regionStyle = `line-height: ${fontSize}px;`;
+      }
+
+      for (let label of this.getComponents()) {
+        if (label instanceof SubtitleRegionContainer) {
+          label.getComponents().forEach((l: SubtitleLabel) => {
+            updateLabel(l);
+          })
+        }
+
+        if (label instanceof SubtitleLabel) {
+          updateLabel(label);
         }
       }
     };

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -36,14 +36,16 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   private FONT_SIZE_FACTOR: number = 1;
   // The number of rows in a cea608 grid
-  private CEA608_NUM_ROWS = 15 / Math.max(this.FONT_SIZE_FACTOR, 1);
+  private CEA608_NUM_ROWS = 15;
   // The number of columns in a cea608 grid
-  private CEA608_NUM_COLUMNS = 32 / this.FONT_SIZE_FACTOR;
+  private CEA608_NUM_COLUMNS = 32;
   // The offset in percent for one column (which is also the width of a column)
   private CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
+
+    this.recalculateCEAGrid();
 
     this.previewSubtitleActive = false;
     this.previewSubtitle = new SubtitleLabel({ text: i18n.getLocalizer('subtitle.example') });
@@ -161,6 +163,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   recalculateCEAGrid() {
+    // Needs to get recalculated in case the font size will change
     this.CEA608_NUM_ROWS = 15 / Math.max(this.FONT_SIZE_FACTOR, 1);
     this.CEA608_NUM_COLUMNS = 32 / this.FONT_SIZE_FACTOR;
     this.CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -34,12 +34,14 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   private static readonly CLASS_CONTROLBAR_VISIBLE = 'controlbar-visible';
   private static readonly CLASS_CEA_608 = 'cea608';
+  private static readonly DEFAULT_CEA608_NUM_ROWS = 15;
+  private static readonly DEFAULT_CEA608_NUM_COLUMNS = 32;
 
   private FONT_SIZE_FACTOR: number = 1;
   // The number of rows in a cea608 grid
-  private CEA608_NUM_ROWS = 15;
+  private CEA608_NUM_ROWS = SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS;
   // The number of columns in a cea608 grid
-  private CEA608_NUM_COLUMNS = 32;
+  private CEA608_NUM_COLUMNS = SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS;
   // The offset in percent for one column (which is also the width of a column)
   private CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
 
@@ -167,8 +169,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   recalculateCEAGrid() {
     // Needs to get recalculated in case the font size will change
-    this.CEA608_NUM_ROWS = 15 / Math.max(this.FONT_SIZE_FACTOR, 1);
-    this.CEA608_NUM_COLUMNS = 32 / this.FONT_SIZE_FACTOR;
+    this.CEA608_NUM_ROWS = SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS / Math.max(this.FONT_SIZE_FACTOR, 1);
+    this.CEA608_NUM_COLUMNS = SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS / this.FONT_SIZE_FACTOR;
     this.CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
   }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -296,7 +296,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       overlayElement.get().forEach((el) => {
         el.style.setProperty("--cea608-row-height", `${newRowHeight}px`);
       });
-      this.subtitleContainerManager.updateRegionsHeight(newRowHeight);
 
       // The size ratio of the letter grid
       const fontGridSizeRatio = (dummyLabelCharWidth * this.CEA608_NUM_COLUMNS) /
@@ -711,11 +710,6 @@ export class SubtitleRegionContainerManager {
     }
 
     this.subtitleRegionContainers = {};
-  }
-
-  updateRegionsHeight(newRowHeight: number) {
-    (document.querySelectorAll(".bmpui-subtitle-region-container") as NodeListOf<HTMLElement>)
-      .forEach((e, _i) => e.style.setProperty("--cea608-row-height", `${newRowHeight}px`));
   }
 }
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -154,6 +154,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   setFontSizeFactor(factor: number): void {
     // We only allow range from 50% to 200% as suggested by spec
+    // https://www.ecfr.gov/current/title-47/part-79/section-79.103#p-79.103(c)(4)
     this.FONT_SIZE_FACTOR = Math.max(0.5, Math.min(2.0, factor));;
 
     this.recalculateCEAGrid();

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -327,6 +327,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         const isLargerFontSize = this.FONT_SIZE_FACTOR > 1
         label.getDomElement().css({
           'font-size': `${fontSize}px`,
+          'line-height': `${fontSize}px`,
           'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
           'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
           'left': isLargerFontSize && '0%',

--- a/src/ts/components/subtitlesettings/fontsizeselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontsizeselectbox.ts
@@ -1,15 +1,15 @@
 import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
-import {UIInstanceManager} from '../../uimanager';
+import { UIInstanceManager } from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../../localization/i18n';
+import { ListItem } from '../listselector';
 
 /**
- * A select box providing a selection of different font colors.
+ * A select box providing a selection of different font sizes.
  *
  * @category Components
  */
 export class FontSizeSelectBox extends SubtitleSettingSelectBox {
-
   constructor(config: SubtitleSettingSelectBoxConfig) {
     super(config);
 
@@ -18,17 +18,45 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
     }, this.config);
   }
 
+  private getFontSizeOptions(): ListItem[] {
+    return [
+      { key: null, label: i18n.getLocalizer('default') },
+      { key: '50', label: i18n.getLocalizer('percent', { value: 50 }) },
+      { key: '75', label: i18n.getLocalizer('percent', { value: 75 }) },
+      { key: '100', label: i18n.getLocalizer('percent', { value: 100 }) },
+      { key: '150', label: i18n.getLocalizer('percent', { value: 150 }) },
+      { key: '200', label: i18n.getLocalizer('percent', { value: 200 }) },
+      { key: '300', label: i18n.getLocalizer('percent', { value: 300 }) },
+      { key: '400', label: i18n.getLocalizer('percent', { value: 400 }) },
+    ];
+  }
+
+  private populateItemsWithFilter(): void {
+    this.clearItems();
+
+    for (const item of this.getFontSizeOptions()) {
+      if (!this.config.filter || this.config.filter(item)) {
+        this.addItem(item.key, item.label);
+      }
+    }
+
+    if (this.settingsManager.fontSize.isSet()) {
+      this.selectItem(this.settingsManager.fontSize.value);
+    }
+  }
+
+  public reapplyFilterAndReload(): void {
+    this.populateItemsWithFilter();
+  }
+
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    this.addItem(null, i18n.getLocalizer('default'));
-    this.addItem('50', i18n.getLocalizer('percent', { value: 50 }));
-    this.addItem('75', i18n.getLocalizer('percent', { value: 75 }));
-    this.addItem('100', i18n.getLocalizer('percent', { value: 100 }));
-    this.addItem('150', i18n.getLocalizer('percent', { value: 150 }));
-    this.addItem('200', i18n.getLocalizer('percent', { value: 200 }));
-    this.addItem('300', i18n.getLocalizer('percent', { value: 300 }));
-    this.addItem('400', i18n.getLocalizer('percent', { value: 400 }));
+    this.populateItemsWithFilter();
+
+    this.onShow.subscribe(() => {
+      this.populateItemsWithFilter();
+    });
 
     this.settingsManager.fontSize.onChanged.subscribe((sender, property) => {
       if (property.isSet()) {
@@ -37,17 +65,11 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
         this.toggleOverlayClass(null);
       }
 
-      // Select the item in case the property was set from outside
       this.selectItem(property.value);
     });
 
     this.onItemSelected.subscribe((sender, key: string) => {
       this.settingsManager.fontSize.value = key;
     });
-
-    // Load initial value
-    if (this.settingsManager.fontSize.isSet()) {
-      this.selectItem(this.settingsManager.fontSize.value);
-    }
   }
 }

--- a/src/ts/components/subtitlesettings/subtitlesettingspanelpage.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingspanelpage.ts
@@ -94,7 +94,6 @@ export class SubtitleSettingsPanelPage extends SettingsPanelPage {
     super.configure(player, uimanager);
 
     this.onActive.subscribe(() => {
-      console.log('font size selector show event', this.config);
       this.overlay.enablePreviewSubtitleLabel();
 
       // Dynamically reapply font size filter

--- a/src/ts/components/subtitlesettings/subtitlesettingspanelpage.ts
+++ b/src/ts/components/subtitlesettings/subtitlesettingspanelpage.ts
@@ -44,11 +44,11 @@ export class SubtitleSettingsPanelPage extends SettingsPanelPage {
     this.overlay = config.overlay;
     this.settingsPanel = config.settingsPanel;
 
-
     this.config = this.mergeConfig(config, {
       components: <Component<ComponentConfig>[]>[
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.font.size'), new FontSizeSelectBox({
           overlay: this.overlay,
+          filter: (item) => this.overlay.filterFontSizeOptions(item),
         })),
         new SettingsPanelItem(i18n.getLocalizer('settings.subtitles.font.style'), new FontStyleSelectBox({
           overlay: this.overlay,
@@ -94,7 +94,19 @@ export class SubtitleSettingsPanelPage extends SettingsPanelPage {
     super.configure(player, uimanager);
 
     this.onActive.subscribe(() => {
+      console.log('font size selector show event', this.config);
       this.overlay.enablePreviewSubtitleLabel();
+
+      // Dynamically reapply font size filter
+      const fontSizeComponent = this.getComponents().find((component: any) =>
+        component instanceof SettingsPanelItem &&
+        component.getComponents().some((c) => c instanceof FontSizeSelectBox)
+      ) as SettingsPanelItem;
+
+      if (fontSizeComponent) {
+        const fontSizeSelectBox = fontSizeComponent.getComponents().find(c => c instanceof FontSizeSelectBox) as FontSizeSelectBox;
+        fontSizeSelectBox?.reapplyFilterAndReload();
+      }
     });
 
     this.onInactive.subscribe(() => {


### PR DESCRIPTION
## Description

As CEA-608 captions are using grid view which scales relatively to the player UI it did not take the font size settings into consideration. However the spec suggest to allow adjustment between 50% to 200%. As the grid view display implementation is quite complex this PR adds adjustment to the whole grid setup so the font size scales without making the letters or lines to overlap. As the grid positioning may break on larger sizes we also disable the positions and letter spacing if the font size factor is larger than 1.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
