### PR TITLE
Fix AdMessageLabel not respecting `config.text`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `SettingsPanel` now temporarily preserves and restores its navigation state and scroll position when it's hidden and shown again without an explicit reset
   - When reopened within the configured `stateResetDelay`, it automatically restores the last active page, navigation stack, and scroll position
-	- The internal state is cleared only after the `stateResetDelay` period has elapsed or when `hideAndReset()` is called
+  - The internal state is cleared only after the `stateResetDelay` period has elapsed or when `hideAndReset()` is called
 - Increased the default auto-hide delay for `SettingsPanel` to provide a smoother experience while adjusting settings
 
 ### Fixed
 
 - `SettingsPanel` automatically hiding in `modernSmallScreenUI`
+- `AdMessageLabel` didn't show anything if a `LabelConfig.text` was configured
 
 ## [4.2.0] - 2025-10-15
 

--- a/spec/components/ads/AdMessageLabel.spec.ts
+++ b/spec/components/ads/AdMessageLabel.spec.ts
@@ -1,0 +1,42 @@
+import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
+import { UIInstanceManager } from '../../../src/ts/UIManager';
+import { AdMessageLabel } from '../../../src/ts/components/ads/AdMessageLabel';
+
+let playerMock: TestingPlayerAPI;
+let uiInstanceManagerMock: UIInstanceManager;
+let adMessageLabel: AdMessageLabel;
+
+describe('AdMessageLabel', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+  });
+
+  describe('message text precedence', () => {
+    const configText = 'Config message';
+
+    beforeEach(() => {
+      adMessageLabel = new AdMessageLabel({ text: configText });
+
+      adMessageLabel.configure(playerMock, uiInstanceManagerMock);
+    });
+
+    it('uses text from LinearAd uiConfig.message over config.text', () => {
+      const adUiConfigMessage = 'Ad-specific message';
+
+      playerMock.eventEmitter.fireAdStartedEvent({
+        uiConfig: {
+          message: adUiConfigMessage,
+        },
+      });
+
+      expect(adMessageLabel.getText()).toEqual(adUiConfigMessage);
+    });
+
+    it('falls back to config.text when LinearAd has no uiConfig.message', () => {
+      playerMock.eventEmitter.fireAdStartedEvent({});
+
+      expect(adMessageLabel.getText()).toEqual(configText);
+    });
+  });
+});

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -44,15 +44,15 @@ export class AdMessageLabel extends Label<LabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
+    const config = this.getConfig();
     let text = config.text;
 
