### PR TITLE
[PW-22833] Fix missing CEA-608 captions rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Setting larger font size while using CEA-608 captions can shift some cues outside of visible area.
+
 ## [3.89.0] - 2025-03-24
 
 ### Added

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -106,10 +106,12 @@ describe('SubtitleOverlay', () => {
       [2.0, 15 / 2.0, 32 / 2.0],  // Larger factor, smaller grid
       [0.5, 15 / 1.0, 32 / 0.5],  // Factor <1 → rows stay 15, columns grow
     ])('setFontSizeFactor(%f) recalculates grid: ROWS = %f, COLUMNS = %f', (factor, expectedRows, expectedColumns) => {
+      // We need to floor for whole rows as they are represented in precompiled sass styles
+      const expectedWholeRows = Math.floor(expectedRows)
       subtitleOverlay.setFontSizeFactor(factor);
       subtitleOverlay.recalculateCEAGrid();
 
-      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(expectedRows);
+      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(expectedWholeRows);
       expect(subtitleOverlay['CEA608_NUM_COLUMNS']).toBe(expectedColumns);
     });
   });

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -217,7 +217,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     }
   }
 
-  resolveColumn(row: number) {
+  resolveRowNumber(row: number): number {
+    // In case there is a font size factor and the row from event would overflow
+    // we need to apply an offset so it gets rendered to visible area.
     if (this.FONT_SIZE_FACTOR > 1 && row > this.CEA608_NUM_ROWS) {
       const rowDelta = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS - this.CEA608_NUM_ROWS);
       return row - rowDelta;
@@ -232,7 +234,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     if (event.position) {
       // Sometimes the positions are undefined, we assume them to be zero
-      event.position.row = this.resolveColumn(event.position.row) || 0;
+      event.position.row = this.resolveRowNumber(event.position.row) || 0;
       event.position.column = event.position.column || 0;
 
       region = region || `cea608-row-${event.position.row}`;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -274,8 +274,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     const element = (r.getDomElement().get() as HTMLElement[])[0];
     const label = r.getComponents();
 
-    const origLabelCom = Object.values((label as any))
-    const originRow = (origLabelCom[0] as any)?.config.originalRowPosition
+    // TODO Get rid of any to access the label as the .getConfig() does not seem to work.
+    const origLabelCom = Object.values((label as any));
+    const originRow = (origLabelCom[0] as any)?.config.originalRowPosition;
 
     const classList = element?.classList;
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -217,13 +217,22 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     }
   }
 
+  resolveColumn(row: number) {
+    if (this.FONT_SIZE_FACTOR > 1 && row > this.CEA608_NUM_ROWS) {
+      const rowDelta = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS - this.CEA608_NUM_ROWS);
+      return row - rowDelta;
+    }
+
+    return row;
+  }
+
   generateLabel(event: SubtitleCueEvent): SubtitleLabel {
     // Sanitize cue data (must be done before the cue ID is generated in subtitleManager.cueEnter / update)
     let region = event.region;
 
     if (event.position) {
       // Sometimes the positions are undefined, we assume them to be zero
-      event.position.row = event.position.row || 0;
+      event.position.row = this.resolveColumn(event.position.row) || 0;
       event.position.column = event.position.column || 0;
 
       region = region || `cea608-row-${event.position.row}`;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -271,29 +271,31 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   updateRegionRowPosition(r: SubtitleRegionContainer): void {
-    const element = (r.getDomElement().get() as HTMLElement[])[0];
-    const label = r.getComponents();
+    const element = r.getDomElement().get()[0];
+    const label = r.getComponents()[0];
 
-    // TODO Get rid of any to access the label as the .getConfig() does not seem to work.
-    const origLabelCom = Object.values((label as any));
-    const originRow = (origLabelCom[0] as any)?.config.originalRowPosition;
+    if (!element || !label) {
+      return;
+    }
 
-    const classList = element?.classList;
+    const rowClassList = element.classList;
+    const originalRow = (label.getConfig() as SubtitleLabelConfig)?.originalRowPosition;
+    const rowClassRegex = /subtitle-position-cea608-row-(\d+)/;
 
-    if (!classList) return;
+    const currentClass = Array.from(rowClassList).find(cls => rowClassRegex.test(cls));
 
-    const currentClass = Array.from(classList).find(cls => /subtitle-position-cea608-row-\d+/.test(cls));
-    if (!currentClass) return;
+    if (!currentClass) {
+      return;
+    }
 
-    const match = currentClass.match(/subtitle-position-cea608-row-(\d+)/);
+    const match = rowClassRegex.exec(currentClass);
     const rowNumber = match ? parseInt(match[1], 10) : null;
+    const newRowNum = this.resolveRowNumber(originalRow ?? rowNumber);
+    const newClass = currentClass.replace(rowClassRegex, `subtitle-position-cea608-row-${newRowNum}`);
 
-    const newRowNum = this.resolveRowNumber(originRow ?? rowNumber);
-    const newClass = currentClass.replace(/subtitle-position-cea608-row-\d+/, `subtitle-position-cea608-row-${newRowNum}`);
+    rowClassList.replace(currentClass, newClass);
+  }
 
-    classList.remove(currentClass);
-    classList.add(newClass);
-  };
 
   configureCea608Captions(player: PlayerAPI, uimanager: UIInstanceManager): void {
     // The calculated font size

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -233,12 +233,12 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     // Sanitize cue data (must be done before the cue ID is generated in subtitleManager.cueEnter / update)
     let region = event.region;
 
-    // We need to keep track of the original row position in case of recalculation,
-    const originalRowNumber = event.position.row;
+    // Sometimes the positions are undefined, we assume them to be zero.
+    // We need to keep track of the original row position in case of recalculation.
+    const originalRowNumber = event.position?.row || 0;
 
     if (event.position) {
-      // Sometimes the positions are undefined, we assume them to be zero
-      event.position.row = this.resolveRowNumber(originalRowNumber) || 0;
+      event.position.row = this.resolveRowNumber(event.position.row) || 0;
       event.position.column = event.position.column || 0;
 
       region = region || `cea608-row-${event.position.row}`;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -171,7 +171,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     // Needs to get recalculated in case the font size will change also we need to floor this
     // to always align to the whole number represented in styles.
     this.CEA608_NUM_ROWS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS / Math.max(this.FONT_SIZE_FACTOR, 1));
-    this.CEA608_NUM_COLUMNS = SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS / this.FONT_SIZE_FACTOR;
+    this.CEA608_NUM_COLUMNS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS / this.FONT_SIZE_FACTOR);
     this.CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
   }
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
- If cues are positioned on the bottom and the larger font size gets applied, the row position is not recalculated and can get hidden based on the precompiled row styles.
- We now recalculate the rows and apply the offset in case the cues are positioned above the available grid.
- We also need to store the original row position from the cue. 

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
