### PR TITLE
WebVTT doesn't render when region styles are present 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- WebVTT doesn't render when region styles are present 
+
 ## [3.93.0] - 2025-05-09
 
 ### Fixed

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -753,17 +753,14 @@ export class SubtitleRegionContainerManager {
 
       if (label.regionStyle) {
         regionContainer.getDomElement().attr('style', label.regionStyle);
+      } 
+
+      if (label.vtt) {
         regionContainer.getDomElement().css('position', 'static');
-      } else if (label.vtt && !label.vtt.region) {
-        /**
-         * If there is no region present to wrap the Cue Box, the Cue box becomes the
-         * region itself. Therefore the positioning values have to come from the box.
-         */
-        regionContainer.getDomElement().css('position', 'static');
-      } else {
-        // getDomElement needs to be called at least once to ensure the component exists
-        regionContainer.getDomElement();
       }
+
+      // getDomElement needs to be called at least once to ensure the component exists
+      regionContainer.getDomElement();
 
       for (const regionContainerId in this.subtitleRegionContainers) {
         this.subtitleOverlay.addComponent(this.subtitleRegionContainers[regionContainerId]);

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -753,6 +753,7 @@ export class SubtitleRegionContainerManager {
 
       if (label.regionStyle) {
         regionContainer.getDomElement().attr('style', label.regionStyle);
+        regionContainer.getDomElement().css('position', 'static');
       } else if (label.vtt && !label.vtt.region) {
         /**
          * If there is no region present to wrap the Cue Box, the Cue box becomes the


### PR DESCRIPTION

## Description
When WebVTT subtitles with a STYLES definition are used, the subtitle CSS `position:static` property, which affects rendering

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
