### PR TITLE
Update `PlaybackTimeLabel` format in Live to VOD transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- The `PlaybackTimeLabel`s time format was incorrectly displayed as `mm:ss` instead of `hh:mm:ss` when the duration is higher than 1 hour when transitioning from Live to VOD
+
 ## [3.97.0] - 2025-06-12
 
 ### Fixed

--- a/src/ts/components/playbacktimelabel.ts
+++ b/src/ts/components/playbacktimelabel.ts
@@ -132,20 +132,21 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       }
     };
 
-    let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
-    liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
-      live = args.live;
-      playbackTimeHandler();
-      updateLiveState();
-    });
-    liveStreamDetector.detect(); // Initial detection
-
     let updateTimeFormatBasedOnDuration = () => {
       // Set time format depending on source duration
       this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
       StringUtils.FORMAT_HHMMSS : StringUtils.FORMAT_MMSS;
       playbackTimeHandler();
     };
+
+    let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
+    liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
+      live = args.live;
+      playbackTimeHandler();
+      updateTimeFormatBasedOnDuration();
+      updateLiveState();
+    });
+    liveStreamDetector.detect(); // Initial detection
 
     player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
     player.on(player.exports.PlayerEvent.Ready, updateTimeFormatBasedOnDuration);


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
This is a follow up fix from #707 where we updated the time in the seekbar during a Live to VOD transision. However, if the duration of the asset is now greater than 1 hour, the format of the time label did not update accordingly and was stuck in `HH:SS` stripping the hours from it.

## Changes
Call the already existing update function to update the format according to the new duration.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
