### PR TITLE
Focus the first setting within a SettingsPanel

### DIFF
--- a/src/ts/components/settings/SettingsPanelPage.ts
+++ b/src/ts/components/settings/SettingsPanelPage.ts
@@ -90,7 +90,7 @@ export class SettingsPanelPage extends Container<SettingsPanelPageConfig> {
   }
 
   onActiveEvent() {
-    const activeItems = this.getItems().filter((item) => item.isActive());
+    const activeItems = this.getItems().filter((item) => item.isActive() && item.getConfig().isSetting);
 
     this.settingsPanelPageEvents.onActive.dispatch(this);
     // Disable focus for iOS and iPadOS 13. They open select boxes automatically on focus and we want to avoid that.

--- a/src/ts/components/settings/subtitlesettings/SubtitleSettingsPanelPage.ts
+++ b/src/ts/components/settings/subtitlesettings/SubtitleSettingsPanelPage.ts
@@ -132,6 +132,7 @@ export class SubtitleSettingsPanelPage extends SettingsPanelPage {
       }),
       settingComponent: new SubtitleSettingsResetButton({}),
       cssClasses: ['title-item'],
+      isSetting: false,
     });
 
     if (config.useDynamicSettingsPanelItem) {


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
When navigating the UI using the keyboard (or remote on TVs), the first element within a `SettingsPanlePage` will get focused. In v4, this will be the title element. To improve UX, we want to focus the first proper setting instead.

### Changes
- Change `isSetting` to false for title element in `SubtitleSettingsSettingsPanelPage`
- Use first element where isSetting is true when a `SettingsPanelPage` opens.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **Will be added at the end**
