### PR TITLE
Add subtitle-only UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Subtitle only UI, without visible UI elements
+
 ### Fixed
 
 - Missing exports in `main.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Subtitle only UI, without visible UI elements
+- `UIFactory.buildSubtitleUI` to create a subtitle-only UI, without visible UI elements
 
 ### Fixed
 

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -202,6 +202,41 @@ export namespace UIFactory {
       config,
     );
   }
+
+  /**
+   * Builds a simple UI which only contains the subtitle overlay, and elements required to support programmatic
+   * subtitle styling (e.g. using `uiManager.getSubtitleSettingsManager().fontSize.value = '150'`).
+   *
+   * This UI has no visible UI elements and only serves the purpose of displaying subtitles. Subtitles need to be
+   * enabled programmatically via the Player API.
+   *
+   * @param player The player instance used to build the UI
+   * @param config The UIConfig object
+   */
+  export function buildSubtitleUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
+    return new UIManager(player, subtitleUi(), config);
+  }
+}
+
+function subtitleUi(): UIContainer {
+  const subtitleOverlay = new SubtitleOverlay();
+
+  // Subtitle styling only works if a `SubtitleSettingsPanelPage` (with the corresponding Subtitle Settings elements)
+  // are in the UI tree.
+  const settingsPanel = new SettingsPanel({
+    components: [],
+    hidden: true,
+  });
+  const subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({
+    settingsPanel: settingsPanel,
+    overlay: subtitleOverlay,
+  });
+  settingsPanel.addComponent(subtitleSettingsPanelPage);
+
+  // Create a custom UI structure with only the SubtitleOverlay (and the hidden SettingsPanel to enable UI customizations)
+  return new UIContainer({
+    components: [subtitleOverlay, settingsPanel],
+  });
 }
 
 function uiLayout(config: UIConfig) {


### PR DESCRIPTION
## Description
Adds a new method to the `UIFactory`, `UIFactory.buildSubtitleUI`, that only contains the `SubtitleOverlay` to render subtitles (and what's needed to be able to customize them). This should make it easier for customers to get subtitle cues being displayed with custom (non-Bitmovin) UIs.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
