### PR TITLE
Fix font size scaling for CEA captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
-- Default font size for CEA captions is lowered, the previous 75% is the new 100%.
+- Default font size for CEA captions is lowered, effectively making the previous 75% the new 100%.
 
 ### Fixed
 - Long CEA captions are cut off when font size changed to greater than 100% via settings panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Default font size for CEA captions is lowered, the previous 75% is the new 100%.
+
+### Fixed
+- Long CEA captions are cut off when font size changed to greater than 100% via settings panel
+- CEA caption font size is not changing when font size set to 75% via settings panel
+- CEA caption positioning breaks when font size is changed via settings panel
+
 ## [3.101.0] - 2025-08-12
 
 ### Fixed

--- a/spec/components/subtitleoverlay.spec.ts
+++ b/spec/components/subtitleoverlay.spec.ts
@@ -1,7 +1,7 @@
-import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
-import { UIInstanceManager } from '../../src/ts/uimanager';
-import { SubtitleOverlay, SubtitleRegionContainer, SubtitleRegionContainerManager } from '../../src/ts/components/subtitleoverlay';
+import { SubtitleOverlay, SubtitleRegionContainerManager } from '../../src/ts/components/subtitleoverlay';
 import { DOM } from '../../src/ts/dom';
+import { UIInstanceManager } from '../../src/ts/uimanager';
+import { MockHelper, TestingPlayerAPI } from '../helper/MockHelper';
 
 let playerMock: jest.Mocked<TestingPlayerAPI>;
 let uiInstanceManagerMock: UIInstanceManager;
@@ -87,75 +87,21 @@ describe('SubtitleOverlay', () => {
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
     });
 
-    it('should preserve default FONT_SIZE_FACTOR of 1 if no font size value on settings present', () => {
-      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(1);
+    it('should preserve default cea608FontSizeFactor of 1 if no font size value on settings present', () => {
+      expect(subtitleOverlay['cea608FontSizeFactor']).toBe(1);
     });
 
     // Font size factor clamping
     test.each([
-      [0.2, 0.5],  // Clamped to minimum
-      [3.0, 2.0],  // Clamped to maximum
-      [1.5, 1.5],  // Within range, no clamping
-      [0.5, 0.5],  // Exact minimum
-      [2.0, 2.0],  // Exact maximum
-      [1.0, 1.0],  // Default value
-    ])('setFontSizeFactor(%f) results in FONT_SIZE_FACTOR = %f', (inputFactor, expectedFactor) => {
+      [0.2, 0.5], // Clamped to minimum
+      [3.0, 2.0], // Clamped to maximum
+      [1.5, 1.5], // Within range, no clamping
+      [0.5, 0.5], // Exact minimum
+      [2.0, 2.0], // Exact maximum
+      [1.0, 1.0], // Default value
+    ])('setFontSizeFactor(%f) results in cea608FontSizeFactor = %f', (inputFactor, expectedFactor) => {
       subtitleOverlay.setFontSizeFactor(inputFactor);
-      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(expectedFactor);
+      expect(subtitleOverlay['cea608FontSizeFactor']).toBe(expectedFactor);
     });
-
-    // Grid recalculations
-    test.each([
-      [1.0, 15 / 1.0, 32 / 1.0],  // Standard grid
-      [2.0, 15 / 2.0, 32 / 2.0],  // Larger factor, smaller grid
-      [0.5, 15 / 1.0, 32 / 0.5],  // Factor <1 → rows stay 15, columns grow
-    ])('setFontSizeFactor(%f) recalculates grid: ROWS = %f, COLUMNS = %f', (factor, expectedRows, expectedColumns) => {
-      // We need to floor for whole rows as they are represented in precompiled sass styles
-      const expectedWholeRows = Math.floor(expectedRows)
-      subtitleOverlay.setFontSizeFactor(factor);
-      subtitleOverlay.recalculateCEAGrid();
-
-      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(expectedWholeRows);
-      expect(subtitleOverlay['CEA608_NUM_COLUMNS']).toBe(expectedColumns);
-    });
-
-    test.each([
-      [1.0, 5, 5, 5],         // Factor 1.0: grid remains 15 rows; row 5 remains unchanged.
-      [1.0, 14, 14, 14],      // Factor 1.0: grid remains 15 rows; row 14 remains unchanged.
-      [2.0, 14, 14, 6],       // Factor 2.0: grid becomes floor(15/2)=7 rows; rowDelta = 15-7=8; 14-8=6.
-      [1.5, 12, 12, 7],       // Factor 1.5: grid becomes floor(15/1.5)=10 rows; 12 > 10 so rowDelta=15-10=5; 12-5=7.
-      [1.5, 8, 8, 8],         // Factor 1.5: grid becomes 10 rows; 8 <= 10 so no clamping.
-      [2.0, 14, undefined, 6] // If no originalRow provided, falls back to initial row (14) and is clamped to 6.
-    ])(
-      'with fontSizeFactor=%f, initialRow=%d, labelOriginalRow=%s, expected new row=%d',
-      (fontSizeFactor, initialRow, labelOriginalRow, expectedRow) => {
-        const element = document.createElement('div');
-        const initialClass = `subtitle-position-cea608-row-${initialRow}`;
-        element.classList.add(initialClass);
-
-        const label = {
-          getConfig: () =>
-            labelOriginalRow !== undefined
-              ? { originalRowPosition: labelOriginalRow }
-              : {}
-        };
-
-        const regionContainer = {
-          getDomElement: jest.fn(() => ({ get: () => [element] })),
-          getComponents: jest.fn(() => [label]),
-        } as unknown as SubtitleRegionContainer;
-
-        subtitleOverlay.setFontSizeFactor(fontSizeFactor);
-        subtitleOverlay.updateRegionRowPosition(regionContainer);
-
-        const expectedClass = `subtitle-position-cea608-row-${expectedRow}`;
-        expect(element.classList.contains(expectedClass)).toBe(true);
-
-        // If the new class differs from the original, ensure the original is removed.
-        if (expectedClass !== initialClass) {
-          expect(element.classList.contains(initialClass)).toBe(false);
-        }
-      }
-    );
   });
 });

