### PR TITLE
Add Ads TV UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Ads UI variant to default TV UI
+
 ## [3.91.0] - 2025-04-10
 
 ### Added

--- a/src/scss/skin-modern/_skin-tv.scss
+++ b/src/scss/skin-modern/_skin-tv.scss
@@ -90,6 +90,10 @@
     font-size: 2.5vh;
   }
 
+  .#{$prefix}-ui-ads-status {
+    font-size: $medium-size;
+  }
+
   :focus {
     border: 0;
     box-shadow: $focus-element-box-shadow;

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -466,7 +466,16 @@ export namespace UIFactory {
       player,
       [
         {
+          ...modernTvAdsUI(),
+          condition: (context: UIConditionContext) => {
+            return context.isAd && context.adRequiresUi;
+          },
+        },
+        {
           ...modernTvUI(),
+          condition: (context: UIConditionContext) => {
+            return !context.isAd && !context.adRequiresUi;
+          }
         },
       ],
       config,
@@ -574,5 +583,51 @@ export namespace UIFactory {
       ui: uiContainer,
       spatialNavigation: spatialNavigation,
     };
+  }
+
+  export function modernTvAdsUI() {
+    const skipAdButton = new AdSkipButton();
+    const playbackToggleButton = new PlaybackToggleButton();
+    const volumeToggleButton = new VolumeToggleButton();
+
+    const uiContainer = new UIContainer({
+      components: [
+        new BufferingOverlay(),
+        new AdClickOverlay(),
+        new PlaybackToggleOverlay(),
+
+        new Container({
+          components: [new AdMessageLabel({ text: i18n.getLocalizer('ads.remainingTime') }), skipAdButton],
+          cssClass: 'ui-ads-status',
+        }),
+        new ControlBar({
+          components: [
+            new Container({
+              components: [
+                playbackToggleButton,
+                volumeToggleButton,
+              ],
+              cssClasses: ['controlbar-bottom'],
+            }),
+          ],
+        }),
+      ],
+      cssClasses: ['ui-skin-tv', 'ui-skin-ads'],
+      hideDelay: 2000,
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
+    });
+
+    const spatialNavigation = new SpatialNavigation(
+      new RootNavigationGroup(uiContainer, playbackToggleButton, volumeToggleButton, skipAdButton),
+    );
+
+    return {
+      ui: uiContainer,
+      spatialNavigation: spatialNavigation,
+    }
   }
 }

--- a/src/ts/uifactory.ts
+++ b/src/ts/uifactory.ts
@@ -588,7 +588,6 @@ export namespace UIFactory {
   export function modernTvAdsUI() {
     const skipAdButton = new AdSkipButton();
     const playbackToggleButton = new PlaybackToggleButton();
-    const volumeToggleButton = new VolumeToggleButton();
 
     const uiContainer = new UIContainer({
       components: [
@@ -605,7 +604,6 @@ export namespace UIFactory {
             new Container({
               components: [
                 playbackToggleButton,
-                volumeToggleButton,
               ],
               cssClasses: ['controlbar-bottom'],
             }),
@@ -622,7 +620,7 @@ export namespace UIFactory {
     });
 
     const spatialNavigation = new SpatialNavigation(
-      new RootNavigationGroup(uiContainer, playbackToggleButton, volumeToggleButton, skipAdButton),
+      new RootNavigationGroup(uiContainer, playbackToggleButton, skipAdButton),
     );
 
     return {


### PR DESCRIPTION
## Description
A port of the ads UI variant to the TV UI. It will not be used for the default Google IMA Ads Module, but with the Bitmvoin Ads Module.

### Not skippable yet:
![Screenshot 2025-04-22 at 14 21 48](https://github.com/user-attachments/assets/07794a77-d6f6-4edc-91c6-e2de6503ba80)

### Skippable:
![Screenshot 2025-04-22 at 14 21 53](https://github.com/user-attachments/assets/c8392b51-c9ab-41ff-9ff8-62be2d20f693)

### Controlbar visible and ad skippable:
![Screenshot 2025-04-22 at 14 39 46](https://github.com/user-attachments/assets/b7fac35d-e830-476d-818d-8d1ed9583f33)


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
