### PR TITLE
Modern UI - Chapter Markers, thicken markers on scrub

### DIFF
--- a/spec/components/seekbar/SeekBar.spec.ts
+++ b/spec/components/seekbar/SeekBar.spec.ts
@@ -2,6 +2,7 @@ import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
 import { SeekBar } from '../../../src/ts/components/seekbar/SeekBar';
 import { UIInstanceManager } from '../../../src/ts/UIManager';
 import { Timeout } from '../../../src/ts/utils/Timeout';
+import { DOM } from '../../../src/ts/DOM';
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;
@@ -14,6 +15,7 @@ describe('SeekBar', () => {
     uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
 
     seekbar = new SeekBar({ smoothPlaybackPositionUpdateIntervalMs: 1 });
+    seekbar.getDomElement();
   });
 
   describe('becomes visible when switching from live to vod', () => {

--- a/src/scss/components/seekbar/_seek-bar.scss
+++ b/src/scss/components/seekbar/_seek-bar.scss
@@ -114,7 +114,7 @@ $seekbar-height: .3125em;
         justify-content: space-between;
         align-items: center;
 
-        &:hover {
+        &:hover, &.#{$prefix}-thicken {
           height: $marker-indicator-height;
           border-radius: $marker-indicator-border-radius;
         }
@@ -132,11 +132,6 @@ $seekbar-height: .3125em;
           border-radius: $marker-indicator-border-radius;
         }
 
-      }
-
-      .#{$prefix}-seekbar-marker.#{$prefix}-thicken {
-        height: $marker-indicator-height;
-        border-radius: $marker-indicator-border-radius;
       }
     }
   }

--- a/src/scss/components/seekbar/_seek-bar.scss
+++ b/src/scss/components/seekbar/_seek-bar.scss
@@ -114,7 +114,7 @@ $seekbar-height: .3125em;
         justify-content: space-between;
         align-items: center;
 
-        &:hover, &.#{$prefix}-thicken {
+        &:hover, &.#{$prefix}-hovered {
           height: $marker-indicator-height;
           border-radius: $marker-indicator-border-radius;
         }

--- a/src/scss/components/seekbar/_seek-bar.scss
+++ b/src/scss/components/seekbar/_seek-bar.scss
@@ -133,6 +133,11 @@ $seekbar-height: .3125em;
         }
 
       }
