### PR TITLE
Modern UI:  Fix timeline and chapter markers on Safari and Firefox

### DIFF
--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -473,12 +473,14 @@ export class SeekBar extends Component<SeekBarConfig> {
     // is positioned absolutely and must therefore be updated when the size of the seekbar changes.
     player.on(player.exports.PlayerEvent.PlayerResized, () => {
       this.refreshPlaybackPosition();
+      this.initializeTimelineMarkers(player, uimanager);
       this.uiBoundingRect = this.uiManager.getUI().getDomElement().get(0).getBoundingClientRect();
     });
     // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
     // resulting in a wrong initial position of the marker. Refreshing it once the UI is configured solved this issue.
     uimanager.onConfigured.subscribe(() => {
       this.refreshPlaybackPosition();
+      this.initializeTimelineMarkers(player, uimanager);
     });
     // It can also happen when a new source is loaded
     player.on(player.exports.PlayerEvent.SourceLoaded, () => {

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -448,6 +448,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       }
       playbackPositionHandler(null, true);
       this.refreshPlaybackPosition();
+      this.initializeTimelineMarkers(player, uimanager);
     };
     let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
     liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
@@ -485,6 +486,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     // It can also happen when a new source is loaded
     player.on(player.exports.PlayerEvent.SourceLoaded, () => {
       this.refreshPlaybackPosition();
+      this.initializeTimelineMarkers(player, uimanager);
     });
     // Add markers when a source is loaded or update when a marker is added or removed
     uimanager.getConfig().events.onUpdated.subscribe(() => {
@@ -1142,6 +1144,10 @@ export class SeekBar extends Component<SeekBarConfig> {
     // For such cases, we refresh the position here in onShow because here it is guaranteed that the component knows
     // its size and can set the position correctly.
     this.refreshPlaybackPosition();
+
+    if (this.player && this.uiManager) {
+      this.initializeTimelineMarkers(this.player, this.uiManager);
+    }
   }
 
   /**

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -447,8 +447,7 @@ export class SeekBar extends Component<SeekBarConfig> {
         this.show();
       }
       playbackPositionHandler(null, true);
-      this.refreshPlaybackPosition();
-      this.initializeTimelineMarkers(player, uimanager);
+      this.refreshLayout();
     };
     let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
     liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
@@ -473,20 +472,17 @@ export class SeekBar extends Component<SeekBarConfig> {
     // Refresh the playback position when the player resized or the UI is configured. The playback position marker
     // is positioned absolutely and must therefore be updated when the size of the seekbar changes.
     player.on(player.exports.PlayerEvent.PlayerResized, () => {
-      this.refreshPlaybackPosition();
-      this.initializeTimelineMarkers(player, uimanager);
+      this.refreshLayout();
       this.uiBoundingRect = this.uiManager.getUI().getDomElement().get(0).getBoundingClientRect();
     });
     // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
     // resulting in a wrong initial position of the marker. Refreshing it once the UI is configured solved this issue.
     uimanager.onConfigured.subscribe(() => {
-      this.refreshPlaybackPosition();
-      this.initializeTimelineMarkers(player, uimanager);
+      this.refreshLayout();
     });
     // It can also happen when a new source is loaded
     player.on(player.exports.PlayerEvent.SourceLoaded, () => {
-      this.refreshPlaybackPosition();
-      this.initializeTimelineMarkers(player, uimanager);
+      this.refreshLayout();
     });
     // Add markers when a source is loaded or update when a marker is added or removed
     uimanager.getConfig().events.onUpdated.subscribe(() => {
@@ -972,6 +968,24 @@ export class SeekBar extends Component<SeekBarConfig> {
   }
 
   /**
+   * Refreshes the layout of the seek bar.
+   *
+   * This includes:
+   * - Re-positioning the playback marker
+   * - Reinitializing timeline markers
+   *
+   * Should be called after UI resizes or layout-affecting events like showing the component.
+   * Subclasses may override this if they introduce custom layout logic.
+   */
+  protected refreshLayout(): void {
+    this.refreshPlaybackPosition();
+
+    if (this.player && this.uiManager) {
+      this.initializeTimelineMarkers(this.player, this.uiManager);
+    }
+  }
+
+  /**
    * Sets the position until which media is buffered.
    * @param percent a number between 0 and 100
    */
@@ -1138,16 +1152,14 @@ export class SeekBar extends Component<SeekBarConfig> {
   protected onShowEvent(): void {
     super.onShowEvent();
 
-    // Refresh the position of the playback position when the seek bar becomes visible. To correctly set the position,
-    // the DOM element must be fully initialized an have its size calculated, because the position is set as an absolute
-    // value calculated from the size. This required size is not known when it is hidden.
-    // For such cases, we refresh the position here in onShow because here it is guaranteed that the component knows
-    // its size and can set the position correctly.
-    this.refreshPlaybackPosition();
-
-    if (this.player && this.uiManager) {
-      this.initializeTimelineMarkers(this.player, this.uiManager);
-    }
+    // Refresh the layout when the seek bar becomes visible.
+    // To correctly position the playback marker and timeline markers,
+    // the DOM element must be fully initialized and have its size calculated,
+    // as their positions are based on absolute values derived from the element's dimensions.
+    // When hidden (e.g., via `display: none`), these dimensions are not available.
+    // By refreshing the layout here in `onShow`, we ensure the component knows its size
+    // and can place the playback and timeline markers accurately.
+    this.refreshLayout();
   }
 
   /**


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

On UI updates, we are only refreshing the playback position on the SeekBar, but not the timeline markers.
This makes Safari and Firefox not able to render the timeline markers.

Also fixes the tedious bug of chapter markers sometimes disappearing when refreshing the page.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry - `no need since base is modern UI`
