### PR TITLE
Fix CEA caption rendering if no user preference is present for font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- CEA caption rendering broken if no user preference is present for subtitle font size
+
 ## [3.92.0] - 2025-04-23
 
 ### Added

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -87,6 +87,10 @@ describe('SubtitleOverlay', () => {
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
     });
 
+    it('should preserve default FONT_SIZE_FACTOR of 1 if no font size value on settings present', () => {
+      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(1);
+    });
+
     // Font size factor clamping
     test.each([
       [0.2, 0.5],  // Clamped to minimum

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -309,8 +309,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
 
     const settingsManager = uimanager.getSubtitleSettingsManager();
-    const fontSizeFactorSettings = this.resolveFontSizeFactor(settingsManager.fontSize.value ?? '100');
-    this.setFontSizeFactor(fontSizeFactorSettings);
+    if (settingsManager.fontSize.value != null) {
+      const fontSizeFactorSettings = this.resolveFontSizeFactor(settingsManager.fontSize.value);
+      this.setFontSizeFactor(fontSizeFactorSettings);
+    }
 
     settingsManager.fontSize.onChanged.subscribe((_sender, property) => {
       if (property.isSet()) {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -263,11 +263,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       return !isNaN(percent) && percent <= 200;
     }
 
-    return true
+    return true;
   };
 
   resolveFontSizeFactor(value: string): number {
-    return parseInt(value) / 100;;
+    return parseInt(value) / 100;
   }
 
   updateRegionRowPosition(r: SubtitleRegionContainer): void {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -309,7 +309,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
 
     const settingsManager = uimanager.getSubtitleSettingsManager();
-    const fontSizeFactorSettings = this.resolveFontSizeFactor(settingsManager.fontSize.value);
+    const fontSizeFactorSettings = this.resolveFontSizeFactor(settingsManager.fontSize.value ?? '100');
     this.setFontSizeFactor(fontSizeFactorSettings);
 
     settingsManager.fontSize.onChanged.subscribe((_sender, property) => {


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

<!-- https://bitmovin.atlassian.net/browse/PW-22838 -->


### Problem
The initial font size calculation fails if there is no user preference for font size present in local storage. Some calculations for styles would result in `NaN` values.

This then results in broken caption rendering

<img width="1127" alt="Screenshot 2025-05-09 at 09 09 48" src="https://github.com/user-attachments/assets/92444b16-5b02-49dd-bb5b-e7a4762b2fd5" />

caused by NaN values in the styles
<img width="1213" alt="Screenshot 2025-05-09 at 09 10 24" src="https://github.com/user-attachments/assets/35a88848-4f81-4e6e-b6b7-42a01833a572" />


#### Repro steps:
1. Play stream w/ CEA captions
2. Clear any user preferences in local storage: Open settings menu for subtitle styling in player UI, click `Reset` on bottom right
3. Reload page
4. Enable CEA captions and observe broken rendering

### Changes

Only restore the font size value from settings manager if it is defined (i.e. restored from local storage).

If it is not defined we can just let the default `FONT_SIZE_FACTOR` of `1` (equivalent to 100%) untouched.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
