### PR TITLE
Add icon component to buttons

### DIFF
--- a/src/scss/_cast-receiver.scss
+++ b/src/scss/_cast-receiver.scss
@@ -60,14 +60,14 @@
     // Chromecast (v1) has very poor rendering performance, so we disable the animations.
     // We also display a pause image while playback is paused, instead of a play action button
     .#{$prefix}-ui-hugeplaybacktogglebutton {
-      .#{$prefix}-image {
+      .#{$prefix}-icon {
         background-image: url('../../assets/images/pause.svg');
         opacity: .7;
       }
 
       // sass-lint:disable force-element-nesting
-      &.#{$prefix}-on .#{$prefix}-image,
-      &.#{$prefix}-off .#{$prefix}-image {
+      &.#{$prefix}-on .#{$prefix}-icon,
+      &.#{$prefix}-off .#{$prefix}-icon {
         animation: none;
         transition: none;
       }

--- a/src/scss/_small-screen.scss
+++ b/src/scss/_small-screen.scss
@@ -35,7 +35,7 @@
   // Decrease huge play button size and replace icon with normal play icon
   .#{$prefix}-ui-hugeplaybacktogglebutton,
   .#{$prefix}-ui-smallcenteredplaybacktogglebutton {
-    .#{$prefix}-image {
+    .#{$prefix}-icon {
       background-size: 2.5em;
     }
   }
@@ -46,7 +46,7 @@
     .#{$prefix}-ui-hugeplaybacktogglebutton,
     .#{$prefix}-ui-smallcenteredplaybacktogglebutton {
       &.#{$prefix}-on {
-        .#{$prefix}-image {
+        .#{$prefix}-icon {
           animation: none;
           background-image: url('../../assets/images/pause.svg');
           visibility: visible;
@@ -54,7 +54,7 @@
       }
 
       &.#{$prefix}-off {
-        .#{$prefix}-image {
+        .#{$prefix}-icon {
           animation: none;
         }
       }

--- a/src/scss/_tv.scss
+++ b/src/scss/_tv.scss
@@ -39,7 +39,7 @@
   }
 
   .#{$prefix}-ui-hugeplaybacktogglebutton {
-    > .#{$prefix}-image {
+    > .#{$prefix}-icon {
       background-size: 20vh;
     }
   }

--- a/src/scss/components/_watermark.scss
+++ b/src/scss/components/_watermark.scss
@@ -5,15 +5,20 @@
 
   $watermark-size: 4em;
 
-  background-image: url('../../assets/images/logo.svg');
-  background-size: initial;
   height: $watermark-size;
+  width: $watermark-size;
   margin: 2em;
   opacity: .8;
   position: absolute;
   right: 0;
   top: 0;
-  width: $watermark-size;
+
+  .#{$prefix}-icon {
+    background-size: initial;
+    background-image: url('../../assets/images/logo.svg');
+    height: $watermark-size;
+    width: $watermark-size;
+  }
 
   &:hover {
     opacity: 1;

--- a/src/scss/components/ads/_ad-skip-button.scss
+++ b/src/scss/components/ads/_ad-skip-button.scss
@@ -9,28 +9,17 @@
   padding: .5em 1em;
   min-width: fit-content;
 
-  .#{$prefix}-label {
-    display: inline-block;
-    color: $color-ads;
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/ad-skip.svg');
+  }
 
-    &::after {
-      background-image: url('../../assets/images/ad-skip.svg');
-      background-repeat: no-repeat;
-      background-size: 1em auto;
-      content: ' ';
-      display: inline-block;
-      height: 1em;
-      vertical-align: bottom;
-      margin-left: .5em;
-      width: 1em;
-    }
+  .#{$prefix}-label {
+    color: $color-ads;
   }
 
   &.#{$prefix}-disabled {
-    .#{$prefix}-label {
-      &::after {
-        display: none;
-      }
+    .#{$prefix}-icon {
+      display: none;
     }
   }
 

--- a/src/scss/components/buttons/_airplay-toggle-button.scss
+++ b/src/scss/components/buttons/_airplay-toggle-button.scss
@@ -4,13 +4,17 @@
 .#{$prefix}-ui-airplaytogglebutton {
   @extend %ui-button;
 
-  background-image: url('../../assets/images/airplay.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/airplay.svg');
+  }
 
   &:hover {
     @include svg-icon-shadow;
   }
 
   &.#{$prefix}-on {
-    background-image: url('../../assets/images/airplayX.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/airplayX.svg');
+    }
   }
 }

