### PR TITLE
Fix UI v4 causing JS exception on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `npm start` not working anymore
+- Crash when using the Player Android SDK where `player.ads.isLinearAdActive` was invoked despite not being available on that platform
 
 ## [4.1.0] - 2025-10-06
 

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -129,9 +129,6 @@ export class SeekBar extends Component<SeekBarConfig> {
   private player: PlayerAPI;
   private uiManager: UIInstanceManager;
 
-  // We need to track the current ad state manually since our mobile SDKs don't expose an API to check if an ad is active.
-  private isAdPlaying: boolean = false;
-
   protected seekBarType: SeekBarType;
 
   protected isUiShown: boolean;
@@ -147,6 +144,8 @@ export class SeekBar extends Component<SeekBarConfig> {
   private pausedTimeshiftUpdater: Timeout;
 
   private isUserSeeking = false;
+  // We need to track the current ad state manually since our mobile SDKs don't expose an API to check if an ad is active.
+  private isAdPlaying: boolean = false;
 
   private seekBarEvents = {
     /**

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -129,7 +129,7 @@ export class SeekBar extends Component<SeekBarConfig> {
   private player: PlayerAPI;
   private uiManager: UIInstanceManager;
 
-  // Necessary since player.ads?.isLinearAdActive?.() does not exist on mobile SDKs
+  // We need to track the current ad state manually since our mobile SDKs don't expose an API to check if an ad is active.
   private isAdPlaying: boolean = false;
 
   protected seekBarType: SeekBarType;

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -288,7 +288,7 @@ export class SeekBar extends Component<SeekBarConfig> {
 
     uimanager.onControlsHide.subscribe(() => {
       // Keep seekbar always active during the playback of a linear ad
-      const isAdPlaying = player.ads?.isLinearAdActive() ?? false;
+      const isAdPlaying = player.ads?.isLinearAdActive?.() ?? false;
       if (isAdPlaying) {
         return;
       }

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -129,6 +129,9 @@ export class SeekBar extends Component<SeekBarConfig> {
   private player: PlayerAPI;
   private uiManager: UIInstanceManager;
 
+  // Necessary since player.ads?.isLinearAdActive?.() does not exist on mobile SDKs
+  private isAdPlaying: boolean = false;
+
   protected seekBarType: SeekBarType;
 
   protected isUiShown: boolean;
@@ -282,14 +285,22 @@ export class SeekBar extends Component<SeekBarConfig> {
       }
     };
 
-    player.on(player.exports.PlayerEvent.AdStarted, resumeSeekBarUpdates);
+    player.on(player.exports.PlayerEvent.AdStarted, () => {
+      this.isAdPlaying = true;
+      resumeSeekBarUpdates();
+    });
+    player.on(player.exports.PlayerEvent.AdBreakFinished, () => {
+      this.isAdPlaying = false;
+    });
+    player.on(player.exports.PlayerEvent.SourceUnloaded, () => {
+      this.isAdPlaying = false;
+    });
 
     uimanager.onControlsShow.subscribe(resumeSeekBarUpdates);
 
     uimanager.onControlsHide.subscribe(() => {
       // Keep seekbar always active during the playback of a linear ad
-      const isAdPlaying = player.ads?.isLinearAdActive?.() ?? false;
-      if (isAdPlaying) {
+      if (this.isAdPlaying) {
         return;
       }
 

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -126,7 +126,7 @@ export namespace StringUtils {
         time = 0;
 
         // compute list of ads and calculate duration of remaining ads based on index of active ad
-        if (player.ads.isLinearAdActive()) {
+        if (player.ads?.isLinearAdActive?.()) {
           const isActiveAd = (ad: Ad) => player.ads.getActiveAd().id === ad.id;
           const indexOfActiveAd = player.ads.getActiveAdBreak().ads.findIndex(isActiveAd);
           const duration = player.ads


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

UI v4 causes a crash on Android: 

```log
Uncaught TypeError: e.isLinearAdActive is not a function
```

This is due to player interface API differences between the platforms: `isLinearAdActive` does not exist for Android.

### Changes

- Fix the crash in `Seekbar.ts` by adding a safeguard for the method existance
- Add a safeguard on the other usage of `isLinearAdActive` as well

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
