### PR TITLE
Prevent overlap between CEA captions and control bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-
 ## [Unreleased]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- CEA captions can overlap with player's control bar
+
 ## [3.98.0] - 2025-06-13
 
 ### Fixed

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -44,8 +44,7 @@
       // We don't want CEA-608 subtitles to make space for the controlbar because they're
       // positioned absolutely in relation to the video picture and thus cannot just move
       // somewhere else.
-      bottom: 2em;
-      transition: none;
+      bottom: 5em;
     }
   }
 }

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -38,13 +38,5 @@
         white-space: normal;
       }
     }
-
-    &.#{$prefix}-controlbar-visible {
-      // Disable the make-space-for-controlbar mechanism
-      // We don't want CEA-608 subtitles to make space for the controlbar because they're
-      // positioned absolutely in relation to the video picture and thus cannot just move
-      // somewhere else.
-      bottom: 5em;
-    }
   }
 }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -1,14 +1,14 @@
-import { Container, ContainerConfig } from './container';
-import { UIInstanceManager } from '../uimanager';
-import { Label, LabelConfig } from './label';
-import { ComponentConfig, Component } from './component';
-import { ControlBar } from './controlbar';
-import { EventDispatcher } from '../eventdispatcher';
-import { DOM, Size } from '../dom';
 import { PlayerAPI, SubtitleCueEvent } from 'bitmovin-player';
-import { i18n } from '../localization/i18n';
-import { VttUtils } from '../vttutils';
 import { VTTProperties } from 'bitmovin-player/types/subtitles/vtt/API';
+import { DOM, Size } from '../dom';
+import { EventDispatcher } from '../eventdispatcher';
+import { i18n } from '../localization/i18n';
+import { UIInstanceManager } from '../uimanager';
+import { VttUtils } from '../vttutils';
+import { Component, ComponentConfig } from './component';
+import { Container, ContainerConfig } from './container';
+import { ControlBar } from './controlbar';
+import { Label, LabelConfig } from './label';
 import { ListItemFilter } from './listselector';
 
 interface SubtitleCropDetectionResult {
@@ -239,7 +239,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     // We need to keep track of the original row position in case of recalculation.
     const originalRowNumber = event.position?.row || 0;
 
-    if (event.position) {
+    if (isCea608SubtitleCue(event)) {
       event.position.row = this.resolveRowNumber(event.position.row) || 0;
       event.position.column = event.position.column || 0;
 
@@ -444,8 +444,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     });
 
     this.preprocessLabelEventCallback.subscribe((event: SubtitleCueEvent, label: SubtitleLabel) => {
-      const isCEA608 = event.position != null;
-      if (!isCEA608) {
+      if (!isCea608SubtitleCue(event)) {
         // Skip all non-CEA608 cues
         return;
       }
@@ -863,4 +862,8 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
   public isEmpty(): boolean {
     return this.labelCount === 0;
   }
+}
+
+function isCea608SubtitleCue(cue: SubtitleCueEvent): boolean {
+  return cue.position != null;
 }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -146,11 +146,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     player.on(player.exports.PlayerEvent.PlaybackFinished, subtitleClearHandler);
     player.on(player.exports.PlayerEvent.SourceUnloaded, subtitleClearHandler);
 
-
-    this.onShow?.subscribe(() => {
-      this.updateCEA608FontSize?.();
-    });
-
     uimanager.onComponentShow.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
@@ -342,6 +337,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         this.setFontSizeFactor(1);
       }
       updateCEA608FontSize();
+    });
+
+    this.onShow?.subscribe(() => {
+      // ensure CEA grid is updated whenever the overlay becomes visible
+      this.updateCEA608FontSize();
     });
 
     const updateCEA608FontSize = this.updateCEA608FontSize = () => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -375,7 +375,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // most browsers, but Safari has a "quantized" font size rendering with huge steps in between so we need
       // to subtract some more pixels to avoid line breaks there as well.
       const overlayElement = this.getDomElement();
