### PR TITLE
Clean up caption window when removing inactive cues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Seeking with active CEA captions left an empty window behind
+
 ## [3.93.0] - 2025-05-09
 
 ### Fixed

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -134,6 +134,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       removedActiveCues.forEach(toRemove => {
         this.subtitleContainerManager.removeLabel(toRemove.label);
       });
+      this.updateComponents();
     };
 
     player.on(player.exports.PlayerEvent.AudioChanged, subtitleClearHandler);


### PR DESCRIPTION
## Description
When playing a stream with CEA captions and having a window color to make the CEA window visible and then seeking, the captions will disappear while the window stays visible.

First play the stream and pause when captions are shown:
![image](https://github.com/user-attachments/assets/7ee23876-25ac-4b0a-b420-bc717867f668)

then start seeking without resuming playback:

![image](https://github.com/user-attachments/assets/32000ae4-baa3-411e-9fae-367b0f276610)


With the changes in this PR the window will also get cleaned up.


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
