### PR TITLE
Text to speech improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `aria-pressed` attribute is not set if both, `onAriaLabel` and `offAriaLabel`, configuration properties are set for a specific component
 - The `aria-label` for Quickseek buttons contain now also the number of seconds the button seeks
 
+### Fixed
+- Error message in `ErrorMessageOverlay` not read by Text-To-Speech engine on Tizen
+
 ## [3.90.0] - 2025-04-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `aria-label` to `ErrorMessageOverlay`
+- New `ariaFallbackMode` configuration option to `SeekBarConfig`, which updates the current playback position also in the `aria-label`. This can be used for devices which don't support the `aria-valuetext` attribute for `slider`s.
+
+### Changed
+- The `aria-pressed` attribute is only set on `ToggleButton`s instead of all buttons
+- The `aria-pressed` attribute is not set if both, `onAriaLabel` and `offAriaLabel`, configuration properties are set for a specific component
+- The `aria-label` for Quickseek buttons contain now also the number of seconds the button seeks
+
 ## [3.89.0] - 2025-03-24
 
 ### Added

--- a/spec/components/togglebutton.spec.ts
+++ b/spec/components/togglebutton.spec.ts
@@ -23,9 +23,11 @@ describe('ToggleButton', () => {
   describe('aria label', () => {
     it('should set on label when toggle state is on', () => {
       const onLocalizer = () => 'on';
+      const offLocalizer = () => 'off';
 
       const config: ToggleButtonConfig = {
         onAriaLabel: onLocalizer,
+        offAriaLabel: offLocalizer,
       };
 
       toggleButton = new ToggleButton(config);
@@ -36,9 +38,11 @@ describe('ToggleButton', () => {
 
     it('should set on label when toggle state is on (string label)', () => {
       const onLocalizer = 'on';
+      const offLocalizer = 'off';
 
       const config: ToggleButtonConfig = {
         onAriaLabel: onLocalizer,
+        offAriaLabel: offLocalizer,
       };
 
       toggleButton = new ToggleButton(config);
@@ -48,9 +52,11 @@ describe('ToggleButton', () => {
     });
 
     it('should set off label when toggle state is off', () => {
+      const onLocalizer = () => 'on';
       const offLocalizer = () => 'off';
 
       const config: ToggleButtonConfig = {
+        onAriaLabel: onLocalizer,
         offAriaLabel: offLocalizer,
       };
 
@@ -62,9 +68,11 @@ describe('ToggleButton', () => {
     });
 
     it('should set off label when toggle state is off (string label)', () => {
+      const onLocalizer = 'on';
       const offLocalizer = 'off';
 
       const config: ToggleButtonConfig = {
+        onAriaLabel: onLocalizer,
         offAriaLabel: offLocalizer,
       };
 
@@ -73,6 +81,62 @@ describe('ToggleButton', () => {
       toggleButton.off();
 
       expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'off');
+    });
+  });
+
+  describe('aria pressed', () => {
+    it('should set pressed to true when toggle state is on', () => {
+      const onLocalizer = () => 'on';
+
+      const config: ToggleButtonConfig = {
+        ariaLabel: onLocalizer,
+      };
+
+      toggleButton = new ToggleButton(config);
+      toggleButton.on();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('aria-pressed', 'true');
+    });
+
+    it('should set pressed to true when toggle state is on (string label)', () => {
+      const onLocalizer = 'on';
+
+      const config: ToggleButtonConfig = {
+        ariaLabel: onLocalizer,
+      };
+
+      toggleButton = new ToggleButton(config);
+      toggleButton.on();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('aria-pressed', 'true');
+    });
+
+    it('should set pressed to false when toggle state is off', () => {
+      const onLocalizer = () => 'on';
+
+      const config: ToggleButtonConfig = {
+        ariaLabel: onLocalizer,
+      };
+
+      toggleButton = new ToggleButton(config);
+      toggleButton.on();
+      toggleButton.off();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('aria-pressed', 'false');
+    });
+
+    it('should set pressed to false when toggle state is off (string label)', () => {
+      const onLocalizer = 'on';
+
+      const config: ToggleButtonConfig = {
+        ariaLabel: onLocalizer,
+      };
+
+      toggleButton = new ToggleButton(config);
+      toggleButton.on();
+      toggleButton.off();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('aria-pressed', 'false');
     });
   });
 });

--- a/src/ts/components/button.ts
+++ b/src/ts/components/button.ts
@@ -54,10 +54,6 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
       'aria-label': i18n.performLocalization(this.config.ariaLabel || this.config.text),
       'class': this.getCssClasses(),
       'type' : 'button',
-      /**
-      * WCAG20 standard to display if a button is pressed or not
-      */
-      'aria-pressed': 'false',
       'tabindex': this.config.tabIndex.toString(),
     };
 

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -137,23 +137,31 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
 
     player.on(player.exports.PlayerEvent.SourceLoaded, (event: PlayerEventBase) => {
       if (this.isShown()) {
-        this.tvNoiseBackground.stop();
-        this.hide();
+        this.clear();
       }
     });
   }
 
   display(errorMessage: string): void {
     this.errorLabel.setText(errorMessage);
+    this.getDomElement().attr('aria-label', errorMessage);
     this.tvNoiseBackground.start();
     this.show();
+  }
+
+  private clear(): void {
+    this.errorLabel.setText('');
+    this.getDomElement().removeAttr('aria-label');
+
+    // Canvas rendering must be explicitly stopped, else it just continues forever and hogs resources
+    this.tvNoiseBackground.stop();
+    this.hide();
   }
 
   release(): void {
     super.release();
 
-    // Canvas rendering must be explicitly stopped, else it just continues forever and hogs resources
-    this.tvNoiseBackground.stop();
+    this.clear();
   }
 }
 

--- a/src/ts/components/errormessageoverlay.ts
+++ b/src/ts/components/errormessageoverlay.ts
@@ -100,6 +100,7 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
       cssClass: 'ui-errormessage-overlay',
       components: [this.tvNoiseBackground, this.errorLabel],
       hidden: true,
+      role: 'status',
     }, this.config);
   }
 
@@ -144,14 +145,12 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
 
   display(errorMessage: string): void {
     this.errorLabel.setText(errorMessage);
-    this.getDomElement().attr('aria-label', errorMessage);
     this.tvNoiseBackground.start();
     this.show();
   }
 
   private clear(): void {
     this.errorLabel.setText('');
-    this.getDomElement().removeAttr('aria-label');
 
     // Canvas rendering must be explicitly stopped, else it just continues forever and hogs resources
     this.tvNoiseBackground.stop();

--- a/src/ts/components/quickseekbutton.ts
+++ b/src/ts/components/quickseekbutton.ts
@@ -39,7 +39,11 @@ export class QuickSeekButton extends Button<QuickSeekButtonConfig> {
     const seekDirection = this.config.seekSeconds < 0 ? 'rewind' : 'forward';
 
     this.config.text = this.config.text || i18n.getLocalizer(`quickseek.${seekDirection}`);
-    this.config.ariaLabel = this.config.ariaLabel || i18n.getLocalizer(`quickseek.${seekDirection}`);
+    this.config.ariaLabel =
+      this.config.ariaLabel ||
+      i18n.getLocalizer(`quickseek.${seekDirection}`, {
+        seekSeconds: Math.abs(this.config.seekSeconds),
+      });
 
     this.getDomElement().data(this.prefixCss('seek-direction'), seekDirection);
   }

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -60,6 +60,13 @@ export interface SeekBarConfig extends ComponentConfig {
    * Used to enable/disable seek preview
    */
   enableSeekPreview?: boolean;
+
+  /**
+   * Enables a fallback mode for handling ARIA details of the seekbar for platforms that don't support the 
+   * `aria-valuetext` attribute, such as Samsung Tizen. In this mode, the `aria-label` attribute is used in addition
+   * to provide the current time.
+   */
+  ariaFallbackMode?: boolean;
 }
 
 /**
@@ -189,12 +196,22 @@ export class SeekBar extends Component<SeekBarConfig> {
   private setAriaSliderValues() {
     if (this.seekBarType === SeekBarType.Live) {
       const timeshiftValue = Math.ceil(this.player.getTimeShift()).toString();
+      const timeShiftText = `${i18n.performLocalization(i18n.getLocalizer('seekBar.timeshift'))} ${i18n.performLocalization(i18n.getLocalizer('seekBar.value'))}: ${timeshiftValue}`;
+
       this.getDomElement().attr('aria-valuenow', timeshiftValue);
-      this.getDomElement().attr('aria-valuetext', `${i18n.performLocalization(i18n.getLocalizer('seekBar.timeshift'))} ${i18n.performLocalization(i18n.getLocalizer('seekBar.value'))}: ${timeshiftValue}`);
+      this.getDomElement().attr('aria-valuetext', timeShiftText);
+
+      if (this.config.ariaFallbackMode) {
+        this.getDomElement().attr('aria-label', `${i18n.performLocalization(this.config.ariaLabel)}: ${timeShiftText}`);
+      }
     } else if (this.seekBarType === SeekBarType.Vod) {
-      const ariaValueText = `${StringUtils.secondsToText(this.player.getCurrentTime())} ${i18n.performLocalization(i18n.getLocalizer('seekBar.durationText'))} ${StringUtils.secondsToText(this.player.getDuration())}`;
+      const ariaValueText = `${StringUtils.secondsToText(this.player.getCurrentTime(), false)} ${i18n.performLocalization(i18n.getLocalizer('seekBar.durationText'))} ${StringUtils.secondsToText(this.player.getDuration(), false)}`;
       this.getDomElement().attr('aria-valuenow', Math.floor(this.player.getCurrentTime()).toString());
       this.getDomElement().attr('aria-valuetext', ariaValueText);
+
+      if (this.config.ariaFallbackMode) {
+        this.getDomElement().attr('aria-label', `${i18n.performLocalization(this.config.ariaLabel)}: ${StringUtils.secondsToText(this.player.getCurrentTime(), false)}`);
+      }
     }
   }
 

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -204,12 +204,12 @@ export class SeekBar extends Component<SeekBarConfig> {
         this.getDomElement().attr('aria-label', `${i18n.performLocalization(this.config.ariaLabel)}: ${timeShiftText}`);
       }
     } else if (this.seekBarType === SeekBarType.Vod) {
-      const ariaValueText = `${StringUtils.secondsToText(this.player.getCurrentTime(), false)} ${i18n.performLocalization(i18n.getLocalizer('seekBar.durationText'))} ${StringUtils.secondsToText(this.player.getDuration(), false)}`;
+      const ariaValueText = `${StringUtils.secondsToText(this.player.getCurrentTime())} ${i18n.performLocalization(i18n.getLocalizer('seekBar.durationText'))} ${StringUtils.secondsToText(this.player.getDuration())}`;
       this.getDomElement().attr('aria-valuenow', Math.floor(this.player.getCurrentTime()).toString());
       this.getDomElement().attr('aria-valuetext', ariaValueText);
 
       if (this.config.addCurrentTimeToAriaLabel) {
-        this.getDomElement().attr('aria-label', `${i18n.performLocalization(this.config.ariaLabel)}: ${StringUtils.secondsToText(this.player.getCurrentTime(), false)}`);
+        this.getDomElement().attr('aria-label', `${i18n.performLocalization(this.config.ariaLabel)}: ${StringUtils.secondsToText(this.player.getCurrentTime())}`);
       }
     }
   }

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -62,11 +62,10 @@ export interface SeekBarConfig extends ComponentConfig {
   enableSeekPreview?: boolean;
 
   /**
-   * Enables a fallback mode for handling ARIA details of the seekbar for platforms that don't support the 
-   * `aria-valuetext` attribute, such as Samsung Tizen. In this mode, the `aria-label` attribute is used in addition
-   * to provide the current time.
+   * Used to add the current playback time into the `aria-label` attribute. This allows screen readers to read the current
+   * current time even on platforms that do not support the `aria-valuetext` attribute, such as Samsung Tizen.
    */
-  ariaFallbackMode?: boolean;
+  addCurrentTimeToAriaLabel?: boolean;
 }
 
 /**
@@ -201,7 +200,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.getDomElement().attr('aria-valuenow', timeshiftValue);
       this.getDomElement().attr('aria-valuetext', timeShiftText);
 
-      if (this.config.ariaFallbackMode) {
+      if (this.config.addCurrentTimeToAriaLabel) {
         this.getDomElement().attr('aria-label', `${i18n.performLocalization(this.config.ariaLabel)}: ${timeShiftText}`);
       }
     } else if (this.seekBarType === SeekBarType.Vod) {
@@ -209,7 +208,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.getDomElement().attr('aria-valuenow', Math.floor(this.player.getCurrentTime()).toString());
       this.getDomElement().attr('aria-valuetext', ariaValueText);
 
-      if (this.config.ariaFallbackMode) {
+      if (this.config.addCurrentTimeToAriaLabel) {
         this.getDomElement().attr('aria-label', `${i18n.performLocalization(this.config.ariaLabel)}: ${StringUtils.secondsToText(this.player.getCurrentTime(), false)}`);
       }
     }

--- a/src/ts/components/togglebutton.ts
+++ b/src/ts/components/togglebutton.ts
@@ -94,6 +94,8 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Conf
        * label instead. This option will be used if both, `onAriaLabel` and `offAriaLabel` are set.
        */
       this.setAriaAttr('pressed', 'false');
+    } else {
+      this.setAriaLabel(this.config.offAriaLabel);
     }
   }
 

--- a/src/ts/components/togglebutton.ts
+++ b/src/ts/components/togglebutton.ts
@@ -75,6 +75,8 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Conf
     }
 
     this.config = this.mergeConfig(config, defaultConfig as Config, this.config);
