### PR TITLE
Fix title bar orientation with additional buttons

### DIFF
--- a/src/scss/components/_title-bar.scss
+++ b/src/scss/components/_title-bar.scss
@@ -19,6 +19,13 @@
     row-gap: .5em;
   }
 
+  .#{$prefix}-titlebar-row {
+    > .#{$prefix}-container-wrapper {
+      display: flex;
+      flex-direction: row;
+    }
+  }
+
   > .#{$prefix}-container-wrapper {
     pointer-events: none;
 

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -356,7 +356,6 @@ function smallScreenUILayout() {
           new VolumeToggleButton(),
           new Spacer(),
           new SettingsToggleButton({ settingsPanel: settingsPanel }),
-          // new SubtitleToggleButton(subtitleSelectItem, subtitleSelectBox),
           new FullscreenToggleButton(),
         ],
         cssClasses: ['controlbar-bottom'],
@@ -374,10 +373,16 @@ function smallScreenUILayout() {
       controlBar,
       new TitleBar({
         components: [
-          new MetadataLabel({ content: MetadataLabelContent.Title }),
-          new CastToggleButton(),
-          new AirPlayToggleButton(),
-          new VRToggleButton(),
+          new Container({
+            components: [
+              new MetadataLabel({ content: MetadataLabelContent.Title }),
+              new Spacer(),
+              new CastToggleButton(),
+              new AirPlayToggleButton(),
+              new VRToggleButton(),
+            ],
+            cssClasses: ['titlebar-row'],
+          }),
         ],
       }),
       new DismissClickOverlay({ target: settingsPanel }),

--- a/src/ts/components/TitleBar.ts
+++ b/src/ts/components/TitleBar.ts
@@ -28,19 +28,24 @@ export class TitleBar extends Container<TitleBarConfig> {
   constructor(config: TitleBarConfig = {}) {
     super(config);
 
-    // Only use default MetadataLabels if no custom components are provided.
-    const hasCustomComponents = Array.isArray(config.components) && config.components.length > 0;
-
     this.config = this.mergeConfig(config, {
       cssClass: 'ui-titlebar',
       hidden: true,
       keepHiddenWithoutMetadata: false,
-      components: hasCustomComponents
-        ? config.components
-        : [
+      components: [
+        new Container({
+          components: [
             new MetadataLabel({ content: MetadataLabelContent.Title }),
+          ],
+          cssClasses: ['titlebar-row']
+        }),
+        new Container({
+          components: [
             new MetadataLabel({ content: MetadataLabelContent.Description }),
           ],
+          cssClasses: ['titlebar-row']
+        }),
+      ],
     }, <TitleBarConfig>this.config);
   }
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
The `TitleBar` doesn't support having buttons next to labels. However, in v4 we want to move some buttons up for the small screen UI.

## Changes
To support this we need to introduce `TitleBar` 'rows' to align elements horizontally. This PR introduces the css class `titlebar-row` to allow exactly that.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **Will be added at the end**
