### PR TITLE
Modern UI - Add TitleBar in Ads UI layout

### DIFF
--- a/src/scss/_ads.scss
+++ b/src/scss/_ads.scss
@@ -4,6 +4,7 @@
 .#{$prefix}-ui-ads {
   @import 'components/ads/ad-skip-button';
   @import 'components/ads/ad-status-overlay';
+  @import 'components/ads/ad-message-label';
 
   .#{$prefix}-ui-seekbar {
     .#{$prefix}-seekbar,

--- a/src/scss/components/ads/_ad-message-label.scss
+++ b/src/scss/components/ads/_ad-message-label.scss
@@ -1,0 +1,13 @@
+@import '../../variables';
+
+.#{$prefix}-ui-ad-message-label {
+  @extend %ui-label;
+
+  pointer-events: none;
+  cursor: default;
+  display: block;
+  font-size: 1.2em;
+  font-weight: 500;
+  text-shadow: 0 0 5px $color-black;
+  white-space: normal;
+}

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -376,6 +376,7 @@ function adsUILayout() {
             cssClasses: ['ui-titlebar-top'],
           }),
         ],
+        keepHiddenWithoutMetadata: true,
       }),
       new ErrorMessageOverlay(),
     ],

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -367,7 +367,6 @@ function adsUILayout() {
       new AdStatusOverlay(),
       controlBar,
       new TitleBar({
-        // keepHiddenWithoutMetadata: true,
         components: [
           new Container({
             components: [

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -50,6 +50,7 @@ import { DynamicSettingsPanelItem } from './components/settings/DynamicSettingsP
 import { TouchControlOverlay } from './components/overlays/TouchControlOverlay';
 import { AdStatusOverlay } from './components/ads/AdStatusOverlay';
 import { DismissClickOverlay } from './components/overlays/DismissClickOverlay';
+import { AdMessageLabel } from './main';
 
 /**
  * Provides factory methods to create Bitmovin provided UIs.
@@ -370,7 +371,7 @@ function adsUILayout() {
         components: [
           new Container({
             components: [
-              new MetadataLabel({ content: MetadataLabelContent.AdMessage }),
+              new AdMessageLabel(),
             ],
             cssClasses: ['ui-titlebar-top'],
           }),

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -366,6 +366,23 @@ function adsUILayout() {
       new PlaybackToggleOverlay(),
       new AdStatusOverlay(),
       controlBar,
+      new TitleBar({
+        // keepHiddenWithoutMetadata: true,
+        components: [
+          new Container({
+            components: [
+              new MetadataLabel({ content: MetadataLabelContent.Title }),
+            ],
+            cssClasses: ['ui-titlebar-top'],
+          }),
+          new Container({
+            components: [
+              new MetadataLabel({ content: MetadataLabelContent.Description }),
+            ],
+            cssClasses: ['ui-titlebar-bottom'],
+          }),
+        ],
+      }),
       new ErrorMessageOverlay(),
     ],
     hideDelay: 2000,

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -370,15 +370,9 @@ function adsUILayout() {
         components: [
           new Container({
             components: [
-              new MetadataLabel({ content: MetadataLabelContent.Title }),
+              new MetadataLabel({ content: MetadataLabelContent.AdMessage }),
             ],
             cssClasses: ['ui-titlebar-top'],
-          }),
-          new Container({
-            components: [
-              new MetadataLabel({ content: MetadataLabelContent.Description }),
-            ],
-            cssClasses: ['ui-titlebar-bottom'],
           }),
         ],
       }),

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -50,7 +50,7 @@ import { DynamicSettingsPanelItem } from './components/settings/DynamicSettingsP
 import { TouchControlOverlay } from './components/overlays/TouchControlOverlay';
 import { AdStatusOverlay } from './components/ads/AdStatusOverlay';
 import { DismissClickOverlay } from './components/overlays/DismissClickOverlay';
-import { AdMessageLabel } from './main';
+import { AdMessageLabel } from './components/ads/AdMessageLabel';
 
 /**
  * Provides factory methods to create Bitmovin provided UIs.

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -12,7 +12,7 @@ export class AdMessageLabel extends Label<LabelConfig> {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClasses: ['label-metadata', 'label-metadata-title'],
+      cssClass: 'ui-ad-message-label',
     }, this.config);
   }
 

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -26,6 +26,8 @@ export class AdMessageLabel extends Label<LabelConfig> {
     clearText();
 
     player.on(player.exports.PlayerEvent.SourceUnloaded, clearText);
+    player.on(player.exports.PlayerEvent.AdError, clearText);
+    player.on(player.exports.PlayerEvent.AdSkipped, clearText);
     player.on(player.exports.PlayerEvent.AdFinished, clearText);
     player.on(player.exports.PlayerEvent.AdStarted, (event) => {
       const ad = (event as AdEvent).ad;

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -1,51 +1,50 @@
-import {Label, LabelConfig} from '../labels/Label';
 import {UIInstanceManager} from '../../UIManager';
-import {StringUtils} from '../../utils/StringUtils';
 import { AdEvent, LinearAd, PlayerAPI } from 'bitmovin-player';
-import { i18n } from '../../localization/i18n';
+import { Label, LabelConfig } from '../labels/Label';
 
 /**
- * A label that displays a message about a running ad, optionally with a countdown.
+ * A label that displays a message regarding the ad that's currently being played.
  *
- * @category Components
+ * @category Labels
  */
 export class AdMessageLabel extends Label<LabelConfig> {
+  private adMessage: string = '';
 
   constructor(config: LabelConfig = {}) {
     super(config);
 
     this.config = this.mergeConfig(config, {
-      cssClass: 'ui-label-ad-message',
-      text: i18n.getLocalizer('ads.remainingTime') ,
+      cssClasses: ['label-metadata', 'label-metadata-title'],
     }, this.config);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
-    let text = config.text;
-
-    let updateMessageHandler = () => {
-      this.setText(StringUtils.replaceAdMessagePlaceholders(i18n.performLocalization(text), null, player));
+    const init = () => {
+      this.setText(this.adMessage);
     };
 
-    let adStartHandler = (event: AdEvent) => {
-      let uiConfig = (event.ad as LinearAd).uiConfig;
-      text = uiConfig && uiConfig.message || config.text;
-
-      updateMessageHandler();
-
-      player.on(player.exports.PlayerEvent.TimeChanged, updateMessageHandler);
+    const unload = () => {
+      this.setText('');
+      this.adMessage = '';
     };
 
-    let adEndHandler = () => {
-      player.off(player.exports.PlayerEvent.TimeChanged, updateMessageHandler);
-    };
+    init();
 
-    player.on(player.exports.PlayerEvent.AdStarted, adStartHandler);
-    player.on(player.exports.PlayerEvent.AdSkipped, adEndHandler);
-    player.on(player.exports.PlayerEvent.AdError, adEndHandler);
-    player.on(player.exports.PlayerEvent.AdFinished, adEndHandler);
+    player.on(player.exports.PlayerEvent.SourceUnloaded, unload);
+    player.on(player.exports.PlayerEvent.AdFinished, unload);
+    player.on(player.exports.PlayerEvent.AdStarted, (event) => {
+      const ad = (event as AdEvent).ad;
+      if (!ad.isLinear) {
+        return;
+      }
+
+      const linearAd = ad as LinearAd;
+      this.adMessage = linearAd.uiConfig?.message ?? '';
+      init();
+    });
+
+    uimanager.getConfig().events.onUpdated.subscribe(init);
   }
 }

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -38,7 +38,5 @@ export class AdMessageLabel extends Label<LabelConfig> {
       const linearAd = ad as LinearAd;
       this.setText(linearAd.uiConfig?.message ?? '');
     });
-
-    uimanager.getConfig().events.onUpdated.subscribe(clearText);
   }
 }

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -8,8 +8,6 @@ import { Label, LabelConfig } from '../labels/Label';
  * @category Labels
  */
 export class AdMessageLabel extends Label<LabelConfig> {
-  private adMessage: string = '';
-
   constructor(config: LabelConfig = {}) {
     super(config);
 
@@ -21,19 +19,14 @@ export class AdMessageLabel extends Label<LabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    const init = () => {
-      this.setText(this.adMessage);
-    };
-
-    const unload = () => {
+    const clearText = () => {
       this.setText('');
-      this.adMessage = '';
     };
 
-    init();
+    clearText();
 
-    player.on(player.exports.PlayerEvent.SourceUnloaded, unload);
-    player.on(player.exports.PlayerEvent.AdFinished, unload);
+    player.on(player.exports.PlayerEvent.SourceUnloaded, clearText);
+    player.on(player.exports.PlayerEvent.AdFinished, clearText);
     player.on(player.exports.PlayerEvent.AdStarted, (event) => {
       const ad = (event as AdEvent).ad;
       if (!ad.isLinear) {
@@ -41,10 +34,9 @@ export class AdMessageLabel extends Label<LabelConfig> {
       }
 
       const linearAd = ad as LinearAd;
-      this.adMessage = linearAd.uiConfig?.message ?? '';
-      init();
+      this.setText(linearAd.uiConfig?.message ?? '');
     });
 
-    uimanager.getConfig().events.onUpdated.subscribe(init);
+    uimanager.getConfig().events.onUpdated.subscribe(clearText);
   }
 }

--- a/src/ts/components/labels/MetadataLabel.ts
+++ b/src/ts/components/labels/MetadataLabel.ts
@@ -14,6 +14,10 @@ export enum MetadataLabelContent {
    * Description of the data source.
    */
   Description,
+  /**
+   * Message displayed when an ad is playing.
+   */
+  AdMessage,
 }
 
 /**
@@ -34,6 +38,7 @@ export interface MetadataLabelConfig extends LabelConfig {
  * @category Labels
  */
 export class MetadataLabel extends Label<MetadataLabelConfig> {
+  private adMessage: string = '';
 
   constructor(config: MetadataLabelConfig) {
     super(config);
@@ -49,9 +54,6 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
     let config = this.getConfig();
     let uiconfig = uimanager.getConfig();
 
-    let mainContentTitle = uiconfig.metadata.title;
-    let mainContentDescription = uiconfig.metadata.description;
-
     let init = () => {
       switch (config.content) {
         case MetadataLabelContent.Title:
@@ -60,17 +62,15 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
         case MetadataLabelContent.Description:
           this.setText(uiconfig.metadata.description);
           break;
+        case MetadataLabelContent.AdMessage:
+          this.setText(this.adMessage);
+          break;
       }
     };
 
     let unload = () => {
       this.setText(null);
-    };
-
-    let restoreMainContentData = () => {
-      uiconfig.metadata.title = mainContentTitle;
-      uiconfig.metadata.description = mainContentDescription;
-      init();
+      this.adMessage = '';
     };
 
     // Init label
@@ -78,10 +78,6 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
     // Clear labels when source is unloaded
     player.on(player.exports.PlayerEvent.SourceUnloaded, unload);
 
-    player.on(player.exports.PlayerEvent.AdBreakStarted, () => {
-      mainContentTitle = uiconfig.metadata.title;
-      mainContentDescription = uiconfig.metadata.description;
-    });
     player.on(player.exports.PlayerEvent.AdStarted, (event) => {
       const ad = (event as AdEvent).ad;
       if (!ad.isLinear) {
@@ -89,11 +85,9 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
       }
 
       const linearAd = ad as LinearAd;
-      uiconfig.metadata.title = linearAd.uiConfig?.message ?? '';
-      uiconfig.metadata.description = '';
+      this.adMessage = linearAd.uiConfig?.message ?? '';
       init();
     });
-    player.on(player.exports.PlayerEvent.AdBreakFinished, restoreMainContentData);
 
     uimanager.getConfig().events.onUpdated.subscribe(init);
   }

--- a/src/ts/components/labels/MetadataLabel.ts
+++ b/src/ts/components/labels/MetadataLabel.ts
@@ -49,7 +49,7 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
     let config = this.getConfig();
     let uiconfig = uimanager.getConfig();
 
-    let mainContentTitle = uiconfig.metadata.title; // TODO: get's updated with 'my lovely title' !!! prevent that!
+    let mainContentTitle = uiconfig.metadata.title;
     let mainContentDescription = uiconfig.metadata.description;
 
     let init = () => {
@@ -95,8 +95,6 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
     });
     player.on(player.exports.PlayerEvent.AdBreakFinished, restoreMainContentData);
 
-    uimanager.getConfig().events.onUpdated.subscribe(() => {
-      init();
-    });
+    uimanager.getConfig().events.onUpdated.subscribe(init);
   }
 }

--- a/src/ts/components/labels/MetadataLabel.ts
+++ b/src/ts/components/labels/MetadataLabel.ts
@@ -1,6 +1,6 @@
 import {LabelConfig, Label} from './Label';
 import {UIInstanceManager} from '../../UIManager';
-import { AdEvent, LinearAd, PlayerAPI } from 'bitmovin-player';
+import { PlayerAPI } from 'bitmovin-player';
 
 /**
  * Enumerates the types of content that the {@link MetadataLabel} can display.
@@ -14,10 +14,6 @@ export enum MetadataLabelContent {
    * Description of the data source.
    */
   Description,
-  /**
-   * Message displayed when an ad is playing.
-   */
-  AdMessage,
 }
 
 /**
@@ -38,7 +34,6 @@ export interface MetadataLabelConfig extends LabelConfig {
  * @category Labels
  */
 export class MetadataLabel extends Label<MetadataLabelConfig> {
-  private adMessage: string = '';
 
   constructor(config: MetadataLabelConfig) {
     super(config);
@@ -62,32 +57,17 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
         case MetadataLabelContent.Description:
           this.setText(uiconfig.metadata.description);
           break;
-        case MetadataLabelContent.AdMessage:
-          this.setText(this.adMessage);
-          break;
       }
     };
 
     let unload = () => {
       this.setText(null);
-      this.adMessage = '';
     };
 
     // Init label
     init();
     // Clear labels when source is unloaded
     player.on(player.exports.PlayerEvent.SourceUnloaded, unload);
-
-    player.on(player.exports.PlayerEvent.AdStarted, (event) => {
-      const ad = (event as AdEvent).ad;
-      if (!ad.isLinear) {
-        return;
-      }
-
-      const linearAd = ad as LinearAd;
-      this.adMessage = linearAd.uiConfig?.message ?? '';
-      init();
-    });
 
     uimanager.getConfig().events.onUpdated.subscribe(init);
   }

--- a/src/ts/components/labels/MetadataLabel.ts
+++ b/src/ts/components/labels/MetadataLabel.ts
@@ -1,6 +1,6 @@
 import {LabelConfig, Label} from './Label';
 import {UIInstanceManager} from '../../UIManager';
-import { PlayerAPI } from 'bitmovin-player';
+import { AdEvent, LinearAd, PlayerAPI } from 'bitmovin-player';
 
 /**
  * Enumerates the types of content that the {@link MetadataLabel} can display.
@@ -49,6 +49,9 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
     let config = this.getConfig();
     let uiconfig = uimanager.getConfig();
 
+    let mainContentTitle = uiconfig.metadata.title; // TODO: get's updated with 'my lovely title' !!! prevent that!
+    let mainContentDescription = uiconfig.metadata.description;
+
     let init = () => {
       switch (config.content) {
         case MetadataLabelContent.Title:
@@ -64,11 +67,36 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
       this.setText(null);
     };
 
+    let restoreMainContentData = () => {
+      uiconfig.metadata.title = mainContentTitle;
+      uiconfig.metadata.description = mainContentDescription;
+      init();
+    };
+
     // Init label
     init();
     // Clear labels when source is unloaded
     player.on(player.exports.PlayerEvent.SourceUnloaded, unload);
 
-    uimanager.getConfig().events.onUpdated.subscribe(init);
+    player.on(player.exports.PlayerEvent.AdBreakStarted, () => {
+      mainContentTitle = uiconfig.metadata.title;
+      mainContentDescription = uiconfig.metadata.description;
+    });
+    player.on(player.exports.PlayerEvent.AdStarted, (event) => {
+      const ad = (event as AdEvent).ad;
+      if (!ad.isLinear) {
+        return;
+      }
+
+      const linearAd = ad as LinearAd;
+      uiconfig.metadata.title = linearAd.uiConfig?.message ?? '';
+      uiconfig.metadata.description = '';
+      init();
+    });
+    player.on(player.exports.PlayerEvent.AdBreakFinished, restoreMainContentData);
+
+    uimanager.getConfig().events.onUpdated.subscribe(() => {
+      init();
+    });
   }
 }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

<img width="1097" height="616" alt="image" src="https://github.com/user-attachments/assets/a6b34b6d-b671-468c-ac75-4e4660521aa1" />


Add the TitleBar to the **generic**\* ads screen, following the planned UI design.

It will fetch metadata for linear ads from their `LinearAdUiConfig.message` field.  

> [!NOTE]
> \* Small-screen and TV-screen will, in case, be planned as separate PRs

> [!TIP]
> Metadata description is not currently set since there is no field in `LinearAdUiConfig` to use



## Testing

Check the new Ads TitleBar by adding a message to the `LinearAdUiConfig` of the `AdBreak`

```diff
  var adBreaks = [
    {
      tag: {
        url: '...',
        type: 'vast',
      },
      position: 'pre',
      linearAdUiConfig: {
+        message: "my lovely title",
      }
    },
    ...
```

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry - `no need on this base branch it seems`
