### PR TITLE
Backport release workflow fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.event_name == 'workflow_call' && format('release-ci-{0}', github.run_id) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ on:
       SLACK_WEBHOOK_URL:
         description: 'Slack webhook URL for notifications'
         required: true
+      RELEASE_DEPLOY_KEY:
+        description: 'SSH deploy key with write access to the repository'
+        required: true
 
 concurrency:
   group: release-${{ inputs.version_number }}-${{ inputs.release_type }}
@@ -68,6 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           ref: ${{ inputs.branch_name || github.ref }}
           # Fetch existing tags because we need to create a new one
           # fetch-tags: true # do not use, currently broken: https://github.com/actions/checkout/issues/1781

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "3.102.0",
+  "version": "3.102.1-beta.1",
   "description": "Bitmovin Player UI Framework",
   "main": "./dist/js/framework/main.js",
   "types": "./dist/js/framework/main.d.ts",

--- a/publish.sh
+++ b/publish.sh
@@ -130,7 +130,7 @@ fi
 echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
 chmod 0600 ~/.npmrc
 
-NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".${NPM_TAG}")
+NPM_LATEST=$(npm view --json ${PACKAGE_NAME} dist-tags | jq -r ".latest")
 echo "INFO latest npm version is $NPM_LATEST"
 
 # We always publish the package with the channel/latest tag because there is no way to publish a package without


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
There were some issues discovered after trying the first release after the updated release process from the `develop` branch. (#747)

The issues where:
- Branch protection
- In-progress release runs were canceled based due to the version bump
- NPM publish failed due to incorrect latest version fetching

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **Not needed for ad-hoc release workflow changes**