--- a/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
+++ b/src/scss/skin-modern/components/_subtitleoverlay-cea608.scss
@@ -30,7 +30,11 @@
       font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace;
       position: absolute;
       text-transform: uppercase;
-      vertical-align: bottom;
+      white-space: nowrap;
+
+      // center vertically
+      top: 50%;
+      transform: translateY(-50%);
 
       // sass-lint:disable force-pseudo-nesting nesting-depth
       &:nth-child(1n-1)::after {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -390,7 +390,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
           'font-size': `${fontSize}px`,
           'line-height': `${rowHeight - windowMargin}px`,
           'letter-spacing': `${fontLetterSpacing}px`,
-          // 'left': SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET, TODO: double check
         });
 
         label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -260,9 +260,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     let fontSize = 0;
     /**
      * The ratio of the font size of 100% to the row height.
-     * e.g. font size 100% fills up 65% of the available row height
+     * e.g. font size 100% fills up 75% of the available row height
      */
-    const fontSize100PercentRatio = 0.65;
+    const fontSize100PercentRatio = 0.75;
     /** The required letter spacing spread the text characters evenly across the grid */
     let fontLetterSpacing = 0;
     /** The ratio of the caption window/row height that is used as margin so that the window encloses the caption */

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -336,7 +336,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       } else {
         this.setFontSizeFactor(1);
       }