--- a/src/scss/components/buttons/_button.scss
+++ b/src/scss/components/buttons/_button.scss
@@ -4,10 +4,6 @@
   @extend %ui-component;
 
   background-color: transparent;
-  background-origin: content-box;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 1.2em;
   border: 0;
   box-sizing: content-box;
   cursor: pointer;
@@ -18,15 +14,14 @@
   -webkit-tap-highlight-color: transparent;
   padding: .25em;
   display: flex;
-  flex-flow: column;
-  justify-content: center;
-
-  .#{$prefix}-label {
-    color: $color-primary;
-    display: none;
-  }
+  align-items: center;
+  flex-direction: column;
+  flex-flow: row;
+  justify-content: flex-start;
+  gap: .4em;
 
   .#{$prefix}-icon {
+    display: inline-block;
     background-color: transparent;
     background-origin: content-box;
     background-position: center;
@@ -35,8 +30,13 @@
     border: 0;
     box-sizing: content-box;
     cursor: pointer;
-    height: 100%;
     width: 100%;
+    height: 1.5em;
+    min-width: 1.5em;
+  }
+
+  .#{$prefix}-label {
+    color: $color-primary;
   }
 
   &.#{$prefix}-disabled {

--- a/src/scss/components/buttons/_button.scss
+++ b/src/scss/components/buttons/_button.scss
@@ -14,13 +14,29 @@
   font-size: 1em;
   height: 1.5em;
   min-width: 1.5em;
-  padding: .25em;
   transition: transform .15s ease;
   -webkit-tap-highlight-color: transparent;
+  padding: .25em;
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
 
   .#{$prefix}-label {
     color: $color-primary;
     display: none;
+  }
+
+  .#{$prefix}-icon {
+    background-color: transparent;
+    background-origin: content-box;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 1.2em;
+    border: 0;
+    box-sizing: content-box;
+    cursor: pointer;
+    height: 100%;
+    width: 100%;
   }
 
   &.#{$prefix}-disabled {

--- a/src/scss/components/buttons/_button.scss
+++ b/src/scss/components/buttons/_button.scss
@@ -10,15 +10,16 @@
   font-size: 1em;
   height: 1.5em;
   min-width: 1.5em;
-  transition: transform .15s ease;
-  -webkit-tap-highlight-color: transparent;
   padding: .25em;
+  transition: transform .15s ease;
+  // sass-lint:disable no-vendor-prefixes
+  -webkit-tap-highlight-color: transparent;
   display: flex;
   align-items: center;
   flex-direction: column;
   flex-flow: row;
   justify-content: flex-start;
-  gap: .4em;
+  column-gap: .4em;
 
   .#{$prefix}-icon {
     display: inline-block;

--- a/src/scss/components/buttons/_cast-toggle-button.scss
+++ b/src/scss/components/buttons/_cast-toggle-button.scss
@@ -4,13 +4,17 @@
 .#{$prefix}-ui-casttogglebutton {
   @extend %ui-button;
 
-  background-image: url('../../assets/images/cast.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/cast.svg');
+  }
 
   &:hover {
     @include svg-icon-shadow;
   }
 
   &.#{$prefix}-on {
-    background-image: url('../../assets/images/chromecastX.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/chromecastX.svg');
+    }
   }
 }

--- a/src/scss/components/buttons/_close-button.scss
+++ b/src/scss/components/buttons/_close-button.scss
@@ -22,7 +22,9 @@
     }
   }
 
-  background-image: url('../../assets/images/close.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/close.svg');
+  }
 
   &:hover {
     @include svg-icon-shadow;

--- a/src/scss/components/buttons/_eco-mode-toggle-button.scss
+++ b/src/scss/components/buttons/_eco-mode-toggle-button.scss
@@ -11,14 +11,18 @@
   }
 
   &.#{$prefix}-on {
-    background-image: url('../../assets/images/toggleOn.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/toggleOn.svg');
+    }
     background-position: 20px center;
     background-size: 45% auto;
     margin-left: 2%;
   }
 
   &.#{$prefix}-off {
-    background-image: url('../../assets/images/toggleOff.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/toggleOff.svg');
+    }
     background-position: 20px center;
     background-size: 45% auto;
   }

--- a/src/scss/components/buttons/_eco-mode-toggle-button.scss
+++ b/src/scss/components/buttons/_eco-mode-toggle-button.scss
@@ -13,18 +13,18 @@
   &.#{$prefix}-on {
     .#{$prefix}-icon {
       background-image: url('../../assets/images/toggleOn.svg');
