### PR TITLE
Make `SettingsPanel` generic

### DIFF
--- a/spec/components/settings/SettingsPanel.spec.ts
+++ b/spec/components/settings/SettingsPanel.spec.ts
@@ -2,7 +2,7 @@ import type { PlayerAPI } from 'bitmovin-player';
 
 import type { Component, ComponentConfig, ViewModeChangedEventArgs } from '../../../src/ts/components/Component';
 import { ViewMode } from '../../../src/ts/components/Component';
-import { SettingsPanel } from '../../../src/ts/components/settings/SettingsPanel';
+import { SettingsPanel, SettingsPanelConfig } from '../../../src/ts/components/settings/SettingsPanel';
 import { SettingsPanelPage } from '../../../src/ts/components/settings/SettingsPanelPage';
 import { EventDispatcher } from '../../../src/ts/EventDispatcher';
 import type { UIInstanceManager } from '../../../src/ts/UIManager';
@@ -14,7 +14,7 @@ import { SelectBox } from '../../../src/ts/components/settings/SelectBox';
 import { SettingsPanelItem } from '../../../src/ts/components/settings/SettingsPanelItem';
 import { VolumeSlider } from '../../../src/ts/components/seekbar/VolumeSlider';
 
-let settingsPanel: SettingsPanel;
+let settingsPanel: SettingsPanel<SettingsPanelConfig>;
 
 describe('SettingsPanel', () => {
   describe('page navigation', () => {

--- a/spec/spatialnavigation/SpatialNavigation.spec.ts
+++ b/spec/spatialnavigation/SpatialNavigation.spec.ts
@@ -2,7 +2,7 @@ import { SpatialNavigation } from '../../src/ts/spatialnavigation/SpatialNavigat
 import { RootNavigationGroup } from '../../src/ts/spatialnavigation/RootNavigationGroup';
 import { UIContainer } from '../../src/ts/components/UIContainer';
 import { NavigationGroup } from '../../src/ts/spatialnavigation/NavigationGroup';
-import { SettingsPanel } from '../../src/ts/components/settings/SettingsPanel';
+import { SettingsPanel, SettingsPanelConfig } from '../../src/ts/components/settings/SettingsPanel';
 import { NodeEventSubscriber } from '../../src/ts/spatialnavigation/NodeEventSubscriber';
 import { SeekBarHandler } from '../../src/ts/spatialnavigation/SeekBarHandler';
 import { Action, Direction } from '../../src/ts/spatialnavigation/types';
@@ -17,7 +17,7 @@ describe('SpatialNavigation', () => {
   let rootNavigationContainer: UIContainer;
 
   let otherNavigationGroup: NavigationGroup;
-  let otherNavigationContainer: SettingsPanel;
+  let otherNavigationContainer: SettingsPanel<SettingsPanelConfig>;
   
   beforeEach(() => {
     rootNavigationContainer = new UIContainer({});

--- a/src/ts/components/settings/DynamicSettingsPanelItem.ts
+++ b/src/ts/components/settings/DynamicSettingsPanelItem.ts
@@ -8,7 +8,7 @@ import { SettingsPanelItem, SettingsPanelItemConfig } from './SettingsPanelItem'
 import { SettingsPanelSelectOption } from './SettingsPanelSelectOption';
 import { SettingsPanelPage } from './SettingsPanelPage';
 import { SubtitleSettingsLabel } from './subtitlesettings/SubtitleSettingsLabel';
-import { SettingsPanel } from './SettingsPanel';
+import { SettingsPanel, SettingsPanelConfig } from './SettingsPanel';
 import { SettingsPanelPageBackButton } from './SettingsPanelPageBackButton';
 import { SubtitleSettingSelectBox } from './subtitlesettings/SubtitleSettingSelectBox';
 import { InteractiveSettingsPanelItem } from './InteractiveSettingsPanelItem';
@@ -30,7 +30,7 @@ export interface DynamicSettingsPanelItemConfig extends SettingsPanelItemConfig 
   /**
    * The enclosing {@link SettingsPanel} where the sub page will be added.
    */
-  container: SettingsPanel;
+  container: SettingsPanel<SettingsPanelConfig>;
 }
 
 /**

--- a/src/ts/components/settings/SettingsPanel.ts
+++ b/src/ts/components/settings/SettingsPanel.ts
@@ -60,7 +60,7 @@ export enum NavigationDirection {
  *
  * @category Components
  */
-export class SettingsPanel extends Container<SettingsPanelConfig> {
+export class SettingsPanel<Config extends SettingsPanelConfig> extends Container<Config> {
 
   private static readonly CLASS_ACTIVE_PAGE = 'active';
 
@@ -69,19 +69,19 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
   private navigationStack: SettingsPanelPage[] = [];
 
   private settingsPanelEvents = {
-    onSettingsStateChanged: new EventDispatcher<SettingsPanel, NoArgs>(),
+    onSettingsStateChanged: new EventDispatcher<SettingsPanel<SettingsPanelConfig>, NoArgs>(),
   };
 
   private hideTimeout: Timeout;
 
-  constructor(config: SettingsPanelConfig) {
+  constructor(config: Config) {
     super(config);
 
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-settings-panel',
       hideDelay: 3000,
       pageTransitionAnimation: true,
-    } as SettingsPanelConfig, this.config);
+    } as Config, this.config);
 
     this.activePage = this.getRootPage();
   }
@@ -261,7 +261,7 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
     return <SettingsPanelPage[]>this.config.components.filter(component => component instanceof SettingsPanelPage);
   }
 
-  get onSettingsStateChanged(): Event<SettingsPanel, NoArgs> {
+  get onSettingsStateChanged(): Event<SettingsPanel<SettingsPanelConfig>, NoArgs> {
     return this.settingsPanelEvents.onSettingsStateChanged.getEvent();
   }
 

--- a/src/ts/components/settings/SettingsPanelPageNavigatorButton.ts
+++ b/src/ts/components/settings/SettingsPanelPageNavigatorButton.ts
@@ -1,5 +1,5 @@
 import {Button, ButtonConfig} from '../buttons/Button';
-import {SettingsPanel} from './SettingsPanel';
+import { SettingsPanel, SettingsPanelConfig } from './SettingsPanel';
 import {SettingsPanelPage} from './SettingsPanelPage';
 import { PlayerAPI } from 'bitmovin-player';
 import { UIInstanceManager } from '../../UIManager';
@@ -13,7 +13,7 @@ export interface SettingsPanelPageNavigatorConfig extends ButtonConfig {
   /**
    * Container `SettingsPanel` where the navigation takes place
    */
-  container: SettingsPanel;
+  container: SettingsPanel<SettingsPanelConfig>;
   /**
    * Page where the button should navigate to
    * If empty it will navigate to the root page (not intended to use as navigate back behavior)
@@ -42,7 +42,7 @@ export interface SettingsPanelPageNavigatorConfig extends ButtonConfig {
  * @category Buttons
  */
 export class SettingsPanelPageNavigatorButton extends Button<SettingsPanelPageNavigatorConfig> {
-  private readonly container: SettingsPanel;
+  private readonly container: SettingsPanel<SettingsPanelConfig>;
   private readonly targetPage?: SettingsPanelPage;
 
   constructor(config: SettingsPanelPageNavigatorConfig) {

--- a/src/ts/components/settings/SettingsToggleButton.ts
+++ b/src/ts/components/settings/SettingsToggleButton.ts
@@ -1,5 +1,5 @@
 import {ToggleButton, ToggleButtonConfig} from '../buttons/ToggleButton';
-import {SettingsPanel} from './SettingsPanel';
+import { SettingsPanel, SettingsPanelConfig } from './SettingsPanel';
 import {UIInstanceManager} from '../../UIManager';
 import {Component, ComponentConfig} from '../Component';
 import {ArrayUtils} from '../../utils/ArrayUtils';
@@ -15,7 +15,7 @@ export interface SettingsToggleButtonConfig extends ToggleButtonConfig {
   /**
    * The settings panel whose visibility the button should toggle.
    */
-  settingsPanel: SettingsPanel;
+  settingsPanel: SettingsPanel<SettingsPanelConfig>;
 
   /**
    * Decides if the button should be automatically hidden when the settings panel does not contain any active settings.
@@ -31,7 +31,7 @@ export interface SettingsToggleButtonConfig extends ToggleButtonConfig {
  */
 export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfig> {
 
-  private visibleSettingsPanels: SettingsPanel[] = [];
+  private visibleSettingsPanels: SettingsPanel<SettingsPanelConfig>[] = [];
 
   constructor(config: SettingsToggleButtonConfig) {
     super(config);

--- a/src/ts/components/settings/subtitlesettings/SubtitleSettingsPanelPage.ts
+++ b/src/ts/components/settings/subtitlesettings/SubtitleSettingsPanelPage.ts
@@ -1,5 +1,5 @@
 import { SettingsPanelPage, SettingsPanelPageConfig } from '../SettingsPanelPage';
-import {SettingsPanel} from '../SettingsPanel';
+import { SettingsPanel, SettingsPanelConfig } from '../SettingsPanel';
 import {SubtitleOverlay} from '../../overlays/SubtitleOverlay';
 import {Component, ComponentConfig} from '../../Component';
 import {FontSizeSelectBox} from './FontSizeSelectBox';
@@ -26,7 +26,7 @@ import { CharacterEdgeColorSelectBox } from './CharacterEdgeColorSelectBox';
  * @category Configs
  */
 export interface SubtitleSettingsPanelPageConfig extends SettingsPanelPageConfig {
-  settingsPanel: SettingsPanel;
+  settingsPanel: SettingsPanel<SettingsPanelConfig>;
   overlay: SubtitleOverlay;
   useDynamicSettingsPanelItem?: boolean;
 }
@@ -37,7 +37,7 @@ export interface SubtitleSettingsPanelPageConfig extends SettingsPanelPageConfig
 export class SubtitleSettingsPanelPage extends SettingsPanelPage {
 
   private readonly overlay: SubtitleOverlay;
-  private readonly settingsPanel: SettingsPanel;
+  private readonly settingsPanel: SettingsPanel<SettingsPanelConfig>;
 
   constructor(config: SubtitleSettingsPanelPageConfig) {
     super(config);

--- a/src/ts/spatialnavigation/TypeGuards.ts
+++ b/src/ts/spatialnavigation/TypeGuards.ts
@@ -1,10 +1,10 @@
 import { Component } from '../components/Component';
-import { SettingsPanel } from '../components/settings/SettingsPanel';
+import { SettingsPanel, SettingsPanelConfig } from '../components/settings/SettingsPanel';
 import { Container } from '../components/Container';
 import { ListBox } from '../components/lists/ListBox';
 import { Action, Direction } from './types';
 
-export function isSettingsPanel(component: Component<unknown>): component is SettingsPanel {
+export function isSettingsPanel(component: Component<unknown>): component is SettingsPanel<SettingsPanelConfig> {
   return component instanceof SettingsPanel;
 }
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
We want to leverage the usage of `ListBox`es in v4. Especially for the TV UI or wherever we put subtitle / audio track selection to the root UI.

The `ListBox` was originally implemented as an alternative to the native select boxes for exactly that use-case. For v4 we already migrated away from using the select boxes to use a more modern settings panel approach. This approach (and especially its styling) can now be re-used for `ListBox`es. To enable the inheritance from `SettingsPanel`, we need to make it generic first.

This PR prepares that by introducing a `SettingsPanelConfig` and making the `SettingsPanel` generic.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **A final v4 changleog entry will be added in a separate PR**