+
+    this.useAriaPressedAttributeAsToggleIndicator = !this.config.onAriaLabel || !this.config.offAriaLabel;
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/togglebutton.ts
+++ b/src/ts/components/togglebutton.ts
@@ -1,5 +1,5 @@
-import {Button, ButtonConfig} from './button';
-import {NoArgs, EventDispatcher, Event} from '../eventdispatcher';
+import { Button, ButtonConfig } from './button';
+import { NoArgs, EventDispatcher, Event } from '../eventdispatcher';
 import { UIInstanceManager } from '../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 import { LocalizableText } from '../localization/i18n';
@@ -22,7 +22,11 @@ export interface ToggleButtonConfig extends ButtonConfig {
    * WCAG20 standard for defining info about the component (usually the name)
    *
    * It is recommended to use `onAriaLabel` and `offAriaLabel` for toggle buttons
-   * as the component can then update them as the button is used.
+   * as the component can then update them as the button is used. If this is the case,
+   * the `aria-pressed` attribute is not set as the specification defines either the name
+   * or the pressed-state should be changed, but not both.
+   * Some platforms, like many versions of Samsung Tizen TVs, don't support the `aria-pressed`
+   * attribute, so it is recommended to use `onAriaLabel` and `offAriaLabel` instead.
    *
    * If both `ariaLabel` and `onAriaLabel` are set, `onAriaLabel` is used.
    */
@@ -49,6 +53,7 @@ export interface ToggleButtonConfig extends ButtonConfig {
 export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Config> {
 
   private onState: boolean;
+  private useAriaPressedAttributeAsToggleIndicator: boolean;
 
   private toggleButtonEvents = {
     onToggle: new EventDispatcher<ToggleButton<Config>, NoArgs>(),
@@ -76,6 +81,20 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Conf
     super.configure(player, uimanager);
     const config = this.getConfig();
     this.getDomElement().addClass(this.prefixCss(config.offClass));
+
+    this.useAriaPressedAttributeAsToggleIndicator = !this.config.onAriaLabel || !this.config.offAriaLabel;
+
+    if (this.useAriaPressedAttributeAsToggleIndicator) {
+      /**
+       * WCAG20 standard to display if a button is pressed or not. In screenreaders, this converts the button to a
+       * toggle button and the button label should not change. Unfortunately, not all devices and screenreaders support
+       * this attribute (e.g. Samsung Tizen TVs).
+       * 
+       * The alternative is to not use this attribute and toggle the button
+       * label instead. This option will be used if both, `onAriaLabel` and `offAriaLabel` are set.
+       */
+      this.setAriaAttr('pressed', 'false');
+    }
   }
 
   /**
@@ -92,9 +111,9 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Conf
       this.onToggleEvent();
       this.onToggleOnEvent();
 
-      this.setAriaAttr('pressed', 'true');
-
-      if (this.config.onAriaLabel) {
+      if (this.useAriaPressedAttributeAsToggleIndicator) {
+        this.setAriaAttr('pressed', 'true');
+      } else {
         this.setAriaLabel(this.config.onAriaLabel);
       }
     }
@@ -114,9 +133,9 @@ export class ToggleButton<Config extends ToggleButtonConfig> extends Button<Conf
       this.onToggleEvent();
       this.onToggleOffEvent();
 
-      this.setAriaAttr('pressed', 'false');
-
-      if (this.config.offAriaLabel) {
+      if (this.useAriaPressedAttributeAsToggleIndicator) {
+        this.setAriaAttr('pressed', 'false');
+      } else {
         this.setAriaLabel(this.config.offAriaLabel);
       }
     }

--- a/src/ts/localization/languages/de.json
+++ b/src/ts/localization/languages/de.json
@@ -56,8 +56,8 @@
   "seekBar.value": "Wert",
   "seekBar.timeshift": "Timeshift",
   "seekBar.durationText": "aus",
-  "quickseek.forward": "Vor",
-  "quickseek.rewind": "Zurück",
+  "quickseek.forward": "{seekSeconds} Sekunden Vor",
+  "quickseek.rewind": "{seekSeconds} Sekunden Zurück",
   "ecoMode": "ecoMode",
   "ecoMode.title":"Eco Mode"
 }

--- a/src/ts/localization/languages/en.json
+++ b/src/ts/localization/languages/en.json
@@ -75,6 +75,6 @@
   "seekBar.value": "Value",
   "seekBar.timeshift": "Timeshift",
   "seekBar.durationText": "out of",
-  "quickseek.forward": "Fast Forward",
-  "quickseek.rewind": "Rewind"
+  "quickseek.forward": "Fast Forward {seekSeconds} seconds",
+  "quickseek.rewind": "Rewind {seekSeconds} seconds"
 }

--- a/src/ts/localization/languages/es.json
+++ b/src/ts/localization/languages/es.json
@@ -75,6 +75,6 @@
   "seekBar.value": "posición",
   "seekBar.timeshift": "cambio de posición",
   "seekBar.durationText": "de",
-  "quickseek.forward": "Adelantar",
-  "quickseek.rewind": "Rebobinar"
+  "quickseek.forward": "Adelantar {seekSeconds} segundos",
+  "quickseek.rewind": "Rebobinar {seekSeconds} segundos"
 }

--- a/src/ts/localization/languages/nl.json
+++ b/src/ts/localization/languages/nl.json
@@ -71,6 +71,6 @@
   "seekBar.value": "Waarde",
   "seekBar.timeshift": "Tijdverschuiving",
   "seekBar.durationText": "van",
-  "quickseek.forward": "Vooruitspoelen",
-  "quickseek.rewind": "Terugspoelen"
+  "quickseek.forward": "{seekSeconds} seconden vooruitspoelen",
+  "quickseek.rewind": "{seekSeconds} seconden terugspoelen"
 }

--- a/src/ts/stringutils.ts
+++ b/src/ts/stringutils.ts
@@ -36,7 +36,7 @@ export namespace StringUtils {
         .replace('ss', leftPadWithZeros(seconds, 2));
   }
 
-  export function secondsToText(totalSeconds: number, leftPadLength = 0): string {
+  export function secondsToText(totalSeconds: number): string {
     const isNegative = totalSeconds < 0;
 
     if (isNegative) {
@@ -51,9 +51,9 @@ export namespace StringUtils {
     const seconds = Math.floor(totalSeconds) % 60;
 
     return (isNegative ? '-' : '') +
-    (hours !== 0 ? `${leftPadWithZeros(hours, leftPadLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.hours'))} ` : '') +
-    (minutes !== 0 ? `${leftPadWithZeros(minutes, leftPadLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.minutes'))} ` : '') +
-    `${leftPadWithZeros(seconds, leftPadLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.seconds'))}`;
+    (hours !== 0 ? `${hours} ${i18n.performLocalization(i18n.getLocalizer('settings.time.hours'))} ` : '') +
+    (minutes !== 0 ? `${minutes} ${i18n.performLocalization(i18n.getLocalizer('settings.time.minutes'))} ` : '') +
+    `${seconds} ${i18n.performLocalization(i18n.getLocalizer('settings.time.seconds'))}`;
   }
 
   /**

--- a/src/ts/stringutils.ts
+++ b/src/ts/stringutils.ts
@@ -36,7 +36,7 @@ export namespace StringUtils {
         .replace('ss', leftPadWithZeros(seconds, 2));
   }
 
-  export function secondsToText(totalSeconds: number): string {
+  export function secondsToText(totalSeconds: number, shouldLeftPadNumbers = true): string {
     const isNegative = totalSeconds < 0;
 
     if (isNegative) {
@@ -50,10 +50,12 @@ export namespace StringUtils {
     const minutes = Math.floor(totalSeconds / 60) - hours * 60;
     const seconds = Math.floor(totalSeconds) % 60;
 
+    const padLength = shouldLeftPadNumbers ? 2 : 0;
+
     return (isNegative ? '-' : '') +
-    (hours !== 0 ? `${leftPadWithZeros(hours, 2)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.hours'))} ` : '') +
-    (minutes !== 0 ? `${leftPadWithZeros(minutes, 2)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.minutes'))} ` : '') +
-    `${leftPadWithZeros(seconds, 2)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.seconds'))}`;
+    (hours !== 0 ? `${leftPadWithZeros(hours, padLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.hours'))} ` : '') +
+    (minutes !== 0 ? `${leftPadWithZeros(minutes, padLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.minutes'))} ` : '') +
+    `${leftPadWithZeros(seconds, padLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.seconds'))}`;
   }
 
   /**

--- a/src/ts/stringutils.ts
+++ b/src/ts/stringutils.ts
@@ -36,7 +36,7 @@ export namespace StringUtils {
         .replace('ss', leftPadWithZeros(seconds, 2));
   }
 
-  export function secondsToText(totalSeconds: number, shouldLeftPadNumbers = true): string {
+  export function secondsToText(totalSeconds: number, leftPadLength = 0): string {
     const isNegative = totalSeconds < 0;
 
     if (isNegative) {
@@ -50,12 +50,10 @@ export namespace StringUtils {
     const minutes = Math.floor(totalSeconds / 60) - hours * 60;
     const seconds = Math.floor(totalSeconds) % 60;
 
-    const padLength = shouldLeftPadNumbers ? 2 : 0;
-
     return (isNegative ? '-' : '') +
-    (hours !== 0 ? `${leftPadWithZeros(hours, padLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.hours'))} ` : '') +
-    (minutes !== 0 ? `${leftPadWithZeros(minutes, padLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.minutes'))} ` : '') +
-    `${leftPadWithZeros(seconds, padLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.seconds'))}`;
+    (hours !== 0 ? `${leftPadWithZeros(hours, leftPadLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.hours'))} ` : '') +
+    (minutes !== 0 ? `${leftPadWithZeros(minutes, leftPadLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.minutes'))} ` : '') +
+    `${leftPadWithZeros(seconds, leftPadLength)} ${i18n.performLocalization(i18n.getLocalizer('settings.time.seconds'))}`;
   }
 
   /**


### PR DESCRIPTION
## Description
The previous implementation of the ARIA spec in the player UI works well on desktop, but has problems on e.g. Samsung Tizen TVs and their integrated Talk Back / Text to Speech functionality.

This PR improves TV support by providing the option to use on/off ARIA labels instead of using the [aria-pressed](https://www.w3.org/TR/wai-aria/#aria-pressed) attribute, as [Tizen doesn't support `pressed`](https://developer.samsung.com/smarttv/develop/guides/fundamentals/text-to-speech.html#ARIA-State-and-Property-Attribute-Support). Additionally, `aria-pressed` is not used automatically for all buttons anymore but is (optionally, if no on/off labels are provided) used for ToggleButtons.

[Tizen does also not support](https://developer.samsung.com/smarttv/develop/guides/fundamentals/text-to-speech.html#ARIA-State-and-Property-Attribute-Support) `aria-valuemax`, `aria-valuemin`, `aria-valuenow` and `aria-valuetext`, which are primarily used for the seekbar and similar sliders. 
This PR adds an optional configuration option to set the current playback time also on the `aria-label` (in addition to the element name).

The `ErrorMessageOverlay` didn't contain any ARIA attribute with the Error, which is added in this PR as well.


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