+      background-position: 20px center;
+      background-size: 45% auto;
+      margin-left: 2%;
     }
-    background-position: 20px center;
-    background-size: 45% auto;
-    margin-left: 2%;
   }
 
   &.#{$prefix}-off {
     .#{$prefix}-icon {
       background-image: url('../../assets/images/toggleOff.svg');
+      background-position: 20px center;
+      background-size: 45% auto;
     }
-    background-position: 20px center;
-    background-size: 45% auto;
   }
 }
 

--- a/src/scss/components/buttons/_fullscreen-toggle-button.scss
+++ b/src/scss/components/buttons/_fullscreen-toggle-button.scss
@@ -4,13 +4,17 @@
 .#{$prefix}-ui-fullscreentogglebutton {
   @extend %ui-button;
 
-  background-image: url('../../assets/images/fullscreen.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/fullscreen.svg');
+  }
 
   &:hover {
     @include svg-icon-shadow;
   }
 
   &.#{$prefix}-on {
-    background-image: url('../../assets/images/fullscreenX.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/fullscreenX.svg');
+    }
   }
 }

--- a/src/scss/components/buttons/_huge-playback-toggle-button.scss
+++ b/src/scss/components/buttons/_huge-playback-toggle-button.scss
@@ -44,7 +44,7 @@
   overflow: hidden; // hide overflow from scale animation
   width: 8em;
 
-  .#{$prefix}-image {
+  .#{$prefix}-icon {
     background-image: url('../../assets/images/play.svg');
     background-position: center;
     background-repeat: no-repeat;
@@ -58,7 +58,7 @@
   }
 
   &.#{$prefix}-on {
-    .#{$prefix}-image {
+    .#{$prefix}-icon {
       animation: #{$prefix}-fade-out $animation-duration cubic-bezier(.55, .055, .675, .19); // http://easings.net/de#easeInCubic
       transition: visibility 0s $animation-duration;
       visibility: hidden;
@@ -66,7 +66,7 @@
   }
 
   &.#{$prefix}-off {
-    .#{$prefix}-image {
+    .#{$prefix}-icon {
       animation:  #{$prefix}-fade-in $animation-duration cubic-bezier(.55, .055, .675, .19); // http://easings.net/de#easeInCubic
       visibility: visible;
     }
@@ -75,7 +75,7 @@
   &.#{$prefix}-no-transition-animations {
     &.#{$prefix}-on,
     &.#{$prefix}-off {
-      .#{$prefix}-image {
+      .#{$prefix}-icon {
         animation: none;
         transition: none;
       }

--- a/src/scss/components/buttons/_huge-replay-button.scss
+++ b/src/scss/components/buttons/_huge-replay-button.scss
@@ -8,7 +8,7 @@
   outline: none;
   width: 5em;
 
-  .#{$prefix}-image {
+  .#{$prefix}-icon {
     background-image: url('../../assets/images/replayX.svg');
     background-position: center;
     background-repeat: no-repeat;

--- a/src/scss/components/buttons/_picture-in-picture-toggle-button.scss
+++ b/src/scss/components/buttons/_picture-in-picture-toggle-button.scss
@@ -4,13 +4,17 @@
 .#{$prefix}-ui-piptogglebutton {
   @extend %ui-button;
 
-  background-image: url('../../assets/images/pip.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/pip.svg');
+  }
 
   &:hover {
     @include svg-icon-shadow;
   }
 
   &.#{$prefix}-on {
-    background-image: url('../../assets/images/pip.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/pip.svg');
+    }
   }
 }

--- a/src/scss/components/buttons/_playback-toggle-button.scss
+++ b/src/scss/components/buttons/_playback-toggle-button.scss
@@ -4,17 +4,23 @@
 .#{$prefix}-ui-playbacktogglebutton {
   @extend %ui-button;
 
-  background-image: url('../../assets/images/play.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/play.svg');
+  }
 
   &:hover {
     @include svg-icon-shadow;
   }
 
   &.#{$prefix}-on {
-    background-image: url('../../assets/images/pause.svg');
+    .#{$prefix}-icon {
+  background-image: url('../../assets/images/pause.svg');
+}
 
     &.#{$prefix}-stoptoggle {
-      background-image: url('../../assets/images/stop.svg');
+      .#{$prefix}-icon {
+  background-image: url('../../assets/images/stop.svg');
+}
     }
   }
 }

