### PR TITLE
Fix changelog and revert accedentially `3.103.0` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - `ui-skin-cast-receiver` -> `ui-cast-receiver`
     - `ui-skin-tv` -> `ui-tv`
 
-## [4.0.0] - 2025-09-26
+## [3.103.1] - 2025-10-07
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.103.0] - 2025-10-07
+## [Unreleased]
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "3.103.0",
+  "version": "4.1.0",
   "description": "Bitmovin Player UI Framework",
   "main": "./dist/js/framework/main.js",
   "types": "./dist/js/framework/main.d.ts",


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
`3.103.0` was accidentally released from `develop` instead of `support/v3.x` which lead to a version bump in the Changelog file. We have already released `3.103.1` to fix this on npmjs. This PR reverts the version bump and fixes the duplicated v4 changelog entry.