### PR TITLE
Make subtitle window fully enclose CEA captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Background of CEA captions now does not cover the subtitle window fully
+
 ## [3.93.0] - 2025-05-09
 
 ### Fixed

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -364,12 +364,14 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         (dummyLabelCharHeight * this.CEA608_NUM_ROWS);
       // The size ratio of the available space for the grid
       const subtitleOverlaySizeRatio = subtitleOverlayWidth / subtitleOverlayHeight;
+      let newRowHeight = 0;
 
       if (subtitleOverlaySizeRatio > fontGridSizeRatio) {
         // When the available space is wider than the text grid, the font size is simply
         // determined by the height of the available space.
-        fontSize = subtitleOverlayHeight / this.CEA608_NUM_ROWS;
-
+        newRowHeight = subtitleOverlayHeight / this.CEA608_NUM_ROWS;
+        fontSize = newRowHeight * (1 - windowPaddingRatio);
+        
         // Calculate the additional letter spacing required to evenly spread the text across the grid's width
         const gridSlotWidth = subtitleOverlayWidth / this.CEA608_NUM_COLUMNS;
         const fontCharWidth = fontSize * fontSizeRatio;
@@ -378,13 +380,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         // When the available space is not wide enough, texts would vertically overlap if we take
         // the height as a base for the font size, so we need to limit the height. We do that
         // by determining the font size by the width of the available space.
-        fontSize = subtitleOverlayWidth / this.CEA608_NUM_COLUMNS / fontSizeRatio;
+        newRowHeight = subtitleOverlayWidth / this.CEA608_NUM_COLUMNS / fontSizeRatio;
+        fontSize = newRowHeight * (1 - windowPaddingRatio);
         fontLetterSpacing = 0;
       }
-
-      // After computing overlay dimensions:
-      const newRowHeight = fontSize;
-      fontSize = newRowHeight * (1 - windowPaddingRatio);
+      
       windowPadding = newRowHeight * windowPaddingRatio;
 
       // Update row position of regions

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -36,6 +36,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CLASS_CEA_608 = 'cea608';
   private static readonly DEFAULT_CEA608_NUM_ROWS = 15;
   private static readonly DEFAULT_CEA608_NUM_COLUMNS = 32;
+  private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
 
   private FONT_SIZE_FACTOR: number = 1;
   // The number of rows in a cea608 grid
@@ -408,7 +409,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
           'line-height': `${fontSize}px`,
           'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
           'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
-          'left': isLargerFontSize && '0%',
+          'left': isLargerFontSize && SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET,
         });
 
         label.regionStyle = `line-height: ${fontSize}px; padding: ${windowPadding / 2}px; height: ${fontSize}px`;
@@ -465,8 +466,14 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // We disable the grid and wrapping in case enlarged font size is used to prevent
       // line and characters overflows
       const isLargerFontSize = this.FONT_SIZE_FACTOR > 1
+      let leftOffset = event.position.column * this.CEA608_COLUMN_OFFSET + '%';
+      if (leftOffset === '0%' || isLargerFontSize) {
+        // ensure that a little of the window still shows for better readability
+        leftOffset = SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET;
+      }
+
       label.getDomElement().css({
-        'left': `${isLargerFontSize ? 0 : event.position.column * this.CEA608_COLUMN_OFFSET}%`,
+        'left': leftOffset,
         'font-size': `${fontSize}px`,
         'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
         'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -304,9 +304,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     let fontLetterSpacing = 0;
     // Flag telling if a font size calculation is required of if the current values are valid
     let fontSizeCalculationRequired = true;
+    // The ratio of the caption window/row height that is used as padding to make the window enclose the caption
+    const windowPaddingRatio = 0.2;
+    let windowPadding: number;
     // Flag telling if the CEA-608 mode is enabled
     this.cea608Enabled = false;
-
 
     const settingsManager = uimanager.getSubtitleSettingsManager();
     if (settingsManager.fontSize.value != null) {
@@ -382,6 +384,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       // After computing overlay dimensions:
       const newRowHeight = fontSize;
+      fontSize = newRowHeight * (1 - windowPaddingRatio);
+      windowPadding = newRowHeight * windowPaddingRatio;
 
       // Update row position of regions
       const regions = this.getComponents();
@@ -407,7 +411,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
           'left': isLargerFontSize && '0%',
         });
 
-        label.regionStyle = `line-height: ${fontSize}px;`;
+        label.regionStyle = `line-height: ${fontSize}px; padding: ${windowPadding / 2}px; height: ${fontSize}px`;
       }
 
       for (let label of this.getComponents()) {
@@ -462,7 +466,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
       });
 
-      label.regionStyle = `line-height: ${fontSize}px;`;
+      label.regionStyle = `line-height: ${fontSize}px; padding: ${windowPadding / 2}px; height: ${fontSize}px`;
     });
 
     const reset = () => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -414,21 +414,21 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         label.regionStyle = `line-height: ${fontSize}px; padding: ${windowPadding / 2}px; height: ${fontSize}px`;
       }
 
-      for (let label of this.getComponents()) {
-        if (label instanceof SubtitleRegionContainer) {
-          label.getDomElement().css({
+      for (const childComponent of this.getComponents()) {
+        if (childComponent instanceof SubtitleRegionContainer) {
+          childComponent.getDomElement().css({
             'line-height': `${fontSize}px`,
             padding: `${windowPadding / 2}px`,
             height: `${fontSize}px`
           });
 
-          label.getComponents().forEach((l: SubtitleLabel) => {
+          childComponent.getComponents().forEach((l: SubtitleLabel) => {
             updateLabel(l);
           })
         }
 
-        if (label instanceof SubtitleLabel) {
-          updateLabel(label);
+        if (childComponent instanceof SubtitleLabel) {
+          updateLabel(childComponent);
         }
       }
     };

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -416,6 +416,12 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       for (let label of this.getComponents()) {
         if (label instanceof SubtitleRegionContainer) {
+          label.getDomElement().css({
+            'line-height': `${fontSize}px`,
+            padding: `${windowPadding / 2}px`,
+            height: `${fontSize}px`
+          });
+
           label.getComponents().forEach((l: SubtitleLabel) => {
             updateLabel(l);
           })


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
<!-- https://bitmovin.atlassian.net/browse/PW-22838 -->

### Problem

The subtitle window of CEA captions does not enclose the caption on all sides.

To demonstrate this, in below example there are two captions with green background and blue subtitle window.

![Screenshot 2025-05-13 at 15 56 12](https://github.com/user-attachments/assets/d09af7e4-2504-4abb-970d-d44a2bdc0e3c)

### Fix

Context: With CEA captions there is a display of 15 equal-height rows, i.e. there's a height allocated for each row.

- Introduce a ratio that defines what amount of the row height should be used for the caption window, effectively a padding at top and bottom. E.g. a ratio of `0.2` means 20% of row height will be padding, 10% at top and bottom, respectively. This also means that the actual cue text has less space, i.e. `0.8` of the row height in our example.
- Ensure that the cues do not stick to the left side of the window but rather leave a little space to let some of the window through. As this must scale with Player resizes and Font changes, this will now be set to 0.5% of the width. Calculating the offset in JS did not work out well, since the width of the component can be 0 if it's not shown.

This results in the captions looking like this now:
![image](https://github.com/user-attachments/assets/1a34154f-069a-4ff6-9847-b580e2181c9d)


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