--- a/src/scss/components/buttons/_playback-toggle-button.scss
+++ b/src/scss/components/buttons/_playback-toggle-button.scss
@@ -14,13 +14,13 @@
 
   &.#{$prefix}-on {
     .#{$prefix}-icon {
-  background-image: url('../../assets/images/pause.svg');
-}
+      background-image: url('../../assets/images/pause.svg');
+    }
 
     &.#{$prefix}-stoptoggle {
       .#{$prefix}-icon {
-  background-image: url('../../assets/images/stop.svg');
-}
+        background-image: url('../../assets/images/stop.svg');
+      }
     }
   }
 }

--- a/src/scss/components/buttons/_quick-seek-button.scss
+++ b/src/scss/components/buttons/_quick-seek-button.scss
@@ -9,10 +9,14 @@
   }
 
   &[data-#{$prefix}-seek-direction='forward'] {
-    background-image: url('../../assets/images/quickseek-fastforward.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/quickseek-fastforward.svg');
+    }
   }
 
   &[data-#{$prefix}-seek-direction='rewind'] {
-    background-image: url('../../assets/images/quickseek-rewind.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/quickseek-rewind.svg');
+    }
   }
 }

--- a/src/scss/components/buttons/_replay-button.scss
+++ b/src/scss/components/buttons/_replay-button.scss
@@ -4,7 +4,9 @@
 .#{$prefix}-ui-replaybutton {
   @extend %ui-button;
 
-  background-image: url('../../assets/images/replay-nocircle.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/replay-nocircle.svg');
+  }
 
   &:hover {
     @include svg-icon-shadow;

--- a/src/scss/components/buttons/_small-centered-playback-toggle-button.scss
+++ b/src/scss/components/buttons/_small-centered-playback-toggle-button.scss
@@ -13,7 +13,7 @@
     @include svg-icon-shadow;
   }
 
-  .#{$prefix}-image {
+  .#{$prefix}-icon {
     background-position: center;
     background-repeat: no-repeat;
     background-size: 4em;
@@ -22,13 +22,13 @@
   }
 
   &.#{$prefix}-on {
-    .#{$prefix}-image {
+    .#{$prefix}-icon {
       background-image: url('../../assets/images/pause.svg');
     }
   }
 
   &.#{$prefix}-off {
-    .#{$prefix}-image {
+    .#{$prefix}-icon {
       background-image: url('../../assets/images/play.svg');
     }
   }
@@ -36,7 +36,7 @@
   &.#{$prefix}-no-transition-animations {
     &.#{$prefix}-on,
     &.#{$prefix}-off {
-      .#{$prefix}-image {
+      .#{$prefix}-icon {
         animation: none;
         transition: none;
       }

--- a/src/scss/components/buttons/_subtitle-settings-panel-toggle-button.scss
+++ b/src/scss/components/buttons/_subtitle-settings-panel-toggle-button.scss
@@ -4,9 +4,13 @@
 .#{$prefix}-ui-subtitlesettingstogglebutton {
   @extend %ui-settingstogglebutton;
 
-  background-image: url('../../assets/images/subtitles.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/subtitles.svg');
+  }
 
   &.#{$prefix}-on {
-    background-image: url('../../assets/images/subtitlesX.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/subtitlesX.svg');
+    }
   }
 }

--- a/src/scss/components/buttons/_subtitle-toggle-button.scss
+++ b/src/scss/components/buttons/_subtitle-toggle-button.scss
@@ -9,12 +9,16 @@
   }
 
   &.#{$prefix}-subtitles-on {
-    background-image: url('../../assets/images/subtitles-on.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/subtitles-on.svg');
+    }
     background-size: 1.5em;
   }
 
   &.#{$prefix}-subtitles-off {
-    background-image: url('../../assets/images/subtitles-off.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/subtitles-off.svg');
+    }
     background-size: 1.5em;
   }
 }

--- a/src/scss/components/buttons/_subtitle-toggle-button.scss
+++ b/src/scss/components/buttons/_subtitle-toggle-button.scss
@@ -12,13 +12,11 @@
     .#{$prefix}-icon {
       background-image: url('../../assets/images/subtitles-on.svg');
     }
-    background-size: 1.5em;
   }
 
   &.#{$prefix}-subtitles-off {
     .#{$prefix}-icon {
       background-image: url('../../assets/images/subtitles-off.svg');
     }
-    background-size: 1.5em;
   }
 }

--- a/src/scss/components/buttons/_volume-toggle-button.scss
+++ b/src/scss/components/buttons/_volume-toggle-button.scss
@@ -9,12 +9,16 @@
   }
 
   &.#{$prefix}-muted {
