### PR TITLE
Modern UI - Ad Interface SeekBar Labels

### DIFF
--- a/src/scss/_ads.scss
+++ b/src/scss/_ads.scss
@@ -4,6 +4,7 @@
 .#{$prefix}-ui-ads {
   @import 'components/ads/ad-skip-button';
   @import 'components/ads/ad-status-overlay';
+  @import 'components/ads/ad-counter-label';
 
   .#{$prefix}-ui-seekbar {
     .#{$prefix}-seekbar,

--- a/src/scss/components/ads/_ad-counter-label.scss
+++ b/src/scss/components/ads/_ad-counter-label.scss
@@ -1,0 +1,7 @@
+@import '../../variables';
+
+.#{$prefix}-ui-label-ad-counter {
+  @extend %ui-label;
+
+  white-space: nowrap;
+}

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -11,6 +11,7 @@ import { SettingsPanelPageOpenButton } from './components/settings/SettingsPanel
 import { SubtitleSelectBox } from './components/settings/SubtitleSelectBox';
 import { ControlBar } from './components/ControlBar';
 import { Container, ContainerConfig } from './components/Container';
+import { AdCounterLabel } from './components/ads/AdCounterLabel';
 import { PlaybackTimeLabel, PlaybackTimeLabelMode } from './components/labels/PlaybackTimeLabel';
 import { SeekBar } from './components/seekbar/SeekBar';
 import { SeekBarLabel } from './components/seekbar/SeekBarLabel';
@@ -338,7 +339,7 @@ function adsUILayout() {
     components: [
       new Container({
         components: [
-          new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.CurrentTime }),
+          new AdCounterLabel(),
           new SeekBar({ label: new SeekBarLabel() }),
           new PlaybackTimeLabel({
             timeLabelMode: PlaybackTimeLabelMode.RemainingTime,

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -341,7 +341,7 @@ function adsUILayout() {
           new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.CurrentTime }),
           new SeekBar({ label: new SeekBarLabel() }),
           new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+            timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
             cssClasses: ['text-right'],
           }),
         ],

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -19,21 +19,16 @@ export class AdCounterLabel extends Label<LabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let currentAdIndex: number = 0;
-    let totalAdsCount: number = 0;
-
-    const reset = () => {
-      currentAdIndex = 0;
-      totalAdsCount = 0;
+    const clearText = () => {
       this.setText('');
     };
 
     player.on(player.exports.PlayerEvent.AdStarted, () => {
-      currentAdIndex++;
-      totalAdsCount = player.ads.getActiveAdBreak().ads?.length ?? 0;
-      this.setText(`Ad ${currentAdIndex} of ${totalAdsCount}`);
+      const activeAdIndex = player.ads.getActiveAdBreak().ads.findIndex((ad) => ad === player.ads.getActiveAd()) + 1;
+      const totalAdsCount = player.ads.getActiveAdBreak().ads?.length ?? 0;
+      this.setText(`Ad ${activeAdIndex} of ${totalAdsCount}`);
     });
-    player.on(player.exports.PlayerEvent.AdBreakStarted, reset);
-    player.on(player.exports.PlayerEvent.AdBreakFinished, reset);
+    player.on(player.exports.PlayerEvent.AdBreakStarted, clearText);
+    player.on(player.exports.PlayerEvent.AdBreakFinished, clearText);
   }
 }

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -25,7 +25,7 @@ export class AdCounterLabel extends Label<LabelConfig> {
 
     player.on(player.exports.PlayerEvent.AdStarted, () => {
       const activeAdIndex = player.ads.getActiveAdBreak().ads.findIndex((ad) => ad === player.ads.getActiveAd()) + 1;
-      const totalAdsCount = player.ads.getActiveAdBreak().ads?.length ?? 0;
+      const totalAdsCount = player.ads.getActiveAdBreak().ads?.length ?? activeAdIndex;
       this.setText(`Ad ${activeAdIndex} of ${totalAdsCount}`);
     });
     player.on(player.exports.PlayerEvent.AdBreakStarted, clearText);

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -1,5 +1,5 @@
 import { UIInstanceManager } from '../../UIManager';
-import {LabelConfig, Label} from '../labels/Label';
+import { LabelConfig, Label } from '../labels/Label';
 import { PlayerAPI } from 'bitmovin-player';
 
 /**

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -1,0 +1,39 @@
+import { UIInstanceManager } from '../../UIManager';
+import {LabelConfig, Label} from '../labels/Label';
+import { PlayerAPI } from 'bitmovin-player';
+
+/**
+ * A label that displays the index of the currently playing ad out of the total number of ads.
+ *
+ * @category Labels
+ */
+export class AdCounterLabel extends Label<LabelConfig> {
+  constructor(config: LabelConfig = {}) {
+    super(config);
+
+    this.config = this.mergeConfig(config, {
+      cssClass: 'ui-label-ad-counter',
+    }, this.config);
+  }
+
+  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
+    super.configure(player, uimanager);
+
+    let currentAdIndex: number = 0;
+    let totalAdsCount: number = 0;
+
+    const reset = () => {
+      currentAdIndex = 0;
+      totalAdsCount = 0;
+      this.setText('');
+    };
+
+    player.on(player.exports.PlayerEvent.AdStarted, () => {
+      currentAdIndex++;
+      totalAdsCount = player.ads.getActiveAdBreak().ads?.length ?? 0;
+      this.setText(`Ad ${currentAdIndex} of ${totalAdsCount}`);
+    });
+    player.on(player.exports.PlayerEvent.AdBreakStarted, reset);
+    player.on(player.exports.PlayerEvent.AdBreakFinished, reset);
+  }
+}

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -55,6 +55,7 @@ export { ClickOverlay, ClickOverlayConfig } from './components/overlays/ClickOve
 export { AdSkipButton, AdSkipButtonConfig } from './components/ads/AdSkipButton';
 export { AdMessageLabel } from './components/ads/AdMessageLabel';
 export { AdClickOverlay } from './components/ads/AdClickOverlay';
+export { AdCounterLabel } from './components/ads/AdCounterLabel';
 export { PlaybackSpeedSelectBox } from './components/settings/PlaybackSpeedSelectBox';
 export { HugeReplayButton } from './components/buttons/HugeReplayButton';
 export { BufferingOverlay, BufferingOverlayConfig } from './components/overlays/BufferingOverlay';


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->



<img width="1103" height="619" alt="image" src="https://github.com/user-attachments/assets/c6258739-6af3-4f34-b1a3-d7c965575f2e" />

Rework the labels around the SeekBar, following the planned ad screen UI re-design.

### Changes

#### Ad Playback Info
- **Total ad duration** is removed - it was previously at the right side of the SeekBar
- **Current ad playback time** is removed
- **Remaining ad playback time** is added and placed to the right of the SeekBar

#### Ad Index Label
- Introduce a new label component to indicate the current ad index out of the total amount of ads
- It is placed on the left side of the SeekBar

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [ ] `CHANGELOG` entry - `no need since base is modern UI`
