### PR TITLE
Fix webpack-dev-server / `npm start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `npm start` not working anymore
+
 ## [4.1.0] - 2025-10-06
 
 ### Added

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,9 +117,16 @@ module.exports = (env, { mode }) => {
       }),
       {
         apply: compiler => {
-          compiler.hooks.done.tapAsync('CreateUiFrameworkFilesPlugin', async compilation => {
-            await createJavascriptUiFrameworkFilesWithReplacedPrefix();
-          });
+          const isDevServer = process.env.WEBPACK_SERVE;
+
+          if (!isDevServer) {
+            // Doing this with the webpack-dev-server leads to an endless loop, so this is only done for normal builds
+            compiler.hooks.done.tapAsync('CreateUiFrameworkFilesPlugin', async compilation => {
+              await createJavascriptUiFrameworkFilesWithReplacedPrefix();
+            });
+          } else {
+            console.warn('Skipping creation of individual UI Framework JS files when using Webpack-Dev-Server');
+          }
         },
       },
     ],


### PR DESCRIPTION
## Description
https://github.com/bitmovin/bitmovin-player-ui/pull/776 broke `npm start` / the webpack-dev-server as the compilation step never completed, thus nothing ever gets served. This is likely due to the `tsc` command in the compiler hook generates files that trigger the dev server to register changes. The compiler hook to generate the individual JS files is now never executed in the webpack-dev-server.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