-    background-image: url('../../assets/images/volume-mute.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/volume-mute.svg');
+    }
   }
 
   &.#{$prefix}-unmuted {
     &[data-#{$prefix}-volume-level-tens='0'] {
-      background-image: url('../../assets/images/volume-mute.svg');
+      .#{$prefix}-icon {
+        background-image: url('../../assets/images/volume-mute.svg');
+      }
     }
 
     &[data-#{$prefix}-volume-level-tens='1'],
@@ -22,7 +26,9 @@
     &[data-#{$prefix}-volume-level-tens='3'],
     &[data-#{$prefix}-volume-level-tens='4'],
     &[data-#{$prefix}-volume-level-tens='5'] {
-      background-image: url('../../assets/images/volume.svg');
+      .#{$prefix}-icon {
+        background-image: url('../../assets/images/volume.svg');
+      }
     }
 
     &[data-#{$prefix}-volume-level-tens='6'],
@@ -30,7 +36,9 @@
     &[data-#{$prefix}-volume-level-tens='8'],
     &[data-#{$prefix}-volume-level-tens='9'],
     &[data-#{$prefix}-volume-level-tens='10'] {
-      background-image: url('../../assets/images/volume.svg');
+      .#{$prefix}-icon {
+        background-image: url('../../assets/images/volume.svg');
+      }
     }
   }
 }

--- a/src/scss/components/buttons/_vr-toggle-button.scss
+++ b/src/scss/components/buttons/_vr-toggle-button.scss
@@ -5,13 +5,17 @@
   @extend %ui-button;
 
   // svg() usage: http://pavliko.github.io/postcss-svg/
-  background-image: url('../../assets/images/glasses.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/glasses.svg');
+  }
 
   &:hover {
     @include svg-icon-shadow;
   }
 
   &.#{$prefix}-on {
-    background-image: url('../../assets/images/glassesX.svg');
+    .#{$prefix}-icon {
+      background-image: url('../../assets/images/glassesX.svg');
+    }
   }
 }

--- a/src/scss/components/labels/_label.scss
+++ b/src/scss/components/labels/_label.scss
@@ -7,6 +7,7 @@
 
   cursor: default;
   white-space: nowrap;
+  // sass-lint:disable no-vendor-prefixes
   -webkit-tap-highlight-color: transparent;
 }
 

--- a/src/scss/components/settings/_settings-panel-navigation-text-button.scss
+++ b/src/scss/components/settings/_settings-panel-navigation-text-button.scss
@@ -5,6 +5,7 @@
 
   font-weight: 500;
   padding-top: 0;
+  justify-content: flex-end;
 
   .#{$prefix}-label {
     display: inline-block;

--- a/src/scss/components/settings/_settings-panel-page-back-button.scss
+++ b/src/scss/components/settings/_settings-panel-page-back-button.scss
@@ -7,7 +7,7 @@
   padding: unset;
   flex: 1;
   text-align: left;
-  gap: .4em;
+  column-gap: .4em;
   min-width: unset;
 
   &:active {

--- a/src/scss/components/settings/_settings-panel-page-back-button.scss
+++ b/src/scss/components/settings/_settings-panel-page-back-button.scss
@@ -7,9 +7,17 @@
   padding: unset;
   flex: 1;
   text-align: left;
+  gap: .4em;
+  min-width: unset;
 
   &:active {
     transform: unset;
+  }
+
+  .#{$prefix}-icon {
+    width: .8em;
+    min-width: unset;
+    background-image: url('../../assets/images/angle-left.svg');
   }
 
   .#{$prefix}-label {
@@ -17,18 +25,6 @@
     font-size: .8em;
     font-weight: 500;
     margin: 0;
-    text-align: justify;
-
-    &::before {
-      background-image: url('../../assets/images/angle-left.svg');
-      background-repeat: no-repeat;
-      background-size: 1.5em auto;
-      content: ' ';
-      display: inline-block;
-      height: 1.5em;
-      vertical-align: -.4em;
-      width: 1.5em;
-    }
   }
 }
 

--- a/src/scss/components/settings/_settings-panel-page-open-button.scss
+++ b/src/scss/components/settings/_settings-panel-page-open-button.scss
@@ -6,15 +6,17 @@
 
   .#{$prefix}-icon {
     background-image: url('../../assets/images/setting.svg');
+    max-height: .8em;
   }
