### PR TITLE
Modern UI - SeekBar coloring: differentiate buffer level color and use primary color for main elements

### DIFF
--- a/src/scss/components/seekbar/_seek-bar.scss
+++ b/src/scss/components/seekbar/_seek-bar.scss
@@ -35,7 +35,7 @@ $seekbar-height: .3125em;
     @extend %bar;
 
     @include seekbar-position-marker($seekbar-height * 3);
-    background-color: $color-highlight;
+    background-color: $color-primary;
     border-radius: 50%;
     box-shadow: 0 0 3px 0 transparentize($color: #000, $amount: .75);
   }
@@ -82,7 +82,7 @@ $seekbar-height: .3125em;
 
     .#{$prefix}-seekbar-playbackposition {
       @extend %bar;
-      background-color: $color-highlight;
+      background-color: $color-primary;
       margin: $bar-inset 0;
       transition: .1s linear, .1s linear;
       transition-property: transform;

--- a/src/scss/components/seekbar/_seek-bar.scss
+++ b/src/scss/components/seekbar/_seek-bar.scss
@@ -68,7 +68,7 @@ $seekbar-height: .3125em;
 
     .#{$prefix}-seekbar-bufferlevel {
       @extend %bar;
-      background-color: $color-primary;
+      background-color:  transparentize($color-primary, .8);
       margin: $bar-inset 0;
       transition: .3s linear, .3s linear;
       transition-property: transform;

--- a/src/scss/components/seekbar/_volume-slider.scss
+++ b/src/scss/components/seekbar/_volume-slider.scss
@@ -7,7 +7,7 @@
 
   .#{$prefix}-seekbar-playbackposition-marker {
     @include seekbar-position-marker($seekbar-height * 3 - .25em);
-    background-color: $color-highlight;
+    background-color: $color-primary;
     border: 0;
   }
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Update SeekBar elements coloring following the planned re-design

**Before**
<img width="618" height="267" alt="image" src="https://github.com/user-attachments/assets/a96925b3-91fa-482f-9beb-7968afcb9c5b" />



**After**
<img width="618" height="267" alt="image" src="https://github.com/user-attachments/assets/327e1720-9a31-4e15-b3c3-e0dea798851e" />

## Changes

#### Switch to white color primary for a few elements:
- playback marker
- seekbar slice until playback position
- volume slider marker

#### Differentiate buffer level coloring

With the new planned design, buffer level would have the same exact color as seekbar elements, and range chapters, making it not visible.

To improve user experience, it has been slightly transparentized into gray.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry - `no need since this is based on modern ui base`
