### PR TITLE
Reuse menu background color for recommendation items

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -153,7 +153,7 @@
             },
             {
               title: 'Recommendation 2: The second best video',
-              resource: { url: 'http://bitmovin.com', thumbnail: 'https://placehold.co/300x300/222/222' },
+              resource: { url: 'http://bitmovin.com', thumbnail: 'https://placehold.co/300x300/2e2e2e/2e2e2e' },
               duration: 64,
             },
             {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -43,7 +43,7 @@ $color-focus: transparentize($color-highlight, 0.8) !default;
  */
 $color-background-menu-title-overlay: rgba(0, 0, 0, 0.25) !default;
 /**
- * Background color for Settings Panel
+ * Background color for menu elements
  */
 $color-background-menu: #2e2e2e !default;
 /**

--- a/src/scss/components/overlays/_recommendation-overlay.scss
+++ b/src/scss/components/overlays/_recommendation-overlay.scss
@@ -50,7 +50,7 @@
       $padding: 0.5em;
       cursor: pointer;
       color: $color-primary;
-      background-color: $color-background-recommendation-item;
+      background-color: $color-background-menu;
       background-position: center;
       background-size: cover;
       border: solid $color-primary 2px;


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
The current `develop` branch has build issues due to a wrongly resolved merge conflict after #769 and #767.

### Changes
Reusing the menu background variable for recommendation item backgrounds.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **Not needed as this was never released**