-  max-height: .8em;
 
   &:hover {
     @include svg-icon-shadow;
   }
 
   &.#{$prefix}-on {
-    transform: rotate(30deg);
+    .#{$prefix}-icon {
+      transform: rotate(30deg);
+    }
   }
 }
 

--- a/src/scss/components/settings/_settings-panel-page-open-button.scss
+++ b/src/scss/components/settings/_settings-panel-page-open-button.scss
@@ -4,7 +4,9 @@
 %ui-settingspanelpageopenbutton {
   @extend %ui-button;
 
-  background-image: url('../../assets/images/setting.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/setting.svg');
+  }
   max-height: .8em;
 
   &:hover {

--- a/src/scss/components/settings/_settings-toggle-button.scss
+++ b/src/scss/components/settings/_settings-toggle-button.scss
@@ -17,6 +17,8 @@
   }
 
   &.#{$prefix}-on {
-    transform: rotate(30deg);
+    .#{$prefix}-icon {
+      transform: rotate(30deg);
+    }
   }
 }

--- a/src/scss/components/settings/_settings-toggle-button.scss
+++ b/src/scss/components/settings/_settings-toggle-button.scss
@@ -12,7 +12,9 @@
 .#{$prefix}-ui-settingstogglebutton {
   @extend %ui-settingstogglebutton;
 
-  background-image: url('../../assets/images/setting.svg');
+  .#{$prefix}-icon {
+    background-image: url('../../assets/images/setting.svg');
+  }
 
   &.#{$prefix}-on {
     transform: rotate(30deg);

--- a/src/ts/DOM.ts
+++ b/src/ts/DOM.ts
@@ -347,7 +347,7 @@ export class DOM {
 
   /**
    * Appends one or more DOM elements as children to all elements.
-   * @param childElements the chrild elements to append
+   * @param childElements the child elements to append
    * @returns {DOM}
    */
   append(...childElements: DOM[]): DOM {

--- a/src/ts/components/ads/AdSkipButton.ts
+++ b/src/ts/components/ads/AdSkipButton.ts
@@ -1,4 +1,4 @@
-import { ButtonConfig, Button } from '../buttons/Button';
+import { Button, ButtonConfig, ButtonStyle } from '../buttons/Button';
 import { UIInstanceManager } from '../../UIManager';
 import { StringUtils } from '../../utils/StringUtils';
 import { AdEvent, LinearAd, PlayerAPI } from 'bitmovin-player';
@@ -36,6 +36,7 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       untilSkippableMessage: 'Skip ad in {remainingTime} sec',
       skippableMessage: 'Skip',
       acceptsTouchWithUiHidden: true,
+      buttonStyle: ButtonStyle.TextIconTrailing,
     }, this.config);
   }
 

--- a/src/ts/components/ads/AdSkipButton.ts
+++ b/src/ts/components/ads/AdSkipButton.ts
@@ -36,7 +36,7 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       untilSkippableMessage: 'Skip ad in {remainingTime} sec',
       skippableMessage: 'Skip',
       acceptsTouchWithUiHidden: true,