-    let updateMessageHandler = () => {
+    const updateMessageHandler = () => {
       this.setText(StringUtils.replaceAdMessagePlaceholders(i18n.performLocalization(text), null, player));
     };
 
-    let adStartHandler = (event: AdEvent) => {
-      let uiConfig = (event.ad as LinearAd).uiConfig;
+    const adStartHandler = (event: AdEvent) => {
+      const uiConfig = (event.ad as LinearAd).uiConfig;
       text = uiConfig?.message || config.text;
 
       updateMessageHandler();
@@ -60,7 +60,7 @@ export class AdMessageLabel extends Label<LabelConfig> {
       player.on(player.exports.PlayerEvent.TimeChanged, updateMessageHandler);
     };
 
-    let adEndHandler = () => {
+    const adEndHandler = () => {
       player.off(player.exports.PlayerEvent.TimeChanged, updateMessageHandler);
     };
 

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -53,7 +53,7 @@ export class AdMessageLabel extends Label<LabelConfig> {
 
     let adStartHandler = (event: AdEvent) => {
       let uiConfig = (event.ad as LinearAd).uiConfig;
-      text = (uiConfig && uiConfig.message) || config.text;
+      text = uiConfig?.message || config.text;
 
       updateMessageHandler();
 

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -7,6 +7,25 @@ import { StringUtils } from '../../utils/StringUtils';
 /**
  * A label that displays a message about a running ad, optionally with a countdown.
  *
+ * The message text supports placeholders that are dynamically replaced with ad timing information:
+ * - `{remainingTime[formatString]}` - Remaining time until the ad ends
+ * - `{playedTime[formatString]}` - Current playback time of the ad
+ * - `{adDuration[formatString]}` - Total duration of the current ad
+ * - `{adBreakRemainingTime[formatString]}` - Remaining time for the entire ad break (including all remaining ads)
+ *
+ * Format string options (optional):
+ * - `%d` - Integer (e.g., `{remainingTime%d}` → `100`)
+ * - `%0Nd` - Integer with N leading zeros (e.g., `{remainingTime%03d}` → `100`)
+ * - `%f` - Float (e.g., `{remainingTime%f}` → `100.0`)
+ * - `%0Nf` - Float with leading zeros (e.g., `{remainingTime%05f}` → `100.0`)
+ * - `%.Mf` - Float with M decimal places (e.g., `{remainingTime%.2f}` → `100.00`)
+ * - `%hh:mm:ss` - Time format with hours (e.g., `{remainingTime%hh:mm:ss}` → `00:01:40`)
+ * - `%mm:ss` - Time format without hours (e.g., `{remainingTime%mm:ss}` → `01:40`)
+ *
+ * Example: `{ text: 'Ad: {remainingTime%mm:ss}' }` displays "Ad: 01:40" for 100 seconds remaining.
+ *
+ * Note: If a LinearAd has a `uiConfig.message` property, it takes precedence over the configured `text`.
+ *
  * @category Labels
  */
 export class AdMessageLabel extends Label<LabelConfig> {

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -68,5 +68,6 @@ export class AdMessageLabel extends Label<LabelConfig> {
     player.on(player.exports.PlayerEvent.AdSkipped, adEndHandler);
     player.on(player.exports.PlayerEvent.AdError, adEndHandler);
     player.on(player.exports.PlayerEvent.AdFinished, adEndHandler);
+    player.on(player.exports.PlayerEvent.SourceUnloaded, adEndHandler);
   }
 }

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -1,9 +1,11 @@
-import { UIInstanceManager } from '../../UIManager';
-import { AdEvent, LinearAd, PlayerAPI } from 'bitmovin-player';
 import { Label, LabelConfig } from '../labels/Label';
+import { i18n } from '../../localization/i18n';
+import { AdEvent, LinearAd, PlayerAPI } from 'bitmovin-player';
+import { UIInstanceManager } from '../../UIManager';
+import { StringUtils } from '../../utils/StringUtils';
 
 /**
- * A label that displays a message regarding the ad that's currently being played.
+ * A label that displays a message about a running ad, optionally with a countdown.
  *
  * @category Labels
  */
@@ -23,24 +25,29 @@ export class AdMessageLabel extends Label<LabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    const clearText = () => {
-      this.setText('');
+    let config = this.getConfig();
+    let text = config.text;
+
+    let updateMessageHandler = () => {
+      this.setText(StringUtils.replaceAdMessagePlaceholders(i18n.performLocalization(text), null, player));
     };
 
-    clearText();
+    let adStartHandler = (event: AdEvent) => {
+      let uiConfig = (event.ad as LinearAd).uiConfig;
+      text = (uiConfig && uiConfig.message) || config.text;
 
-    player.on(player.exports.PlayerEvent.SourceUnloaded, clearText);
-    player.on(player.exports.PlayerEvent.AdError, clearText);
-    player.on(player.exports.PlayerEvent.AdSkipped, clearText);
-    player.on(player.exports.PlayerEvent.AdFinished, clearText);
-    player.on(player.exports.PlayerEvent.AdStarted, event => {
-      const ad = (event as AdEvent).ad;
-      if (!ad.isLinear) {
-        return;
-      }
+      updateMessageHandler();
 
-      const linearAd = ad as LinearAd;
-      this.setText(linearAd.uiConfig?.message ?? '');
-    });
+      player.on(player.exports.PlayerEvent.TimeChanged, updateMessageHandler);
+    };
+
+    let adEndHandler = () => {
+      player.off(player.exports.PlayerEvent.TimeChanged, updateMessageHandler);
+    };
+
+    player.on(player.exports.PlayerEvent.AdStarted, adStartHandler);
+    player.on(player.exports.PlayerEvent.AdSkipped, adEndHandler);
+    player.on(player.exports.PlayerEvent.AdError, adEndHandler);
+    player.on(player.exports.PlayerEvent.AdFinished, adEndHandler);
   }
 }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
In v4 The `AdMessageLabel` no longer respected a potentially configured `config.text` option and was always just respecting `LinearAdUiConfig.message` instead.

This PR fixes that by falling back to the `LabelConfig.text` in case no `LinearAdUiConfig.message` is set.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