-      const subtitleOverlayWidth = overlayElement.width() - 10;
+      const subtitleOverlayWidthUsableRatio = (1 - parseFloat(SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET) / 100);
+      const subtitleOverlayWidth = Math.floor(subtitleOverlayWidthUsableRatio * overlayElement.width()) - 10;
       const subtitleOverlayHeight = overlayElement.height();
 
       // The size ratio of the letter grid

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -47,7 +47,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
 
   private cea608Enabled = false;
-  private updateCEA608FontSize: () => void;
+  private ensureCea608GridSizeUpdated: () => void;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
@@ -150,8 +150,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       if (component instanceof ControlBar) {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
 
-        if (this.cea608Enabled && this.updateCEA608FontSize) {
-          awaitTransitionEnd(this.getDomElement()).then(this.updateCEA608FontSize);
+        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated) {
+          awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
         }
       }
     });
@@ -160,8 +160,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       if (component instanceof ControlBar) {
         this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
 
-        if (this.cea608Enabled && this.updateCEA608FontSize) {
-          awaitTransitionEnd(this.getDomElement()).then(this.updateCEA608FontSize);
+        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated) {
+          awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
         }
       }
     });
@@ -336,15 +336,15 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       } else {
         this.setFontSizeFactor(1);
       }
-      updateCEA608FontSize();
+      this.ensureCea608GridSizeUpdated();
     });
 
     this.onShow?.subscribe(() => {
       // ensure CEA grid is updated whenever the overlay becomes visible
-      this.updateCEA608FontSize();
+      this.ensureCea608GridSizeUpdated();
     });
 
-    const updateCEA608FontSize = this.updateCEA608FontSize = () => {
+    this.ensureCea608GridSizeUpdated = () => {
       const overlayElement = this.getDomElement();
       const currentWidth = overlayElement.width();
       const currentHeight = overlayElement.height();
@@ -465,7 +465,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     player.on(player.exports.PlayerEvent.PlayerResized, () => {
       if (this.cea608Enabled) {
-        updateCEA608FontSize();
+        this.ensureCea608GridSizeUpdated();
       }
     });
 

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -321,8 +321,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     let fontSize = 0;
     // The required letter spacing spread the text characters evenly across the grid
     let fontLetterSpacing = 0;
-    // Flag telling if a font size calculation is required of if the current values are valid
-    let fontSizeCalculationRequired = true;
     // The ratio of the caption window/row height that is used as padding to make the window enclose the caption
     const windowPaddingRatio = 0.2;
     let windowPadding: number;
@@ -456,8 +454,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     player.on(player.exports.PlayerEvent.PlayerResized, () => {
       if (this.cea608Enabled) {
         updateCEA608FontSize();
-      } else {
-        fontSizeCalculationRequired = true;
       }
     });
 
@@ -470,15 +466,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       if (!this.cea608Enabled) {
         this.cea608Enabled = true;
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
-
-        // We conditionally update the font size by this flag here to avoid updating every time a subtitle
-        // is added into an empty overlay. Because we reset the overlay when all subtitles are gone, this
-        // would trigger an unnecessary update every time, but it's only required under certain conditions,
-        // e.g. after the player size has changed.
-        if (fontSizeCalculationRequired) {
-          updateCEA608FontSize();
-          fontSizeCalculationRequired = false;
-        }
       }
 
       // We disable the grid and wrapping in case enlarged font size is used to prevent

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -47,6 +47,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
 
   private cea608Enabled = false;
+  private updateCEA608FontSize: () => void;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
@@ -145,14 +146,40 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     player.on(player.exports.PlayerEvent.PlaybackFinished, subtitleClearHandler);
     player.on(player.exports.PlayerEvent.SourceUnloaded, subtitleClearHandler);
 
+
+    this.onShow?.subscribe(() => {
+      this.updateCEA608FontSize?.();
+    });
+
     uimanager.onComponentShow.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
+        // Recalculate CEA-608 dimensions after transition completes
+        if (this.cea608Enabled && this.updateCEA608FontSize) {
+
+          const overlayElement = this.getDomElement().get(0);
+          const transitionEndHandler = () => {
+            this.updateCEA608FontSize();
+            overlayElement.removeEventListener('transitionend', transitionEndHandler);
+          };
+          overlayElement.addEventListener('transitionend', transitionEndHandler);
+        }
       }
     });