-      buttonStyle: ButtonStyle.TextIconTrailing,
+      buttonStyle: ButtonStyle.TextWithTrailingIcon,
     }, this.config);
   }
 

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -48,6 +48,12 @@ export interface ButtonConfig extends ComponentConfig {
    * Default: false
    */
   acceptsTouchWithUiHidden?: boolean;
+
+  /**
+   * The style of the button.
+   * Default: `ButtonStyle.Icon`
+   */
+  buttonStyle?: ButtonStyle;
 }
 
 /**
@@ -69,6 +75,7 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
       role: 'button',
       tabIndex: 0,
       acceptsTouchWithUiHidden: false,
+      buttonStyle: ButtonStyle.Icon,
     } as Config, this.config);
   }
 
@@ -87,21 +94,44 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
 
     // Create the button element with the text label
     let buttonElement = new DOM('button', buttonElementAttributes, this)
-      .append(
-        new DOM(
-          'div',
-          {
-            'class': this.prefixCss('icon'),
-            'alt': i18n.performLocalization(this.config.ariaLabel || this.config.text),
-          },
-        ),
-      )
-      .append(
-        new DOM('span', {
-          'class': this.prefixCss('label'),
-        }
-      )
-      .html(i18n.performLocalization(this.config.text)));
+
+    const addIconElement = () => {
+      buttonElement
+        .append(
+          new DOM(
+            'div',
+            {
+              'class': this.prefixCss('icon'),
+              'alt': i18n.performLocalization(this.config.ariaLabel || this.config.text),
+            },
+          ),
+        );
+    }
+
+    const addLabelElement = () => {
+      buttonElement
+        .append(
+          new DOM('span', { 'class': this.prefixCss('label'), })
+            .html(i18n.performLocalization(this.config.text))
+        );
+    }
+
+    switch (this.config.buttonStyle) {
+      case ButtonStyle.Icon:
+        addIconElement();
+        break;
+      case ButtonStyle.Text:
+        addLabelElement();
+        break;
+      case ButtonStyle.TextIconLeading:
+        addIconElement();
+        addLabelElement();
+        break;
+      case ButtonStyle.TextIconTrailing:
+        addLabelElement();
+        addIconElement();
+        break;
+    }
 
     // Listen for the click event on the button element and trigger the corresponding event on the button component
     buttonElement.on('click', (e) => {

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -62,9 +62,22 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
     }
 
     // Create the button element with the text label
-    let buttonElement = new DOM('button', buttonElementAttributes, this).append(new DOM('span', {
-      'class': this.prefixCss('label'),
-    }).html(i18n.performLocalization(this.config.text)));
+    let buttonElement = new DOM('button', buttonElementAttributes, this)
+      .append(
+        new DOM(
+          'div',
+          {
+            'class': this.prefixCss('icon'),
+            'alt': i18n.performLocalization(this.config.ariaLabel || this.config.text),
+          },
+        ),
+      )
+      .append(
+        new DOM('span', {
+          'class': this.prefixCss('label'),
+        }
+      )
+      .html(i18n.performLocalization(this.config.text)));
 
     // Listen for the click event on the button element and trigger the corresponding event on the button component
     buttonElement.on('click', (e) => {

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -19,12 +19,12 @@ export enum ButtonStyle {
    * Display the button with an icon and text.
    * The Icon is displayed before the text.
    */
-  TextIconLeading = 'text-icon-leading',
+  TextWithLeadingIcon = 'text-icon-leading',
   /**
    * Display the button with an icon and text.
    * The Icon is displayed after the text.
    */
-  TextIconTrailing = 'text-icon-trailing',
+  TextWithTrailingIcon = 'text-icon-trailing',
 }
 
 /**
@@ -123,11 +123,11 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
       case ButtonStyle.Text:
         addLabelElement();
         break;
-      case ButtonStyle.TextIconLeading:
+      case ButtonStyle.TextWithLeadingIcon:
         addIconElement();
         addLabelElement();
         break;
-      case ButtonStyle.TextIconTrailing:
+      case ButtonStyle.TextWithTrailingIcon:
         addLabelElement();
         addIconElement();
         break;

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -4,6 +4,30 @@ import {EventDispatcher, NoArgs, Event} from '../../EventDispatcher';
 import { LocalizableText , i18n } from '../../localization/i18n';
 
 /**
+ * Configures the style of a {@link Button} component.
+ */
+export enum ButtonStyle {
+  /**
+   * Only display the button as an icon.
+   */
+  Icon = 'icon',
+  /**
+   * Only display the button as text.
+   */
+  Text = 'text',
+  /**
+   * Display the button with an icon and text.
+   * The Icon is displayed before the text.
+   */
+  TextIconLeading = 'text-icon-leading',
+  /**
+   * Display the button with an icon and text.
+   * The Icon is displayed after the text.
+   */
+  TextIconTrailing = 'text-icon-trailing',
+}
+
+/**
  * Configuration interface for a {@link Button} component.
  *
  * @category Configs

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -51,7 +51,7 @@ export interface ButtonConfig extends ComponentConfig {
 
   /**
    * The style of the button.
-   * Default: `ButtonStyle.Icon`
+   * Default: {@link ButtonStyle.Icon}
    */
   buttonStyle?: ButtonStyle;
 }

--- a/src/ts/components/buttons/HugePlaybackToggleButton.ts
+++ b/src/ts/components/buttons/HugePlaybackToggleButton.ts
@@ -157,20 +157,6 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
     }
   }
 