-      this.ensureCea608GridSizeUpdated();
+
+      if (this.cea608Enabled) {
+        this.ensureCea608GridSizeUpdated();
+      }
     });
 
     this.onShow?.subscribe(() => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -36,7 +36,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CLASS_CEA_608 = 'cea608';
   private static readonly CEA608_NUM_ROWS = 15;
   private static readonly CEA608_NUM_COLUMNS = 32;
-  private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;;
+  private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
   private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
   
   private cea608Enabled = false;
@@ -254,17 +254,24 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   configureCea608Captions(player: PlayerAPI, uimanager: UIInstanceManager): void {
-    // The calculated font size
-    let fontSize = 0;
+    /** The calculated row height in px */
     let rowHeight = 0;
-    // The required letter spacing spread the text characters evenly across the grid
+    /** The calculated font size in px */
+    let fontSize = 0;
+    /**
+     * The ratio of the font size of 100% to the row height.
+     * e.g. font size 100% fills up 65% of the available row height
+     */
+    const fontSize100PercentRatio = 0.65;
+    /** The required letter spacing spread the text characters evenly across the grid */
     let fontLetterSpacing = 0;
-    // The ratio of the caption window/row height that is used as margin so that the window encloses the caption
+    /** The ratio of the caption window/row height that is used as margin so that the window encloses the caption */
     const windowMarginRatio = 0.2;
+    /** The calculated window margin in px */
     let windowMargin: number;
-    // Flag telling if the CEA-608 mode is enabled
+    /** Flag telling if the CEA-608 rendering mode is currently enabled */
     this.cea608Enabled = false;
-    // Track last known dimensions to avoid unnecessary recalculations
+    /** Track last known grid params to avoid unnecessary recalculations */
     let lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
 
     const settingsManager = uimanager.getSubtitleSettingsManager();
@@ -354,7 +361,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         // When the available space is wider than the text grid, the font size is simply
         // determined by the height of the available space.
         rowHeight = subtitleOverlayHeight / SubtitleOverlay.CEA608_NUM_ROWS;
-        fontSize = rowHeight * (1 - windowMarginRatio) * this.cea608FontSizeFactor * (2/3); // TODO: extract to constant
+        const fontSize100Percent = rowHeight * (1 - windowMarginRatio) * fontSize100PercentRatio;
+        fontSize = fontSize100Percent * this.cea608FontSizeFactor;
         // Calculate the additional letter spacing required to evenly spread the text across the grid's width
         const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
         const fontCharWidth = fontSize * fontSizeRatio;
@@ -364,7 +372,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         // the height as a base for the font size, so we need to limit the height. We do that
         // by determining the font size by the width of the available space.
         rowHeight = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS / fontSizeRatio;
-        fontSize = rowHeight * (1 - windowMarginRatio) * this.cea608FontSizeFactor;
+        const fontSize100Percent = rowHeight * (1 - windowMarginRatio) * fontSize100PercentRatio;
+        fontSize = fontSize100Percent * this.cea608FontSizeFactor;
         fontLetterSpacing = 0;
       }
       

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -388,18 +388,17 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       const updateLabel = (label: SubtitleLabel) => {
         label.getDomElement().css({
           'font-size': `${fontSize}px`,
-          'line-height': `${fontSize}px`,
+          'line-height': `${rowHeight - windowMargin}px`,
           'letter-spacing': `${fontLetterSpacing}px`,
           // 'left': SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET, TODO: double check
         });
 
-        label.regionStyle = `line-height: ${fontSize}px; margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
+        label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
       }
 
       for (const childComponent of this.getComponents()) {
         if (childComponent instanceof SubtitleRegionContainer) {
           childComponent.getDomElement().css({
-            'line-height': `${fontSize}px`,
             margin: `${windowMargin / 2}px`,
             height: `${rowHeight}px`
           });
@@ -442,9 +441,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         'left': leftOffset,
         'font-size': `${fontSize}px`,
         'letter-spacing': `${fontLetterSpacing}px`,
+        'line-height': `${rowHeight - windowMargin}px`,
       });
 
-      label.regionStyle = `line-height: ${fontSize}px; margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
+      label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
     });
 
     const reset = () => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -34,25 +34,17 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   private static readonly CLASS_CONTROLBAR_VISIBLE = 'controlbar-visible';
   private static readonly CLASS_CEA_608 = 'cea608';
-  private static readonly DEFAULT_CEA608_NUM_ROWS = 15;
-  private static readonly DEFAULT_CEA608_NUM_COLUMNS = 32;
+  private static readonly CEA608_NUM_ROWS = 15;
+  private static readonly CEA608_NUM_COLUMNS = 32;
+  private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;;
   private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
