### PR TITLE
Modern UI -  Chapter Markers, redesign metadata labels

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -11,6 +11,7 @@ $color-secondary: #999 !default;
 $color-background: #111 !default;
 $color-background-highlight: transparentize(mix($color-black, $color-highlight, 75%), .3) !default;
 $color-background-bars: transparentize($color-black, .3) !default;
+$color-background-seekbar-label: rgba(20, 20, 20, .8);
 $color-focus: #1b7fcc;
 
 $color-item-hover: #54565a !default;

--- a/src/scss/components/labels/_seek-bar-label.scss
+++ b/src/scss/components/labels/_seek-bar-label.scss
@@ -27,45 +27,45 @@
   }
 
   .#{$prefix}-seekbar-label-inner {
-    // border: solid $color-primary .0625em;
-    // border-radius: .5em;
     overflow: hidden;
 
     > .#{$prefix}-container-wrapper {
       position: relative;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
 
-      .#{$prefix}-seekbar-thumbnail {// THUMBNAIL
+      .#{$prefix}-seekbar-thumbnail {
         width: 7em;
         border: solid #fff 0.0625em;
         border-radius: .4em;
       }
 
-      .#{$prefix}-seekbar-label-metadata {// LABEL
-        margin-top: .5em;
-        // background: linear-gradient(to bottom, $color-transparent, $color-background-bars);
-        background-color: rgba(20, 20, 20, 0.75);
+      .#{$prefix}-seekbar-label-metadata {
+        background-color: rgba(20, 20, 20, 0.80);
         bottom: 0;
         box-sizing: border-box;
         display: inline-block;
-        // padding: .5em; // use .2em if only keeping chapter title, and not time || if removing time tho, consider you may need to place it when the chapter has no title!
-        padding: .2em .4em;
-        // position: absolute;
-        width: 100%;
-        border-radius: .5em;
+        padding: .3em .5em;
+        width: fit-content;
+        border-radius: .4em;
+      }
 
-        .#{$prefix}-seekbar-label-time {
-          display: block;
-          // font-weight: 600;
-          font-weight: 500;
-          line-height: .8em;
-        }
+      .#{$prefix}-seekbar-label-time {
+        display: block;
+        font-weight: 500;
+        line-height: .8em;
+        margin-top: .5em;
+      }
 
-        .#{$prefix}-seekbar-label-title {
-          display: block;
-          font-weight: 600;
-          margin-bottom: .3em;
-          white-space: normal;
-        }
+      .#{$prefix}-seekbar-label-title {
+        @include hidden;
+
+        display: block;
+        font-weight: 600;
+        margin-bottom: .3em;
+        white-space: normal;
+        margin-bottom: .5em;
       }
     }
   }

--- a/src/scss/components/labels/_seek-bar-label.scss
+++ b/src/scss/components/labels/_seek-bar-label.scss
@@ -63,7 +63,6 @@
 
         display: block;
         font-weight: 600;
-        margin-bottom: .3em;
         white-space: normal;
         margin-bottom: .5em;
       }

--- a/src/scss/components/labels/_seek-bar-label.scss
+++ b/src/scss/components/labels/_seek-bar-label.scss
@@ -7,7 +7,7 @@
 
   bottom: 100%;
   left: 0;
-  margin-bottom: .75em;
+  margin-bottom: .2em;
   pointer-events: none;
   position: absolute;
   text-align: center;
@@ -27,35 +27,42 @@
   }
 
   .#{$prefix}-seekbar-label-inner {
-    border: solid $color-primary .0625em;
-    border-radius: .5em;
+    // border: solid $color-primary .0625em;
+    // border-radius: .5em;
     overflow: hidden;
 
     > .#{$prefix}-container-wrapper {
       position: relative;
 
-      .#{$prefix}-seekbar-thumbnail {
+      .#{$prefix}-seekbar-thumbnail {// THUMBNAIL
         width: 7em;
+        border: solid #fff 0.0625em;
+        border-radius: .4em;
       }
 
-      .#{$prefix}-seekbar-label-metadata {
-        background: linear-gradient(to bottom, $color-transparent, $color-background-bars);
+      .#{$prefix}-seekbar-label-metadata {// LABEL
+        margin-top: .5em;
+        // background: linear-gradient(to bottom, $color-transparent, $color-background-bars);
+        background-color: rgba(20, 20, 20, 0.75);
         bottom: 0;
         box-sizing: border-box;
-        display: block;
-        padding: .5em;
-        position: absolute;
+        display: inline-block;
+        // padding: .5em; // use .2em if only keeping chapter title, and not time || if removing time tho, consider you may need to place it when the chapter has no title!
+        padding: .2em .4em;
+        // position: absolute;
         width: 100%;