-  protected toDomElement(): DOM {
-    let buttonElement = super.toDomElement();
-
-    // Add child that contains the play button image
-    // Setting the image directly on the button does not work together with scaling animations, because the button
-    // can cover the whole video player are and scaling would extend it beyond. By adding an inner element, confined
-    // to the size if the image, it can scale inside the player without overshooting.
-    buttonElement.append(new DOM('div', {
-      'class': this.prefixCss('image'),
-    }));
-
-    return buttonElement;
-  }
-
   /**
    * Enables or disables the play state transition animations of the play button image. Can be used to suppress
    * animations.

--- a/src/ts/components/buttons/SmallCenteredPlaybackToggleButton.ts
+++ b/src/ts/components/buttons/SmallCenteredPlaybackToggleButton.ts
@@ -83,20 +83,6 @@ export class SmallCenteredPlaybackToggleButton extends PlaybackToggleButton {
     }
   }
 
-  protected toDomElement(): DOM {
-    let buttonElement = super.toDomElement();
-
-    // Add child that contains the play button image
-    // Setting the image directly on the button does not work together with scaling animations, because the button
-    // can cover the whole video player are and scaling would extend it beyond. By adding an inner element, confined
-    // to the size if the image, it can scale inside the player without overshooting.
-    buttonElement.append(new DOM('div', {
-      'class': this.prefixCss('image'),
-    }));
-
-    return buttonElement;
-  }
-
   /**
    * Enables or disables the play state transition animations of the play button image. Can be used to suppress
    * animations.

--- a/src/ts/components/settings/SettingsPanelPageBackButton.ts
+++ b/src/ts/components/settings/SettingsPanelPageBackButton.ts
@@ -1,7 +1,8 @@
-import {UIInstanceManager} from '../../UIManager';
-import {SettingsPanelPageNavigatorButton, SettingsPanelPageNavigatorConfig} from './SettingsPanelPageNavigatorButton';
+import { UIInstanceManager } from '../../UIManager';
+import { SettingsPanelPageNavigatorButton, SettingsPanelPageNavigatorConfig } from './SettingsPanelPageNavigatorButton';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../../localization/i18n';
+import { ButtonStyle } from '../buttons/Button';
 
 /**
  * @category Buttons
@@ -14,6 +15,7 @@ export class SettingsPanelPageBackButton extends SettingsPanelPageNavigatorButto
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-settingspanelpagebackbutton',
       text: i18n.getLocalizer('back'),
+      buttonStyle: ButtonStyle.TextIconLeading,
     } as SettingsPanelPageNavigatorConfig, this.config);
   }
 

--- a/src/ts/components/settings/SettingsPanelPageBackButton.ts
+++ b/src/ts/components/settings/SettingsPanelPageBackButton.ts
@@ -15,7 +15,7 @@ export class SettingsPanelPageBackButton extends SettingsPanelPageNavigatorButto
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-settingspanelpagebackbutton',
       text: i18n.getLocalizer('back'),
-      buttonStyle: ButtonStyle.TextIconLeading,
+      buttonStyle: ButtonStyle.TextWithLeadingIcon,
     } as SettingsPanelPageNavigatorConfig, this.config);
   }
 

--- a/src/ts/components/settings/SettingsPanelPageNavigatorButton.ts
+++ b/src/ts/components/settings/SettingsPanelPageNavigatorButton.ts
@@ -1,8 +1,6 @@
-import {Button, ButtonConfig} from '../buttons/Button';
+import { Button, ButtonConfig, ButtonStyle } from '../buttons/Button';
 import { SettingsPanel, SettingsPanelConfig } from './SettingsPanel';
-import {SettingsPanelPage} from './SettingsPanelPage';
-import { PlayerAPI } from 'bitmovin-player';
-import { UIInstanceManager } from '../../UIManager';
+import { SettingsPanelPage } from './SettingsPanelPage';
 
 /**
  * Configuration interface for a {@link SettingsPanelPageNavigatorButton}
@@ -47,7 +45,12 @@ export class SettingsPanelPageNavigatorButton extends Button<SettingsPanelPageNa
 
   constructor(config: SettingsPanelPageNavigatorConfig) {
     super(config);
-    this.config = this.mergeConfig(config, {} as SettingsPanelPageNavigatorConfig, this.config);
+    this.config = this.mergeConfig(
+      config, {
+        buttonStyle: ButtonStyle.Text,
+      },
+      this.config
+    );
 
     this.container = (this.config as SettingsPanelPageNavigatorConfig).container;
     this.targetPage = (this.config as SettingsPanelPageNavigatorConfig).targetPage;


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
We current use background-image on buttons to display our icons within the UI. With this approach it's not easily possible to style the button and the icon differently. E.g. our new TV UI design will feature a new background color for focused buttons which is currently not possible when already using the background for the icon.

### Changes
To prepare for this already, this PR introduces a dedicated icon element for all buttons to detach the icon from the background.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **Will be added at the end of v4**
