### PR TITLE
Immediately update the playback position with click based seeking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Immediately update the playback position when seeking using a click
+
 ## [3.98.0] - 2025-06-13
 
 ### Fixed

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -767,7 +767,6 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.setSeekPosition(targetPercentage);
       this.setPlaybackPosition(targetPercentage);
 
-
       // Fire seeked event
       this.onSeekedEvent(targetPercentage);
     };

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -763,6 +763,11 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.setSeeking(false);
       seeking = false;
 
+      // Update the UI in case we only have a click or touch
+      this.setSeekPosition(targetPercentage);
+      this.setPlaybackPosition(targetPercentage);
+
+
       // Fire seeked event
       this.onSeekedEvent(targetPercentage);
     };


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
### Problem
When seeking by clicking on the seekbar, the playback position doesn't update immediately, but only after the Seek is completed. This is particularly bad when the seek results in stalling.

### Changes
Immediately update the playback position to the seek target position. This now matches the behaviour of scrubbing on the SeekBar.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
