### PR TITLE
Fix some subtitle and caption issues related to font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Font size change in subtitle rendering options menu has no effect for CEA captions
 - Subtitle font size changes for VTT/TTML subtitles when the subtitle rendering options menu is opened
+- Subtitle font size preference from local storage is not restored upon UI initialization
 
 ## [3.100.0] - 2025-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Font size change in subtitle rendering options menu has no effect for CEA captions
+- Subtitle font size changes for VTT/TTML subtitles when the subtitle rendering options menu is opened
+
 ## [3.100.0] - 2025-08-12
 
 ### Fixed

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -344,7 +344,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     this.onShow?.subscribe(() => {
       // ensure CEA grid is updated whenever the overlay becomes visible
-      this.ensureCea608GridSizeUpdated();
+      if (this.cea608Enabled) {
+        this.ensureCea608GridSizeUpdated();
+      }
     });
 
     this.ensureCea608GridSizeUpdated = () => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -336,7 +336,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       } else {
         this.setFontSizeFactor(1);
       }
-      this.ensureCea608GridSizeUpdated();
+
+      if (this.cea608Enabled) {
+        this.ensureCea608GridSizeUpdated();
+      }
     });
 
     this.onShow?.subscribe(() => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -320,7 +320,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     // Flag telling if the CEA-608 mode is enabled
     this.cea608Enabled = false;
     // Track last known dimensions to avoid unnecessary recalculations
-    let lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0 };
+    let lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
 
     const settingsManager = uimanager.getSubtitleSettingsManager();
     if (settingsManager.fontSize.value != null) {
@@ -350,13 +350,18 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       const currentHeight = overlayElement.height();
       const hasOverlaySizeChanged = currentWidth !== lastCeaGridRecalculation.overlayWidth ||
         currentHeight !== lastCeaGridRecalculation.overlayHeight;
-      
-      if (!hasOverlaySizeChanged) {
-        // subtitle overlay dimensions have not changed, no need to recalculate
+      const hasFontSizeFactorChanged = this.FONT_SIZE_FACTOR !== lastCeaGridRecalculation.fontSizeFactor;
+
+      if (!hasOverlaySizeChanged && !hasFontSizeFactorChanged) {
+        // none of the input variables changed, no need to recalculate
         return;
       }
       
-      lastCeaGridRecalculation = { overlayWidth: currentWidth, overlayHeight: currentHeight };
+      lastCeaGridRecalculation = {
+        overlayWidth: currentWidth,
+        overlayHeight: currentHeight,
+        fontSizeFactor: this.FONT_SIZE_FACTOR,
+      };
       
       const dummyLabel = new SubtitleLabel({ text: 'X' });
       dummyLabel.getDomElement().css({

--- a/src/ts/components/subtitlesettings/fontsizeselectbox.ts
+++ b/src/ts/components/subtitlesettings/fontsizeselectbox.ts
@@ -1,8 +1,8 @@
-import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
-import { UIInstanceManager } from '../../uimanager';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../../localization/i18n';
+import { UIInstanceManager } from '../../uimanager';
 import { ListItem } from '../listselector';
+import { SubtitleSettingSelectBox, SubtitleSettingSelectBoxConfig } from './subtitlesettingselectbox';
 
 /**
  * A select box providing a selection of different font sizes.
@@ -52,12 +52,6 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    this.populateItemsWithFilter();
-
-    this.onShow.subscribe(() => {
-      this.populateItemsWithFilter();
-    });
-
     this.settingsManager.fontSize.onChanged.subscribe((sender, property) => {
       if (property.isSet()) {
         this.toggleOverlayClass('fontsize-' + property.value);
@@ -71,5 +65,12 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
     this.onItemSelected.subscribe((sender, key: string) => {
       this.settingsManager.fontSize.value = key;
     });
+
+    this.onShow.subscribe(() => {
+      this.populateItemsWithFilter();
+    });
+
+    // init
+    this.populateItemsWithFilter();
   }
 }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->


Fixing the following issues:
- Caption font size change in subtitle rendering options menu has no effect for CEA captions (broken since v3.100.0)
- Subtitle font size changes for VTT/TTML subtitles when the subtitle rendering options menu is opened (broken since v3.89.0)
- Subtitle/caption font size preference from local storage is not restored upon UI initialization (broken since v3.89.0)

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
