### PR TITLE
Use 'latest' NPM tag to gather current version instead of pre-released versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
           git config --global user.name 'Automated Release'
           git config --global user.email 'release-automation@bitmovin.com'
           git add package.json CHANGELOG.md
-          git commit -m "Bump version to ${{ steps.version_number.outputs.version_number }}"
+          git commit -m "[skip ci] Bump version to ${{ steps.version_number.outputs.version_number }}"
           git tag "${{ steps.version_number.outputs.tag_name }}"
           git push origin ${{ inputs.branch_name || github.ref_name }}
           git push origin "${{ steps.version_number.outputs.tag_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    name: Test, Build and Lint
+    uses: ./.github/workflows/ci.yml
+
   version_bump:
+    needs: test
     name: Version Bump
     runs-on: ubuntu-latest
     outputs:
@@ -143,11 +148,6 @@ jobs:
           git tag "${{ steps.version_number.outputs.tag_name }}"
           git push origin ${{ inputs.branch_name || github.ref_name }}
           git push origin "${{ steps.version_number.outputs.tag_name }}"
-
-  test:
-    needs: version_bump
-    name: Test, Build and Lint
-    uses: ./.github/workflows/ci.yml
 
   release:
     name: Publish Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "4.0.0-beta.4",
+  "version": "4.0.0-beta.5",
   "description": "Bitmovin Player UI Framework",
   "main": "./dist/js/framework/main.js",
   "types": "./dist/js/framework/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "4.0.0-beta.5",
+  "version": "4.0.0-alpha.1",
   "description": "Bitmovin Player UI Framework",
   "main": "./dist/js/framework/main.js",
   "types": "./dist/js/framework/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "Bitmovin Player UI Framework",
   "main": "./dist/js/framework/main.js",
   "types": "./dist/js/framework/main.d.ts",

--- a/publish.sh
+++ b/publish.sh
@@ -130,7 +130,7 @@ fi
 echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
 chmod 0600 ~/.npmrc
 
-NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".${NPM_TAG}")
+NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".latest")
 echo "INFO latest npm version is $NPM_LATEST"
 
 # We always publish the package with the channel/latest tag because there is no way to publish a package without

--- a/publish.sh
+++ b/publish.sh
@@ -130,14 +130,19 @@ fi
 echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
 chmod 0600 ~/.npmrc
 
-NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".latest")
+NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".${NPM_TAG}")
 echo "INFO latest npm version is $NPM_LATEST"
 
 # We always publish the package with the channel/latest tag because there is no way to publish a package without
 # a tag (the default tag is always "latest"). If the published version is older that the currently tagged version,
 # we have to revert the tag afterwards to avoid version regressions.
-echo "INFO publishing ${VERSION_NUMBER} to npm with tag '${NPM_TAG}' (current tagged version is ${NPM_LATEST})"
+echo "INFO publishing ${VERSION_NUMBER} to npm with tag '${NPM_TAG}' (current tagged version is ${NPM_LATEST:-"none"})"
 npm publish --tag ${NPM_TAG} ${NPM_DRY_RUN_CMD}
+
+# If there is no previously tagged version (e.g. for alpha/beta/rc releases) we don't need to do anything
+if [[ "$NPM_LATEST" == "null" ]]; then
+  exit 0
+fi
 
 # Checks if one version is greater than the other
 # https://stackoverflow.com/a/24067243/370252

--- a/publish.sh
+++ b/publish.sh
@@ -130,7 +130,7 @@ fi
 echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
 chmod 0600 ~/.npmrc
 
-NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".${NPM_TAG}")
+NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".${NPM_TAG} // empty")
 echo "INFO latest npm version is $NPM_LATEST"
 
 # We always publish the package with the channel/latest tag because there is no way to publish a package without
@@ -140,7 +140,7 @@ echo "INFO publishing ${VERSION_NUMBER} to npm with tag '${NPM_TAG}' (current ta
 npm publish --tag ${NPM_TAG} ${NPM_DRY_RUN_CMD}
 
 # If there is no previously tagged version (e.g. for alpha/beta/rc releases) we don't need to do anything
-if [[ "$NPM_LATEST" == "null" ]]; then
+if [[ -z "$NPM_LATEST" ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
The [first beta release](https://github.com/bitmovin/bitmovin-player-ui/actions/runs/17830558389) workflow failed as the latest version is fetched with the release type. There was no beta version first to the command returned `null` which caused a failure further down the line. 

Using `latest` will ensure that the latest stable version is used for the comparison. This will be needed for v3 back-port releases going forward.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **Not needed for an ad-hoc workflow fix**