-
-  private CEA608_FONT_SIZE_FACTOR = 1;
-  // The number of rows in a cea608 grid
-  private CEA608_NUM_ROWS = SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS;
-  // The number of columns in a cea608 grid
-  private CEA608_NUM_COLUMNS = SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS;
-  // The offset in percent for one column (which is also the width of a column)
-  private CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
-
+  
   private cea608Enabled = false;
+  private cea608FontSizeFactor = 1;
   private ensureCea608GridSizeUpdated: () => void;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
-
-    this.recalculateCEAGrid();
 
     this.previewSubtitleActive = false;
     this.previewSubtitle = new SubtitleLabel({ text: i18n.getLocalizer('subtitle.example') });
@@ -174,17 +166,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   setFontSizeFactor(factor: number): void {
     // We only allow range from 50% to 200% as suggested by spec
     // https://www.ecfr.gov/current/title-47/part-79/section-79.103#p-79.103(c)(4)
-    this.CEA608_FONT_SIZE_FACTOR = Math.max(0.5, Math.min(2.0, factor));
-
-    this.recalculateCEAGrid();
-  }
-
-  recalculateCEAGrid() {
-    // Needs to get recalculated in case the font size will change also we need to floor this
-    // to always align to the whole number represented in styles.
-    this.CEA608_NUM_ROWS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS / Math.max(this.CEA608_FONT_SIZE_FACTOR, 1));
-    this.CEA608_NUM_COLUMNS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS / this.CEA608_FONT_SIZE_FACTOR);
-    this.CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
+    this.cea608FontSizeFactor = Math.max(0.5, Math.min(2, factor));
   }
 
   detectCroppedSubtitleLabel(
@@ -230,17 +212,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     }
   }
 