+
     uimanager.onComponentHide.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
+        // Recalculate CEA-608 dimensions after transition completes
+        if (this.cea608Enabled && this.updateCEA608FontSize) {
+
+          const overlayElement = this.getDomElement().get(0);
+          const transitionEndHandler = () => {
+            this.updateCEA608FontSize();
+            overlayElement.removeEventListener('transitionend', transitionEndHandler);
+          };
+          overlayElement.addEventListener('transitionend', transitionEndHandler);
+        }
       }
     });
 
@@ -329,7 +356,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       updateCEA608FontSize();
     });
 
-    const updateCEA608FontSize = () => {
+    const updateCEA608FontSize = this.updateCEA608FontSize = () => {
       const dummyLabel = new SubtitleLabel({ text: 'X' });
       dummyLabel.getDomElement().css({
         // By using a large font size we do not need to use multiple letters and can get still an

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -319,6 +319,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     let windowPadding: number;
     // Flag telling if the CEA-608 mode is enabled
     this.cea608Enabled = false;
+    // Track last known dimensions to avoid unnecessary recalculations
+    let lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0 };
 
     const settingsManager = uimanager.getSubtitleSettingsManager();
     if (settingsManager.fontSize.value != null) {
@@ -343,6 +345,19 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     });
 
     const updateCEA608FontSize = this.updateCEA608FontSize = () => {
+      const overlayElement = this.getDomElement();
+      const currentWidth = overlayElement.width();
+      const currentHeight = overlayElement.height();
+      const hasOverlaySizeChanged = currentWidth !== lastCeaGridRecalculation.overlayWidth ||
+        currentHeight !== lastCeaGridRecalculation.overlayHeight;
+      
+      if (!hasOverlaySizeChanged) {
+        // subtitle overlay dimensions have not changed, no need to recalculate
+        return;
+      }
+      
+      lastCeaGridRecalculation = { overlayWidth: currentWidth, overlayHeight: currentHeight };
+      
       const dummyLabel = new SubtitleLabel({ text: 'X' });
       dummyLabel.getDomElement().css({
         // By using a large font size we do not need to use multiple letters and can get still an
@@ -370,10 +385,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // layouting, but the actual reason could not be determined. Aiming for a target width - 1px would work in
       // most browsers, but Safari has a "quantized" font size rendering with huge steps in between so we need
       // to subtract some more pixels to avoid line breaks there as well.
-      const overlayElement = this.getDomElement();
       const subtitleOverlayWidthUsableRatio = (1 - parseFloat(SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET) / 100);
-      const subtitleOverlayWidth = Math.floor(subtitleOverlayWidthUsableRatio * overlayElement.width()) - 10;
-      const subtitleOverlayHeight = overlayElement.height();
+      const subtitleOverlayWidth = Math.floor(subtitleOverlayWidthUsableRatio * currentWidth) - 10;
+      const subtitleOverlayHeight = currentHeight;
 
       // The size ratio of the letter grid
       const fontGridSizeRatio = (dummyLabelCharWidth * this.CEA608_NUM_COLUMNS) /
@@ -872,6 +886,12 @@ function isCea608SubtitleCue(cue: SubtitleCueEvent): boolean {
 }
 
 function awaitTransitionEnd(domElement: DOM) {
+  const hasTransition = getComputedStyle(domElement.get(0)).transitionProperty !== 'none';
+  
+  if (!hasTransition) {
+    return Promise.resolve();
+  }
+
   return new Promise<void>(resolve => {
     const transitionHandler = () => {
       domElement.off('transitionend', transitionHandler);

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -159,8 +159,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
           const overlayElement = this.getDomElement().get(0);
           const transitionEndHandler = () => {
-            this.updateCEA608FontSize();
             overlayElement.removeEventListener('transitionend', transitionEndHandler);
+            this.updateCEA608FontSize();
           };
           overlayElement.addEventListener('transitionend', transitionEndHandler);
         }
@@ -175,8 +175,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
           const overlayElement = this.getDomElement().get(0);
           const transitionEndHandler = () => {
-            this.updateCEA608FontSize();
             overlayElement.removeEventListener('transitionend', transitionEndHandler);
+            this.updateCEA608FontSize();
           };
           overlayElement.addEventListener('transitionend', transitionEndHandler);
         }

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -154,15 +154,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     uimanager.onComponentShow.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
-        // Recalculate CEA-608 dimensions after transition completes
-        if (this.cea608Enabled && this.updateCEA608FontSize) {
 
-          const overlayElement = this.getDomElement().get(0);
-          const transitionEndHandler = () => {
-            overlayElement.removeEventListener('transitionend', transitionEndHandler);
-            this.updateCEA608FontSize();
-          };
-          overlayElement.addEventListener('transitionend', transitionEndHandler);
+        if (this.cea608Enabled && this.updateCEA608FontSize) {
+          // Recalculate CEA-608 grid params after transition completes
+          this.getDomElement().on('transitionend', () => this.updateCEA608FontSize(), { once: true });
         }
       }
     });
@@ -170,15 +165,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     uimanager.onComponentHide.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
-        // Recalculate CEA-608 dimensions after transition completes
-        if (this.cea608Enabled && this.updateCEA608FontSize) {
 
-          const overlayElement = this.getDomElement().get(0);
-          const transitionEndHandler = () => {
-            overlayElement.removeEventListener('transitionend', transitionEndHandler);
-            this.updateCEA608FontSize();
-          };
-          overlayElement.addEventListener('transitionend', transitionEndHandler);
+        if (this.cea608Enabled && this.updateCEA608FontSize) {
+          // Recalculate CEA-608 grid params after transition completes
+          this.getDomElement().on('transitionend', () => this.updateCEA608FontSize(), { once: true });
         }
       }
     });

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -151,8 +151,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
 
         if (this.cea608Enabled && this.updateCEA608FontSize) {
-          // Recalculate CEA-608 grid params after transition completes
-          this.getDomElement().on('transitionend', () => this.updateCEA608FontSize(), { once: true });
+          awaitTransitionEnd(this.getDomElement()).then(this.updateCEA608FontSize);
         }
       }
     });
