### PR TITLE
Update time in seekbar immediately when transitioning from Live to VOD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- The `PlaybackTimeLabel`s now immediately display the time instead of flickering `LIVE` for a short time when transitioning from Live to VOD
+
 ## [3.96.0] - 2025-05-16
 
 ### Changed

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -114,13 +114,6 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       }
     };
 
-    let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
-    liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
-      live = args.live;
-      updateLiveState();
-    });
-    liveStreamDetector.detect(); // Initial detection
-
     let playbackTimeHandler = () => {
       if (!live && player.getDuration() !== Infinity) {
         this.setTime(
@@ -138,6 +131,14 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
         });
       }
     };
+
+    let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
+    liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
+      live = args.live;
+      playbackTimeHandler();
+      updateLiveState();
+    });
+    liveStreamDetector.detect(); // Initial detection
 
     let updateTimeFormatBasedOnDuration = () => {
       // Set time format depending on source duration


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
In the use case when a stream transitions from Live to VOD, the `PlaybackTimeLabel` will become visible. In the case the UI is visible in exactly that moment, the text of the `PlaybackTimeLabel` will be `LIVE` until the next `TimeChangedEvent` is received.

<img src="https://github.com/user-attachments/assets/d2723fbf-b63d-413b-b15c-b9ae7497ec43" width="300px"/>

### Fix
To fix this, the `PlaybackTimeLabel` now immediately updates its time information when detecting a Live to VOD transition.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