-  resolveRowNumber(row: number): number {
-    // In case there is a font size factor and the row from event would overflow
-    // we need to apply an offset so it gets rendered to visible area.
-    if (this.CEA608_FONT_SIZE_FACTOR > 1 && row > this.CEA608_NUM_ROWS) {
-      const rowDelta = SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS - this.CEA608_NUM_ROWS;
-      return row - rowDelta;
-    }
-
-    return row;
-  }
-
   generateLabel(event: SubtitleCueEvent): SubtitleLabel {
     // Sanitize cue data (must be done before the cue ID is generated in subtitleManager.cueEnter / update)
     let region = event.region;
@@ -250,7 +221,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     const originalRowNumber = event.position?.row || 0;
 
     if (isCea608SubtitleCue(event)) {
-      event.position.row = this.resolveRowNumber(event.position.row) || 0;
+      event.position.row = event.position.row || 0;
       event.position.column = event.position.column || 0;
 
       region = region || `cea608-row-${event.position.row}`;
@@ -282,41 +253,15 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     return parseInt(value) / 100;
   }
 
-  updateRegionRowPosition(r: SubtitleRegionContainer): void {
-    const element = r.getDomElement().get()[0];
-    const label = r.getComponents()[0];
-
-    if (!element || !label) {
-      return;
-    }
-
-    const rowClassList = element.classList;
-    const originalRow = (label.getConfig() as SubtitleLabelConfig)?.originalRowPosition;
-    const rowClassRegex = /subtitle-position-cea608-row-(\d+)/;
-
-    const currentClass = Array.from(rowClassList).find(cls => rowClassRegex.test(cls));
-
-    if (!currentClass) {
-      return;
-    }
-
-    const match = rowClassRegex.exec(currentClass);
-    const rowNumber = match ? parseInt(match[1], 10) : null;
-    const newRowNum = this.resolveRowNumber(originalRow ?? rowNumber);
-    const newClass = currentClass.replace(rowClassRegex, `subtitle-position-cea608-row-${newRowNum}`);
-
-    rowClassList.replace(currentClass, newClass);
-  }
-
-
   configureCea608Captions(player: PlayerAPI, uimanager: UIInstanceManager): void {
     // The calculated font size
     let fontSize = 0;
+    let rowHeight = 0;
     // The required letter spacing spread the text characters evenly across the grid
     let fontLetterSpacing = 0;
-    // The ratio of the caption window/row height that is used as padding to make the window enclose the caption
-    const windowPaddingRatio = 0.2;
-    let windowPadding: number;
+    // The ratio of the caption window/row height that is used as margin so that the window encloses the caption
+    const windowMarginRatio = 0.2;
+    let windowMargin: number;
     // Flag telling if the CEA-608 mode is enabled
     this.cea608Enabled = false;
     // Track last known dimensions to avoid unnecessary recalculations
@@ -355,7 +300,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       const currentHeight = overlayElement.height();
       const hasOverlaySizeChanged = currentWidth !== lastCeaGridRecalculation.overlayWidth ||
         currentHeight !== lastCeaGridRecalculation.overlayHeight;
-      const hasFontSizeFactorChanged = this.FONT_SIZE_FACTOR !== lastCeaGridRecalculation.fontSizeFactor;
+      const hasFontSizeFactorChanged = this.cea608FontSizeFactor !== lastCeaGridRecalculation.fontSizeFactor;
 
       if (!hasOverlaySizeChanged && !hasFontSizeFactorChanged) {
         // none of the input variables changed, no need to recalculate
@@ -365,7 +310,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       lastCeaGridRecalculation = {
         overlayWidth: currentWidth,
         overlayHeight: currentHeight,
-        fontSizeFactor: this.FONT_SIZE_FACTOR,
+        fontSizeFactor: this.cea608FontSizeFactor,
       };
       
       const dummyLabel = new SubtitleLabel({ text: 'X' });
@@ -380,8 +325,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       this.updateComponents();
       this.show();
 
-      const dummyLabelCharWidth = dummyLabel.getDomElement().width() * this.CEA608_FONT_SIZE_FACTOR;
-      const dummyLabelCharHeight = dummyLabel.getDomElement().height() * this.CEA608_FONT_SIZE_FACTOR;
+      const dummyLabelCharWidth = dummyLabel.getDomElement().width();
+      const dummyLabelCharHeight = dummyLabel.getDomElement().height();
       const fontSizeRatio = (dummyLabelCharWidth / dummyLabelCharHeight);
 
       this.removeComponent(dummyLabel);
@@ -400,66 +345,54 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       const subtitleOverlayHeight = currentHeight;
 
       // The size ratio of the letter grid
-      const fontGridSizeRatio = (dummyLabelCharWidth * this.CEA608_NUM_COLUMNS) /
-        (dummyLabelCharHeight * this.CEA608_NUM_ROWS);
+      const fontGridSizeRatio = (dummyLabelCharWidth * SubtitleOverlay.CEA608_NUM_COLUMNS) /
+        (dummyLabelCharHeight * SubtitleOverlay.CEA608_NUM_ROWS);
       // The size ratio of the available space for the grid
       const subtitleOverlaySizeRatio = subtitleOverlayWidth / subtitleOverlayHeight;
-      let newRowHeight = 0;
 
       if (subtitleOverlaySizeRatio > fontGridSizeRatio) {
         // When the available space is wider than the text grid, the font size is simply
         // determined by the height of the available space.
-        newRowHeight = subtitleOverlayHeight / this.CEA608_NUM_ROWS;
-        fontSize = newRowHeight * (1 - windowPaddingRatio);
-        
+        rowHeight = subtitleOverlayHeight / SubtitleOverlay.CEA608_NUM_ROWS;
+        fontSize = rowHeight * (1 - windowMarginRatio) * this.cea608FontSizeFactor * (2/3); // TODO: extract to constant
         // Calculate the additional letter spacing required to evenly spread the text across the grid's width
-        const gridSlotWidth = subtitleOverlayWidth / this.CEA608_NUM_COLUMNS;
+        const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
         const fontCharWidth = fontSize * fontSizeRatio;
         fontLetterSpacing = Math.max(gridSlotWidth - fontCharWidth, 0);
       } else {
         // When the available space is not wide enough, texts would vertically overlap if we take
         // the height as a base for the font size, so we need to limit the height. We do that
         // by determining the font size by the width of the available space.
-        newRowHeight = subtitleOverlayWidth / this.CEA608_NUM_COLUMNS / fontSizeRatio;
-        fontSize = newRowHeight * (1 - windowPaddingRatio);
+        rowHeight = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS / fontSizeRatio;
+        fontSize = rowHeight * (1 - windowMarginRatio) * this.cea608FontSizeFactor;
         fontLetterSpacing = 0;
       }
       
-      windowPadding = newRowHeight * windowPaddingRatio;
-
-      // Update row position of regions
-      const regions = this.getComponents();
-      regions.forEach(r => {
-        if (r instanceof SubtitleRegionContainer) {
-          this.updateRegionRowPosition(r);
-        }
-      });
+      windowMargin = rowHeight * windowMarginRatio;
 
       // Update the CSS custom property on the overlay DOM element
       overlayElement.get().forEach((el) => {
-        el.style.setProperty("--cea608-row-height", `${newRowHeight}px`);
+        el.style.setProperty("--cea608-row-height", `${rowHeight}px`);
       });
 
       // Update font-size of all active subtitle labels
       const updateLabel = (label: SubtitleLabel) => {
-        const isLargerFontSize = this.CEA608_FONT_SIZE_FACTOR > 1
         label.getDomElement().css({
           'font-size': `${fontSize}px`,
           'line-height': `${fontSize}px`,
-          'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
-          'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
-          'left': isLargerFontSize && SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET,
+          'letter-spacing': `${fontLetterSpacing}px`,
+          // 'left': SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET, TODO: double check
         });
 
-        label.regionStyle = `line-height: ${fontSize}px; padding: ${windowPadding / 2}px; height: ${fontSize}px`;
+        label.regionStyle = `line-height: ${fontSize}px; margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
       }
 
       for (const childComponent of this.getComponents()) {
         if (childComponent instanceof SubtitleRegionContainer) {
           childComponent.getDomElement().css({
             'line-height': `${fontSize}px`,
-            padding: `${windowPadding / 2}px`,
-            height: `${fontSize}px`
+            margin: `${windowMargin / 2}px`,
+            height: `${rowHeight}px`
           });
 
           childComponent.getComponents().forEach((l: SubtitleLabel) => {
@@ -490,11 +423,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
       }
 
-      // We disable the grid and wrapping in case enlarged font size is used to prevent
-      // line and characters overflows
-      const isLargerFontSize = this.CEA608_FONT_SIZE_FACTOR > 1
-      let leftOffset = event.position.column * this.CEA608_COLUMN_OFFSET + '%';
-      if (leftOffset === '0%' || isLargerFontSize) {
+      let leftOffset = event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET + '%';
+      if (leftOffset === '0%') {
         // ensure that a little of the window still shows for better readability
         leftOffset = SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET;
       }
@@ -502,11 +432,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       label.getDomElement().css({
         'left': leftOffset,
         'font-size': `${fontSize}px`,
-        'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
-        'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
+        'letter-spacing': `${fontLetterSpacing}px`,
       });
 
-      label.regionStyle = `line-height: ${fontSize}px; padding: ${windowPadding / 2}px; height: ${fontSize}px`;
+      label.regionStyle = `line-height: ${fontSize}px; margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
     });
 
     const reset = () => {

--- a/src/ts/components/subtitleoverlay.ts
+++ b/src/ts/components/subtitleoverlay.ts
@@ -38,7 +38,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly DEFAULT_CEA608_NUM_COLUMNS = 32;
   private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
 
-  private FONT_SIZE_FACTOR: number = 1;
+  private CEA608_FONT_SIZE_FACTOR = 1;
   // The number of rows in a cea608 grid
   private CEA608_NUM_ROWS = SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS;
   // The number of columns in a cea608 grid
@@ -174,7 +174,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   setFontSizeFactor(factor: number): void {
     // We only allow range from 50% to 200% as suggested by spec
     // https://www.ecfr.gov/current/title-47/part-79/section-79.103#p-79.103(c)(4)
-    this.FONT_SIZE_FACTOR = Math.max(0.5, Math.min(2.0, factor));
+    this.CEA608_FONT_SIZE_FACTOR = Math.max(0.5, Math.min(2.0, factor));
 
     this.recalculateCEAGrid();
   }
@@ -182,8 +182,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   recalculateCEAGrid() {
     // Needs to get recalculated in case the font size will change also we need to floor this
     // to always align to the whole number represented in styles.
-    this.CEA608_NUM_ROWS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS / Math.max(this.FONT_SIZE_FACTOR, 1));
-    this.CEA608_NUM_COLUMNS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS / this.FONT_SIZE_FACTOR);
+    this.CEA608_NUM_ROWS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS / Math.max(this.CEA608_FONT_SIZE_FACTOR, 1));
+    this.CEA608_NUM_COLUMNS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS / this.CEA608_FONT_SIZE_FACTOR);
     this.CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
   }
 