@@ -162,8 +161,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
 
         if (this.cea608Enabled && this.updateCEA608FontSize) {
-          // Recalculate CEA-608 grid params after transition completes
-          this.getDomElement().on('transitionend', () => this.updateCEA608FontSize(), { once: true });
+          awaitTransitionEnd(this.getDomElement()).then(this.updateCEA608FontSize);
         }
       }
     });
@@ -872,3 +870,15 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
 function isCea608SubtitleCue(cue: SubtitleCueEvent): boolean {
   return cue.position != null;
 }
+
+function awaitTransitionEnd(domElement: DOM) {
+  return new Promise<void>(resolve => {
+    const transitionHandler = () => {
+      domElement.off('transitionend', transitionHandler);
+      domElement.off('transitioncancel', transitionHandler);
+      resolve();
+    };
+    domElement.on('transitionend', transitionHandler);
+    domElement.on('transitioncancel', transitionHandler);
+  });
+};


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

<!-- https://bitmovin.atlassian.net/browse/PW-26432 -->

### Problem

CEA captions are rendered behind the player's control bar.


### Fix

This PR implements scaling the CEA grid down and moving it up when the control bar becomes visible, so that the two do not overlap.

Side fix: Fixed undesired word wraps with caption cues that use the full length of 32 characters

Before

<img width="1225" height="703" alt="Screenshot 2025-08-08 at 14 45 36" src="https://github.com/user-attachments/assets/fb3ffbfe-179b-4ebc-af07-438fe2159d35" />

After

<img width="1222" height="701" alt="Screenshot 2025-08-08 at 14 44 28" src="https://github.com/user-attachments/assets/c92cffe3-e8cc-4177-b45d-6fcd26ccc1fa" />

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
