### PR TITLE
Modern UI - Fix auto-hide timer not applied on Scrolling and when clicking buttons

### DIFF
--- a/src/ts/components/UIContainer.ts
+++ b/src/ts/components/UIContainer.ts
@@ -263,6 +263,14 @@ export class UIContainer extends Container<UIContainerConfig> {
           }
         }
       },
+    }, {
+      // When scrolling, we show the UI
+      name: 'wheel',
+      handler: (e) => {
+        if (checkActionAllowed(e)) {
+          this.showUi();
+        }
+      },
     }];
 
     this.userInteractionEvents.forEach((event) => this.userInteractionEventSource.on(event.name, event.handler));

--- a/src/ts/components/UIContainer.ts
+++ b/src/ts/components/UIContainer.ts
@@ -275,6 +275,13 @@ export class UIContainer extends Container<UIContainerConfig> {
 
     this.userInteractionEvents.forEach((event) => this.userInteractionEventSource.on(event.name, event.handler));
 
+    // Add click listener running on capture phase to intercept clicks before stopPropagation() in buttons
+    this.userInteractionEventSource.on('click', (e) => {
+      if (checkActionAllowed(e)) {
+        this.showUi();
+      }
+    }, { capture: true });
+
     uimanager.onSeek.subscribe(() => {
       this.uiHideTimeout.clear(); // Don't hide UI while a seek is in progress
       isSeeking = true;


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Auto-hide timer should be applied on user interactions, but right now it is not during:
- button clicking (e.g. volume toggle button)
- scrolling (e.g. continuous scrolling in the renditions menu)

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry - `I'd not include since this is a fix to an unreleased version`