@@ -233,7 +233,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   resolveRowNumber(row: number): number {
     // In case there is a font size factor and the row from event would overflow
     // we need to apply an offset so it gets rendered to visible area.
-    if (this.FONT_SIZE_FACTOR > 1 && row > this.CEA608_NUM_ROWS) {
+    if (this.CEA608_FONT_SIZE_FACTOR > 1 && row > this.CEA608_NUM_ROWS) {
       const rowDelta = SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS - this.CEA608_NUM_ROWS;
       return row - rowDelta;
     }
@@ -373,8 +373,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       this.updateComponents();
       this.show();
 
-      const dummyLabelCharWidth = dummyLabel.getDomElement().width() * this.FONT_SIZE_FACTOR;
-      const dummyLabelCharHeight = dummyLabel.getDomElement().height() * this.FONT_SIZE_FACTOR;
+      const dummyLabelCharWidth = dummyLabel.getDomElement().width() * this.CEA608_FONT_SIZE_FACTOR;
+      const dummyLabelCharHeight = dummyLabel.getDomElement().height() * this.CEA608_FONT_SIZE_FACTOR;
       const fontSizeRatio = (dummyLabelCharWidth / dummyLabelCharHeight);
 
       this.removeComponent(dummyLabel);
@@ -435,7 +435,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       // Update font-size of all active subtitle labels
       const updateLabel = (label: SubtitleLabel) => {
-        const isLargerFontSize = this.FONT_SIZE_FACTOR > 1
+        const isLargerFontSize = this.CEA608_FONT_SIZE_FACTOR > 1
         label.getDomElement().css({
           'font-size': `${fontSize}px`,
           'line-height': `${fontSize}px`,
@@ -485,7 +485,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       // We disable the grid and wrapping in case enlarged font size is used to prevent
       // line and characters overflows
-      const isLargerFontSize = this.FONT_SIZE_FACTOR > 1
+      const isLargerFontSize = this.CEA608_FONT_SIZE_FACTOR > 1
       let leftOffset = event.position.column * this.CEA608_COLUMN_OFFSET + '%';
       if (leftOffset === '0%' || isLargerFontSize) {
         // ensure that a little of the window still shows for better readability


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Fixing font size scaling for CEA captions and related issues.

### User facing fixes
- Long CEA captions are cut off when font size changed to greater than 100% via settings panel
- CEA caption font size is not changing when font size set to 75% via settings panel
- CEA caption positioning breaks when font size is changed via settings panel, e.g. when set to 50% captions move up into the middle and to the left

### Implementation changes
- The default size of 100% is now smaller, 75% of the max size. What was previously 75% is the new 100%. That gives us more room to scale up.
- Remove dynamic recalculation of row and column numbers for the CEA grid -- we are sticking to the 32x15 cell grid.
- Remove overflow/line wrap handling. We should rather prevent it from happening than try to handle it in an unreliable way.
- Remove handling font size >100% differently than <=100%.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