+        border-radius: .5em;
 
         .#{$prefix}-seekbar-label-time {
           display: block;
+          // font-weight: 600;
           font-weight: 500;
           line-height: .8em;
         }
 
         .#{$prefix}-seekbar-label-title {
           display: block;
-          font-weight: 500;
+          font-weight: 600;
           margin-bottom: .3em;
           white-space: normal;
         }

--- a/src/scss/components/labels/_seek-bar-label.scss
+++ b/src/scss/components/labels/_seek-bar-label.scss
@@ -37,12 +37,12 @@
 
       .#{$prefix}-seekbar-thumbnail {
         width: 7em;
-        border: solid #fff 0.0625em;
+        border: solid $color-primary .0625em;
         border-radius: .4em;
       }
 
       .#{$prefix}-seekbar-label-metadata {
-        background-color: rgba(20, 20, 20, 0.80);
+        background-color: $color-background-seekbar-label;
         bottom: 0;
         box-sizing: border-box;
         display: inline-block;

--- a/src/ts/components/seekbar/SeekBarLabel.ts
+++ b/src/ts/components/seekbar/SeekBarLabel.ts
@@ -41,18 +41,16 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
   constructor(config: SeekBarLabelConfig = {}) {
     super(config);
 
-    this.timeLabel = new Label({ cssClasses: ['seekbar-label-time'] });
-    this.titleLabel = new Label({ cssClasses: ['seekbar-label-title'] });
+    this.timeLabel = new Label({ cssClasses: ['seekbar-label-metadata', 'seekbar-label-time'] });
+    this.titleLabel = new Label({ cssClasses: ['seekbar-label-metadata', 'seekbar-label-title'] });
     this.thumbnail = new Component({ cssClasses: ['seekbar-thumbnail'], role: 'img' });
     this.thumbnailImageLoader = new ImageLoader();
 
     this.container = new Container({
       components: [
+        this.titleLabel,
         this.thumbnail,
-        new Container({
-          components: [this.titleLabel, this.timeLabel],
-          cssClass: 'seekbar-label-metadata',
-        }),
+        this.timeLabel,
       ],
       cssClass: 'seekbar-label-inner',
     });
@@ -76,7 +74,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
         StringUtils.FORMAT_HHMMSS : StringUtils.FORMAT_MMSS;
       // Set initial state of title and thumbnail to handle sourceLoaded when switching to a live-stream
-      this.setTitleText(null);
+      this.setTitleText('');
       this.setThumbnail(null);
     };
 
@@ -116,7 +114,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     if (args.marker) {
       this.setTitleText(args.marker.marker.title);
     } else {
-      this.setTitleText(null);
+      this.setTitleText('');
     }
 
     // Remove CSS classes from previous marker
@@ -173,6 +171,12 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
    */
   setTitleText(text = '') {
     this.titleLabel.setText(text);
+
+    if (!text || text === '') {
+      this.titleLabel.hide();
+    } else {
+      this.titleLabel.show();
+    }
   }
 
   /**

--- a/src/ts/components/seekbar/SeekBarLabel.ts
+++ b/src/ts/components/seekbar/SeekBarLabel.ts
@@ -74,7 +74,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       this.timeFormat = Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600 ?
         StringUtils.FORMAT_HHMMSS : StringUtils.FORMAT_MMSS;
       // Set initial state of title and thumbnail to handle sourceLoaded when switching to a live-stream
-      this.setTitleText('');
+      this.setTitleText(null);
       this.setThumbnail(null);
     };
 
@@ -114,7 +114,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     if (args.marker) {
       this.setTitleText(args.marker.marker.title);
     } else {
-      this.setTitleText('');
+      this.setTitleText(null);
     }
 
     // Remove CSS classes from previous marker
@@ -169,10 +169,10 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
    * Sets the text on the title label.
    * @param text the text to show on the label
    */
-  setTitleText(text = '') {
+  setTitleText(text?: string) {
     this.titleLabel.setText(text);
 
-    if (!text || text === '') {
+    if (text == null) {
       this.titleLabel.hide();
     } else {
       this.titleLabel.show();


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Redesign the chapter markers as planned

#### Before
<img width="681" height="378" alt="image" src="https://github.com/user-attachments/assets/f7772850-282b-4f4c-a8e5-a584faba376a" />


#### After
<img width="681" height="378" alt="image" src="https://github.com/user-attachments/assets/ec6171e9-07d8-4679-9f68-6b2055972194" />

**Biggest changes:**
- Move the text labels (title and time) out of the Thumbnail container
  - Place the title label on top of the Thumbnail
- Use an uniform background for the text labels



## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry - `no need since base is modern UI branch`