+
+      .#{$prefix}-seekbar-marker.#{$prefix}-thicken {
+        height: $marker-indicator-height;
+        border-radius: $marker-indicator-border-radius;
+      }
     }
   }
 

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -1118,7 +1118,6 @@ export class SeekBar extends Component<SeekBarConfig> {
   }
 
   protected onSeekedEvent(percentage: number) {
-
     this.clearAllThickenedMarkers();
     this.seekBarEvents.onSeeked.dispatch(this, percentage);
   }

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -1070,12 +1070,12 @@ export class SeekBar extends Component<SeekBarConfig> {
   private clearAllThickenedMarkers(): void {
     this.seekBarMarkersContainer
       .find(`.${this.prefixCss('seekbar-marker')}`)
-      ?.removeClass(this.prefixCss('thicken'));
+      ?.removeClass(this.prefixCss('hovered'));
   }
 
   private thickenMarker(marker: SeekBarMarker | null): void {
     if (marker?.element) {
-      marker.element.addClass(this.prefixCss('thicken'));
+      marker.element.addClass(this.prefixCss('hovered'));
     }
   }
 

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -1070,7 +1070,7 @@ export class SeekBar extends Component<SeekBarConfig> {
   private clearAllThickenedMarkers(): void {
     this.seekBarMarkersContainer
       .find(`.${this.prefixCss('seekbar-marker')}`)
-      .removeClass(this.prefixCss('thicken'));
+      ?.removeClass(this.prefixCss('thicken'));
   }
 
   private thickenMarker(marker: SeekBarMarker | null): void {

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -1093,6 +1093,12 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.updateLabelPosition(targetOffsetPx);
     }
 
+    this.seekBarMarkersContainer.find(`.${this.prefixCss('seekbar-marker')}`).removeClass(this.prefixCss('thicken'));
+    if (snappedMarker?.element) {
+      snappedMarker.element.addClass(this.prefixCss('thicken'));
+      console.log(snappedMarker?.element);
+    }
+
     this.seekBarEvents.onSeekPreview.dispatch(this, {
       scrubbing: scrubbing,
       position: seekPositionPercentage,

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -1093,10 +1093,12 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.updateLabelPosition(targetOffsetPx);
     }
 
-    this.seekBarMarkersContainer.find(`.${this.prefixCss('seekbar-marker')}`).removeClass(this.prefixCss('thicken'));
-    if (snappedMarker?.element) {
-      snappedMarker.element.addClass(this.prefixCss('thicken'));
-      console.log(snappedMarker?.element);
+    if (scrubbing) {
+      this.seekBarMarkersContainer.find(`.${this.prefixCss('seekbar-marker')}`).removeClass(this.prefixCss('thicken'));
+      if (snappedMarker?.element) {
+        snappedMarker.element.addClass(this.prefixCss('thicken'));
+        console.log(snappedMarker?.element);
+      }
     }
 
     this.seekBarEvents.onSeekPreview.dispatch(this, {
@@ -1107,6 +1109,9 @@ export class SeekBar extends Component<SeekBarConfig> {
   }
 
   protected onSeekedEvent(percentage: number) {
+    this.seekBarMarkersContainer.find(`.${this.prefixCss('seekbar-marker')}`)
+      .removeClass(this.prefixCss('thicken'));
+
     this.seekBarEvents.onSeeked.dispatch(this, percentage);
   }
 

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -107,6 +107,7 @@ export class SeekBar extends Component<SeekBarConfig> {
    * The CSS class that is added to the DOM element while the seek bar is in 'seeking' state.
    */
   private static readonly CLASS_SEEKING = 'seeking';
+  private static readonly CLASS_CHAPTER_HOVERED = 'hovered';
 
   private seekBar: DOM;
   private seekBarPlaybackPosition: DOM;
@@ -1070,12 +1071,12 @@ export class SeekBar extends Component<SeekBarConfig> {
   private clearAllThickenedMarkers(): void {
     this.seekBarMarkersContainer
       .find(`.${this.prefixCss('seekbar-marker')}`)
-      ?.removeClass(this.prefixCss('hovered'));
+      ?.removeClass(this.prefixCss(SeekBar.CLASS_CHAPTER_HOVERED));
   }
 
   private thickenMarker(marker: SeekBarMarker | null): void {
     if (marker?.element) {
-      marker.element.addClass(this.prefixCss('hovered'));
+      marker.element.addClass(this.prefixCss(SeekBar.CLASS_CHAPTER_HOVERED));
     }
   }
 

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -1067,6 +1067,18 @@ export class SeekBar extends Component<SeekBarConfig> {
     this.label.setPositionInBounds(pixelPosition, this.uiBoundingRect);
   };
 
+  private clearAllThickenedMarkers(): void {
+    this.seekBarMarkersContainer
+      .find(`.${this.prefixCss('seekbar-marker')}`)
+      .removeClass(this.prefixCss('thicken'));
+  }
+
+  private thickenMarker(marker: SeekBarMarker | null): void {
+    if (marker?.element) {
+      marker.element.addClass(this.prefixCss('thicken'));
+    }
+  }
+
   protected onSeekPreviewEvent(percentage: number, targetOffsetPx: number, scrubbing: boolean) {
     let snappedMarker = this.timelineMarkersHandler && this.timelineMarkersHandler.getMarkerAtPosition(percentage);
 
@@ -1094,11 +1106,8 @@ export class SeekBar extends Component<SeekBarConfig> {
     }
 
     if (scrubbing) {
-      this.seekBarMarkersContainer.find(`.${this.prefixCss('seekbar-marker')}`).removeClass(this.prefixCss('thicken'));
-      if (snappedMarker?.element) {
-        snappedMarker.element.addClass(this.prefixCss('thicken'));
-        console.log(snappedMarker?.element);
-      }
+      this.clearAllThickenedMarkers();
+      this.thickenMarker(snappedMarker);
     }
 
     this.seekBarEvents.onSeekPreview.dispatch(this, {
@@ -1109,9 +1118,8 @@ export class SeekBar extends Component<SeekBarConfig> {
   }
 
   protected onSeekedEvent(percentage: number) {
-    this.seekBarMarkersContainer.find(`.${this.prefixCss('seekbar-marker')}`)
-      .removeClass(this.prefixCss('thicken'));
 
+    this.clearAllThickenedMarkers();
     this.seekBarEvents.onSeeked.dispatch(this, percentage);
   }
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

https://github.com/bitmovin/bitmovin-player-ui/pull/715#pullrequestreview-3052374472

Thicken the chapter range-marker on scrubbing.

This especially improves UX on mobile devices since there is no hover event there, therefore it would not be possible to see the highlighter chapter marker without this change

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry - `no need since base is modern ui`
