### PR TITLE
Remove deleted script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf dist; rm -rf docs",
     "lint-ts": "npx eslint 'src/ts/**/*.ts'",
     "lint-sass": "npx sass-lint",
-    "prepublishOnly": "npm run build:prod && npm run copy-json",
+    "prepublishOnly": "npm run build:prod",
     "prepare": "husky"
   },
   "repository": {


### PR DESCRIPTION
## Description
The `prepublishOnly` npm script still referenced the `npm run copy-json`, which was deleted as it's not needed anymore. This usage was removed now.

No Changelog entry as this issue was never released.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
