### PR TITLE
Enable prefer-const linter rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,7 +25,6 @@ export default tseslint.config({
   ],
   rules: {
     'no-prototype-builtins': 'off',
-    'prefer-const': 'off', // TODO: enable rule and run autofix
     'prefer-rest-params': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-explicit-any': 'off',

--- a/spec/UIManager.spec.ts
+++ b/spec/UIManager.spec.ts
@@ -177,7 +177,7 @@ describe('UIManager', () => {
       describe('and a PlaylistTransition event occurs', () => {
         it('dispatches onUpdated', () => {
           const uiManager = new UIManager(playerMock, MockHelper.generateDOMMock() as any);
-          let onUpdatedSpy = jest.fn();
+          const onUpdatedSpy = jest.fn();
           (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
 
           playerMock.eventEmitter.firePlaylistTransitionEvent();

--- a/spec/components/UIContainer.spec.ts
+++ b/spec/components/UIContainer.spec.ts
@@ -51,7 +51,7 @@ describe('UIContainer', () => {
         });
         uiContainer.configure(playerMock, uiInstanceManagerMock);
 
-        let uiHideTimeoutSpy: any = jest.spyOn((uiContainer as any).uiHideTimeout, 'start');
+        const uiHideTimeoutSpy: any = jest.spyOn((uiContainer as any).uiHideTimeout, 'start');
         playerMock.eventEmitter.fireSourceLoadedEvent();
 
         expect(uiHideTimeoutSpy).not.toHaveBeenCalled();

--- a/spec/components/labels/SeekbarLabel.spec.ts
+++ b/spec/components/labels/SeekbarLabel.spec.ts
@@ -36,7 +36,7 @@ describe('SeekBarLabel', () => {
         jest.spyOn(playerMock, 'getCurrentTime').mockReturnValue(100);
         jest.spyOn(playerMock, 'getTimeShift').mockReturnValue(0);
 
-        let args: SeekPreviewEventArgs = {
+        const args: SeekPreviewEventArgs = {
           scrubbing: false,
           position: 10,
         };
@@ -50,7 +50,7 @@ describe('SeekBarLabel', () => {
         jest.spyOn(playerMock, 'getCurrentTime').mockReturnValue(95);
         jest.spyOn(playerMock, 'getTimeShift').mockReturnValue(-5);
 
-        let args: SeekPreviewEventArgs = {
+        const args: SeekPreviewEventArgs = {
           scrubbing: false,
           position: 80,
         };
@@ -68,7 +68,7 @@ describe('SeekBarLabel', () => {
       });
 
       it('with correct seek target value', () => {
-        let args: SeekPreviewEventArgs = {
+        const args: SeekPreviewEventArgs = {
           scrubbing: false,
           position: 10,
         };
@@ -84,7 +84,7 @@ describe('SeekBarLabel', () => {
           end: 20,
         });
 
-        let args: SeekPreviewEventArgs = {
+        const args: SeekPreviewEventArgs = {
           scrubbing: false,
           position: 10,
         };

--- a/spec/utils/AudioUtils.spec.ts
+++ b/spec/utils/AudioUtils.spec.ts
@@ -3,11 +3,11 @@ import { ListSelector, ListSelectorConfig } from '../../src/ts/components/lists/
 import { AudioTrackSwitchHandler } from '../../src/ts/utils/AudioTrackUtils';
 import { AudioTrack } from 'bitmovin-player';
 
-let playerMock = MockHelper.getPlayerMock();
+const playerMock = MockHelper.getPlayerMock();
 let audioTrackSwitchHandler: AudioTrackSwitchHandler;
-let uiManagerMock = MockHelper.getUiInstanceManagerMock();
+const uiManagerMock = MockHelper.getUiInstanceManagerMock();
 
-let ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.fn().mockImplementation(() => ({
+const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.fn().mockImplementation(() => ({
   onItemSelected: MockHelper.getEventDispatcherMock(),
   hasItem: jest.fn(),
   addItem: jest.fn(),

--- a/spec/utils/SubtitleUtils.spec.ts
+++ b/spec/utils/SubtitleUtils.spec.ts
@@ -3,11 +3,11 @@ import { MockHelper } from '../helper/MockHelper';
 import { ListSelector, ListSelectorConfig } from '../../src/ts/components/lists/ListSelector';
 import { PlayerSubtitlesAPI } from 'bitmovin-player';
 
-let playerMock = MockHelper.getPlayerMock();
+const playerMock = MockHelper.getPlayerMock();
 let subtitleSwitchHandler: SubtitleSwitchHandler;
-let uiManagerMock = MockHelper.getUiInstanceManagerMock();
+const uiManagerMock = MockHelper.getUiInstanceManagerMock();
 
-let ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.fn().mockImplementation(() => ({
+const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.fn().mockImplementation(() => ({
   onItemSelected: MockHelper.getEventDispatcherMock(),
   hasItem: jest.fn(),
   addItem: jest.fn(),

--- a/src/ts/DOM.ts
+++ b/src/ts/DOM.ts
@@ -77,11 +77,11 @@ export class DOM {
 
     if (something instanceof Array) {
       if (something.length > 0 && something[0] instanceof HTMLElement) {
-        let elements = something as HTMLElementWithComponent[];
+        const elements = something as HTMLElementWithComponent[];
         this.elements = elements;
       }
     } else if (something instanceof HTMLElement) {
-      let element = something as HTMLElementWithComponent;
+      const element = something as HTMLElementWithComponent;
       this.elements = [element];
     } else if (something instanceof Document) {
       // When a document is passed in, we do not do anything with it, but by setting this.elements to null
@@ -89,11 +89,11 @@ export class DOM {
       // instead of elements.
       this.elements = null;
     } else if (attributes) {
-      let tagName = something;
-      let element = document.createElement(tagName) as HTMLElementWithComponent;
+      const tagName = something;
+      const element = document.createElement(tagName) as HTMLElementWithComponent;
 
-      for (let attributeName in attributes) {
-        let attributeValue = attributes[attributeName];
+      for (const attributeName in attributes) {
+        const attributeValue = attributes[attributeName];
         if (attributeValue != null) {
           element.setAttribute(attributeName, attributeValue);
         }
@@ -105,7 +105,7 @@ export class DOM {
 
       this.elements = [element];
     } else {
-      let selector = something;
+      const selector = something;
       this.elements = this.findChildElements(selector) as HTMLElementWithComponent[];
     }
   }
@@ -155,7 +155,7 @@ export class DOM {
   }
 
   private findChildElementsOfElement(element: HTMLElement | Document, selector: string): HTMLElement[] {
-    let childElements = element.querySelectorAll(selector);
+    const childElements = element.querySelectorAll(selector);
 
     // Convert NodeList to Array
     // https://toddmotto.com/a-comprehensive-dive-into-nodelists-arrays-converting-nodelists-and-understanding-the-dom/
@@ -182,7 +182,7 @@ export class DOM {
    * @returns {DOM} a new DOM instance representing all matched children
    */
   find(selector: string): DOM {
-    let allChildElements = this.findChildElements(selector) as HTMLElementWithComponent[];
+    const allChildElements = this.findChildElements(selector) as HTMLElementWithComponent[];
     return new DOM(allChildElements);
   }
 
@@ -257,7 +257,7 @@ export class DOM {
    * @returns {string} the value of a form element
    */
   val(): string {
-    let element = this.elements[0];
+    const element = this.elements[0];
 
     if (element instanceof HTMLSelectElement || element instanceof HTMLInputElement) {
       return element.value;
@@ -374,7 +374,7 @@ export class DOM {
    */
   remove(): void {
     this.forEach(element => {
-      let parent = element.parentNode;
+      const parent = element.parentNode;
       if (parent) {
         parent.removeChild(element);
       }
@@ -386,9 +386,9 @@ export class DOM {
    * @returns {Offset}
    */
   offset(): Offset {
-    let element = this.elements[0];
-    let elementRect = element.getBoundingClientRect();
-    let htmlRect = document.body.parentElement.getBoundingClientRect();
+    const element = this.elements[0];
+    const elementRect = element.getBoundingClientRect();
+    const htmlRect = document.body.parentElement.getBoundingClientRect();
 
     // Virtual viewport scroll handling (e.g. pinch zoomed viewports in mobile browsers or desktop Chrome/Edge)
     // 'normal' zooms and virtual viewport zooms (aka layout viewport) result in different
@@ -447,7 +447,7 @@ export class DOM {
     eventHandler: EventListenerOrEventListenerObject,
     options?: boolean | AddEventListenerOptions,
   ): DOM {
-    let events = eventName.split(' ');
+    const events = eventName.split(' ');
 
     events.forEach(event => {
       if (this.elements == null) {
@@ -474,7 +474,7 @@ export class DOM {
     eventHandler: EventListenerOrEventListenerObject,
     options?: boolean | AddEventListenerOptions,
   ): DOM {
-    let events = eventName.split(' ');
+    const events = eventName.split(' ');
 
     events.forEach(event => {
       if (this.elements == null) {
@@ -578,7 +578,7 @@ export class DOM {
   css(propertyValueCollection: CssProperties): DOM;
   css(propertyNameOrCollection: string | CssProperties, value?: string): string | null | DOM {
     if (typeof propertyNameOrCollection === 'string') {
-      let propertyName = propertyNameOrCollection;
+      const propertyName = propertyNameOrCollection;
 
       if (arguments.length === 2) {
         return this.setCss(propertyName, value);
@@ -586,7 +586,7 @@ export class DOM {
         return this.getCss(propertyName);
       }
     } else {
-      let propertyValueCollection = propertyNameOrCollection;
+      const propertyValueCollection = propertyNameOrCollection;
       return this.setCssCollection(propertyValueCollection);
     }
   }

--- a/src/ts/EventDispatcher.ts
+++ b/src/ts/EventDispatcher.ts
@@ -91,7 +91,7 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
     // Iterate through listeners, compare with parameter, and remove if found
     // NOTE: In case we ever remove all matching listeners instead of just the first, we need to reverse-iterate here
     for (let i = 0; i < this.listeners.length; i++) {
-      let subscribedListener = this.listeners[i];
+      const subscribedListener = this.listeners[i];
       if (subscribedListener.listener === listener) {
         subscribedListener.clear();
         ArrayUtils.remove(this.listeners, subscribedListener);
@@ -107,7 +107,7 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
    */
   unsubscribeAll(): void {
     // In case of RateLimitedEventListenerWrapper we need to make sure that the timeout callback won't be called
-    for (let listener of this.listeners) {
+    for (const listener of this.listeners) {
       listener.clear();
     }
 
@@ -120,7 +120,7 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
    * @param args the arguments for the event
    */
   dispatch(sender: Sender, args: Args = null) {
-    let listenersToRemove = [];
+    const listenersToRemove = [];
 
     // Call every listener
     // We iterate over a copy of the array of listeners to avoid the case where events are not fired on listeners when
@@ -130,7 +130,7 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
     // as listener y+1 will not be called when subscribed from within the handler of listener y.
     // Array.slice(0) is the fastest array copy method according to: https://stackoverflow.com/a/21514254/370252
     const listeners = this.listeners.slice(0);
-    for (let listener of listeners) {
+    for (const listener of listeners) {
       listener.fire(sender, args);
 
       if (listener.isOnce()) {
@@ -139,7 +139,7 @@ export class EventDispatcher<Sender, Args> implements Event<Sender, Args> {
     }
 
     // Remove one-time listener
-    for (let listenerToRemove of listenersToRemove) {
+    for (const listenerToRemove of listenersToRemove) {
       ArrayUtils.remove(this.listeners, listenerToRemove);
     }
   }

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -240,10 +240,10 @@ function subtitleUi(): UIContainer {
 }
 
 function uiLayout(config: UIConfig) {
-  let subtitleOverlay = new SubtitleOverlay();
+  const subtitleOverlay = new SubtitleOverlay();
 
   const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode != undefined);
-  let controlBar = new ControlBar({
+  const controlBar = new ControlBar({
     components: [
       new Container({
         components: [
@@ -302,7 +302,7 @@ function uiLayout(config: UIConfig) {
 }
 
 function adsUILayout() {
-  let controlBar = new AdControlBar({
+  const controlBar = new AdControlBar({
     components: [
       new Container({
         components: [
@@ -350,11 +350,11 @@ function adsUILayout() {
 }
 
 function smallScreenUILayout() {
-  let subtitleOverlay = new SubtitleOverlay();
+  const subtitleOverlay = new SubtitleOverlay();
 
   const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
 
-  let controlBar = new ControlBar({
+  const controlBar = new ControlBar({
     components: [
       new Container({
         components: [
@@ -422,7 +422,7 @@ function smallScreenUILayout() {
 }
 
 function smallScreenAdsUILayout() {
-  let controlBar = new AdControlBar({
+  const controlBar = new AdControlBar({
     components: [
       new Container({
         components: [
@@ -470,7 +470,7 @@ function smallScreenAdsUILayout() {
 }
 
 function castReceiverUILayout(config: UIConfig) {
-  let controlBar = new ControlBar({
+  const controlBar = new ControlBar({
     components: [
       new Container({
         components: [
@@ -685,7 +685,6 @@ function buildDefaultSettingsPanel(
   hideDelay: number | undefined = undefined,
   enableEcoMode: boolean = false,
 ): SettingsPanel<SettingsPanelConfig> {
-  let mainSettingsPanelPage: SettingsPanelPage;
   const settingsPanelConfig: SettingsPanelConfig = {
     components: [],
     hidden: true,
@@ -731,7 +730,7 @@ function buildDefaultSettingsPanel(
     components.unshift(ecoModeContainer);
   }
 
-  mainSettingsPanelPage = new SettingsPanelPage({
+  const mainSettingsPanelPage = new SettingsPanelPage({
     components,
   });
 

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -158,8 +158,8 @@ export class UIManager {
   constructor(player: PlayerAPI, playerUiOrUiVariants: UIContainer | UIVariant[], uiconfig: UIConfig = {}) {
     if (playerUiOrUiVariants instanceof UIContainer) {
       // Single-UI constructor has been called, transform arguments to UIVariant[] signature
-      let playerUi = <UIContainer>playerUiOrUiVariants;
-      let uiVariants = [];
+      const playerUi = <UIContainer>playerUiOrUiVariants;
+      const uiVariants = [];
 
       // Add the default player UI
       uiVariants.push({ ui: playerUi });
@@ -252,8 +252,8 @@ export class UIManager {
     // Create UI instance managers for the UI variants
     // The instance managers map to the corresponding UI variants by their array index
     this.uiInstanceManagers = [];
-    let uiVariantsWithoutCondition = [];
-    for (let uiVariant of this.uiVariants) {
+    const uiVariantsWithoutCondition = [];
+    for (const uiVariant of this.uiVariants) {
       if (uiVariant.condition == null) {
         // Collect variants without conditions for error checking
         uiVariantsWithoutCondition.push(uiVariant);
@@ -296,7 +296,7 @@ export class UIManager {
     });
 
     // Dynamically select a UI variant that matches the current UI condition.
-    let resolveUiVariant = (event: PlayerEventBase) => {
+    const resolveUiVariant = (event: PlayerEventBase) => {
       // Make sure that the AdStarted event data is persisted through ad playback in case other events happen
       // in the meantime, e.g. player resize. We need to store this data because there is no other way to find out
       // ad details while an ad is playing (in v8.0 at least; from v8.1 there will be ads.getActiveAd()).
@@ -338,13 +338,13 @@ export class UIManager {
       }
 
       // Detect if an ad has started
-      let isAd = adStartedEvent != null;
+      const isAd = adStartedEvent != null;
       let adRequiresUi = false;
       if (isAd) {
-        let ad = adStartedEvent.ad;
+        const ad = adStartedEvent.ad;
         // for now only linear ads can request a UI
         if (ad.isLinear) {
-          let linearAd = ad as LinearAd;
+          const linearAd = ad as LinearAd;
           adRequiresUi = (linearAd.uiConfig && linearAd.uiConfig.requestsUi) || false;
         }
       }
@@ -436,7 +436,7 @@ export class UIManager {
    * @param {() => void} onShow a callback that is executed just before the new UI variant is shown
    */
   switchToUiVariant(uiVariant: UIVariant, onShow?: () => void): void {
-    let uiVariantIndex = this.uiVariants.indexOf(uiVariant);
+    const uiVariantIndex = this.uiVariants.indexOf(uiVariant);
 
     const previousUi = this.currentUi;
     const nextUi: InternalUIInstanceManager = this.uiInstanceManagers[uiVariantIndex];
@@ -508,7 +508,7 @@ export class UIManager {
 
     // Select new UI variant
     // If no variant condition is fulfilled, we switch to *no* UI
-    for (let uiVariant of this.uiVariants) {
+    for (const uiVariant of this.uiVariants) {
       const matchesCondition = uiVariant.condition == null || uiVariant.condition(switchingContext) === true;
       if (nextUiVariant == null && matchesCondition) {
         nextUiVariant = uiVariant;
@@ -526,8 +526,8 @@ export class UIManager {
   }
 
   private addUi(ui: InternalUIInstanceManager): void {
-    let dom = ui.getUI().getDomElement();
-    let player = ui.getWrappedPlayer();
+    const dom = ui.getUI().getDomElement();
+    const player = ui.getWrappedPlayer();
 
     ui.configureControls();
     /* Append the UI DOM after configuration to avoid CSS transitions at initialization
@@ -567,7 +567,7 @@ export class UIManager {
   }
 
   release(): void {
-    for (let uiInstanceManager of this.uiInstanceManagers) {
+    for (const uiInstanceManager of this.uiInstanceManagers) {
       this.releaseUi(uiInstanceManager);
     }
     this.managerPlayerWrapper.clearEventHandlers();
@@ -799,9 +799,9 @@ export class UIInstanceManager {
   protected clearEventHandlers(): void {
     this.playerWrapper.clearEventHandlers();
 
-    let events = <any>this.events; // avoid TS7017
-    for (let event in events) {
-      let dispatcher = <EventDispatcher<Object, Object>>events[event];
+    const events = <any>this.events; // avoid TS7017
+    for (const event in events) {
+      const dispatcher = <EventDispatcher<Object, Object>>events[event];
       dispatcher.unsubscribeAll();
     }
   }
@@ -832,7 +832,7 @@ class InternalUIInstanceManager extends UIInstanceManager {
   }
 
   private configureControlsTree(component: Component<ComponentConfig>) {
-    let configuredComponents: Component<ComponentConfig>[] = [];
+    const configuredComponents: Component<ComponentConfig>[] = [];
 
     UIUtils.traverseTree(component, component => {
       // First, check if we have already configured a component, and throw an error if we did. Multiple configuration
@@ -840,7 +840,7 @@ class InternalUIInstanceManager extends UIInstanceManager {
       // times hints at a wrong UI structure.
       // We could just skip configuration in such a case and not throw an exception, but enforcing a clean UI tree
       // seems like the better choice.
-      for (let configuredComponent of configuredComponents) {
+      for (const configuredComponent of configuredComponents) {
         if (configuredComponent === component) {
           // Write the component to the console to simplify identification of the culprit
           // (e.g. by inspecting the config)
@@ -878,7 +878,7 @@ class InternalUIInstanceManager extends UIInstanceManager {
     component.release();
 
     if (component instanceof Container) {
-      for (let childComponent of component.getComponents()) {
+      for (const childComponent of component.getComponents()) {
         this.releaseControlsTree(childComponent);
       }
     }
@@ -921,10 +921,10 @@ export class PlayerWrapper {
     const namesToIgnore = ['constructor', ...objectProtoPropertyNames];
     const members = getAllPropertyNames(player).filter(name => namesToIgnore.indexOf(name) === -1);
     // Split the members into methods and properties
-    let methods = <any[]>[];
-    let properties = <any[]>[];
+    const methods = <any[]>[];
+    const properties = <any[]>[];
 
-    for (let member of members) {
+    for (const member of members) {
       if (typeof (<any>player)[member] === 'function') {
         methods.push(member);
       } else {
@@ -933,10 +933,10 @@ export class PlayerWrapper {
     }
 
     // Create wrapper object
-    let wrapper = <any>{};
+    const wrapper = <any>{};
 
     // Add function wrappers for all API methods that do nothing but calling the base method on the player
-    for (let method of methods) {
+    for (const method of methods) {
       wrapper[method] = function () {
         // console.log('called ' + member); // track method calls on the player
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -945,7 +945,7 @@ export class PlayerWrapper {
     }
 
     // Add all public properties of the player to the wrapper
-    for (let property of properties) {
+    for (const property of properties) {
       // Get an eventually existing property descriptor to differentiate between plain properties and properties with
       // getters/setters.
       const propertyDescriptor = ((target: PlayerAPI) => {
@@ -1000,7 +1000,7 @@ export class PlayerWrapper {
       if (this.eventHandlers[event]) {
         // check if there are handlers for this event registered
         // Extend the data object with default values to convert it to a {@link PlayerEventBase} object.
-        let playerEventData = <PlayerEventBase>Object.assign(
+        const playerEventData = <PlayerEventBase>Object.assign(
           {},
           {
             timestamp: Date.now(),
@@ -1012,7 +1012,7 @@ export class PlayerWrapper {
         );
 
         // Execute the registered callbacks
-        for (let callback of this.eventHandlers[event]) {
+        for (const callback of this.eventHandlers[event]) {
           callback(playerEventData);
         }
       }
@@ -1045,8 +1045,8 @@ export class PlayerWrapper {
       }
     }
 
-    for (let eventType in this.eventHandlers) {
-      for (let callback of this.eventHandlers[eventType]) {
+    for (const eventType in this.eventHandlers) {
+      for (const callback of this.eventHandlers[eventType]) {
         this.player.off(eventType as PlayerEvent, callback);
       }
     }

--- a/src/ts/components/CastUIContainer.ts
+++ b/src/ts/components/CastUIContainer.ts
@@ -19,7 +19,7 @@ export class CastUIContainer extends UIContainer {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
+    const config = this.getConfig();
 
     /*
      * Show UI on Cast devices at certain playback events
@@ -33,31 +33,31 @@ export class CastUIContainer extends UIContainer {
 
     let isUiShown = false;
 
-    let hideUi = () => {
+    const hideUi = () => {
       uimanager.onControlsHide.dispatch(this);
       isUiShown = false;
     };
 
     this.castUiHideTimeout = new Timeout(config.hideDelay, hideUi);
 
-    let showUi = () => {
+    const showUi = () => {
       if (!isUiShown) {
         uimanager.onControlsShow.dispatch(this);
         isUiShown = true;
       }
     };
 
-    let showUiPermanently = () => {
+    const showUiPermanently = () => {
       showUi();
       this.castUiHideTimeout.clear();
     };
 
-    let showUiWithTimeout = () => {
+    const showUiWithTimeout = () => {
       showUi();
       this.castUiHideTimeout.start();
     };
 
-    let showUiAfterSeek = () => {
+    const showUiAfterSeek = () => {
       if (player.isPlaying()) {
         showUiWithTimeout();
       } else {

--- a/src/ts/components/Component.ts
+++ b/src/ts/components/Component.ts
@@ -308,7 +308,7 @@ export class Component<Config extends ComponentConfig> {
    * Subclasses usually overwrite this method to extend or replace the DOM element with their own design.
    */
   protected toDomElement(): DOM {
-    let element = new DOM(
+    const element = new DOM(
       this.config.tag,
       {
         id: this.config.id,
@@ -365,7 +365,7 @@ export class Component<Config extends ComponentConfig> {
    */
   protected mergeConfig<Config>(config: Config, defaults: Partial<Config>, base: Config): Config {
     // Extend default config with supplied config
-    let merged = Object.assign({}, base, defaults, config);
+    const merged = Object.assign({}, base, defaults, config);
 
     // Return the extended config
     return merged;
@@ -384,7 +384,7 @@ export class Component<Config extends ComponentConfig> {
       return this.prefixCss(css);
     });
     // Join array values into a string
-    let flattenedString = flattenedArray.join(' ');
+    const flattenedString = flattenedArray.join(' ');
     // Return trimmed string to prevent whitespace at the end from the join operation
     return flattenedString.trim();
   }

--- a/src/ts/components/Container.ts
+++ b/src/ts/components/Container.ts
@@ -108,7 +108,7 @@ export class Container<Config extends ContainerConfig> extends Component<Config>
    * Removes all child components from the container.
    */
   removeComponents(): void {
-    for (let component of this.getComponents().slice()) {
+    for (const component of this.getComponents().slice()) {
       this.removeComponent(component);
     }
   }
@@ -144,7 +144,7 @@ export class Container<Config extends ContainerConfig> extends Component<Config>
 
   protected toDomElement(): DOM {
     // Create the container element (the outer <div>)
-    let containerElement = new DOM(
+    const containerElement = new DOM(
       this.config.tag,
       {
         id: this.config.id,
@@ -160,12 +160,12 @@ export class Container<Config extends ContainerConfig> extends Component<Config>
     }
 
     // Create the inner container element (the inner <div>) that will contain the components
-    let innerContainer = new DOM(this.config.tag, {
+    const innerContainer = new DOM(this.config.tag, {
       class: this.prefixCss('container-wrapper'),
     });
     this.innerContainerElement = innerContainer;
 
-    for (let initialComponent of this.config.components) {
+    for (const initialComponent of this.config.components) {
       this.componentsToAppend.push(initialComponent);
     }
     this.updateComponents();

--- a/src/ts/components/RecommendationItem.ts
+++ b/src/ts/components/RecommendationItem.ts
@@ -91,12 +91,12 @@ export class RecommendationItem extends Component<RecommendationItemConfig> {
       this,
     );
 
-    let innerTitleElement = new Label({ text: recommendationConfig.title, cssClass: 'title' });
+    const innerTitleElement = new Label({ text: recommendationConfig.title, cssClass: 'title' });
     titleElement.append(innerTitleElement.getDomElement());
     itemElement.append(titleElement);
 
     if (recommendationConfig.duration != null) {
-      let timeElement = new Label({
+      const timeElement = new Label({
         text: recommendationConfig.duration ? StringUtils.secondsToTime(recommendationConfig.duration) : '',
         cssClass: 'duration',
       });

--- a/src/ts/components/TvNoiseCanvas.ts
+++ b/src/ts/components/TvNoiseCanvas.ts
@@ -66,11 +66,11 @@ export class TvNoiseCanvas extends Component<ComponentConfig> {
     }
 
     let currentPixelOffset;
-    let canvasWidth = this.canvasWidth;
-    let canvasHeight = this.canvasHeight;
+    const canvasWidth = this.canvasWidth;
+    const canvasHeight = this.canvasHeight;
 
     // Create texture
-    let noiseImage = this.canvasContext.createImageData(canvasWidth, canvasHeight);
+    const noiseImage = this.canvasContext.createImageData(canvasWidth, canvasHeight);
 
     // Fill texture with noise
     for (let y = 0; y < canvasHeight; y++) {

--- a/src/ts/components/UIContainer.ts
+++ b/src/ts/components/UIContainer.ts
@@ -111,7 +111,7 @@ export class UIContainer extends Container<UIContainerConfig> {
   }
 
   private configureUIShowHide(player: PlayerAPI, uimanager: UIInstanceManager): void {
-    let config = this.getConfig();
+    const config = this.getConfig();
     let isUiShown = false;
     let isSettingsPanelShown = false;
     let isHideUiPending = false;
@@ -184,7 +184,7 @@ export class UIContainer extends Container<UIContainerConfig> {
         }
 
         // Issue a preview event to check if we are good to hide the controls
-        let previewHideEventArgs = <CancelEventArgs>{};
+        const previewHideEventArgs = <CancelEventArgs>{};
         uimanager.onPreviewControlsHide.dispatch(this, previewHideEventArgs);
 
         if (!previewHideEventArgs.cancel) {
@@ -373,20 +373,20 @@ export class UIContainer extends Container<UIContainerConfig> {
   }
 
   private configurePlayerStates(player: PlayerAPI, uimanager: UIInstanceManager): void {
-    let container = this.getDomElement();
+    const container = this.getDomElement();
 
     // Convert player states into CSS class names
-    let stateClassNames = <any>[];
-    for (let state in PlayerUtils.PlayerState) {
+    const stateClassNames = <any>[];
+    for (const state in PlayerUtils.PlayerState) {
       if (isNaN(Number(state))) {
-        let enumName = PlayerUtils.PlayerState[<any>PlayerUtils.PlayerState[state]];
+        const enumName = PlayerUtils.PlayerState[<any>PlayerUtils.PlayerState[state]];
         stateClassNames[PlayerUtils.PlayerState[state]] = this.prefixCss(
           UIContainer.STATE_PREFIX + enumName.toLowerCase(),
         );
       }
     }
 
-    let removeStates = () => {
+    const removeStates = () => {
       container.removeClass(stateClassNames[PlayerUtils.PlayerState.Idle]);
       container.removeClass(stateClassNames[PlayerUtils.PlayerState.Prepared]);
       container.removeClass(stateClassNames[PlayerUtils.PlayerState.Playing]);
@@ -470,7 +470,7 @@ export class UIContainer extends Container<UIContainerConfig> {
     });
 
     // Layout size classes
-    let updateLayoutSizeClasses = (width: number, height: number) => {
+    const updateLayoutSizeClasses = (width: number, height: number) => {
       container.removeClass(this.prefixCss('layout-max-width-400'));
       container.removeClass(this.prefixCss('layout-max-width-600'));
       container.removeClass(this.prefixCss('layout-max-width-800'));
@@ -488,8 +488,8 @@ export class UIContainer extends Container<UIContainerConfig> {
     };
     player.on(player.exports.PlayerEvent.PlayerResized, (e: PlayerResizedEvent) => {
       // Convert strings (with "px" suffix) to ints
-      let width = Math.round(Number(e.width.substring(0, e.width.length - 2)));
-      let height = Math.round(Number(e.height.substring(0, e.height.length - 2)));
+      const width = Math.round(Number(e.width.substring(0, e.width.length - 2)));
+      const height = Math.round(Number(e.height.substring(0, e.height.length - 2)));
 
       updateLayoutSizeClasses(width, height);
     });
@@ -524,7 +524,7 @@ export class UIContainer extends Container<UIContainerConfig> {
   }
 
   protected toDomElement(): DOM {
-    let container = super.toDomElement();
+    const container = super.toDomElement();
 
     // Detect flexbox support (not supported in IE9)
     if (document && typeof document.createElement('p').style.flex !== 'undefined') {

--- a/src/ts/components/ads/AdClickOverlay.ts
+++ b/src/ts/components/ads/AdClickOverlay.ts
@@ -26,13 +26,13 @@ export class AdClickOverlay extends ClickOverlay {
     let clickThroughCallback: () => void = null;
 
     player.on(player.exports.PlayerEvent.AdStarted, (event: AdEvent) => {
-      let ad = event.ad;
+      const ad = event.ad;
       this.setUrl(ad.clickThroughUrl);
       clickThroughCallback = ad.clickThroughUrlOpened;
     });
 
     // Clear click-through URL when ad has finished
-    let adFinishedHandler = () => {
+    const adFinishedHandler = () => {
       this.setUrl(null);
     };
 

--- a/src/ts/components/ads/AdSkipButton.ts
+++ b/src/ts/components/ads/AdSkipButton.ts
@@ -46,12 +46,12 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
+    const config = this.getConfig();
     let untilSkippableMessage = config.untilSkippableMessage;
     let skippableMessage = config.skippableMessage;
     let skipOffset = -1;
 
-    let updateSkipMessageHandler = () => {
+    const updateSkipMessageHandler = () => {
       this.show();
 
       // Update the skip message on the button
@@ -64,8 +64,8 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       }
     };
 
-    let adStartHandler = (event: AdEvent) => {
-      let ad = event.ad as LinearAd;
+    const adStartHandler = (event: AdEvent) => {
+      const ad = event.ad as LinearAd;
       skipOffset = ad.skippableAfter;
       untilSkippableMessage = (ad.uiConfig && ad.uiConfig.untilSkippableMessage) || config.untilSkippableMessage;
       skippableMessage = (ad.uiConfig && ad.uiConfig.skippableMessage) || config.skippableMessage;
@@ -80,7 +80,7 @@ export class AdSkipButton extends Button<AdSkipButtonConfig> {
       }
     };
 
-    let adEndHandler = () => {
+    const adEndHandler = () => {
       player.off(player.exports.PlayerEvent.TimeChanged, updateSkipMessageHandler);
     };
 

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -99,7 +99,7 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
     }
 
     // Create the button element with the text label
-    let buttonElement = new DOM('button', buttonElementAttributes, this);
+    const buttonElement = new DOM('button', buttonElementAttributes, this);
 
     const addIconElement = () => {
       const icon = new Icon({ ariaLabel: this.config.ariaLabel, altText: this.config.text });

--- a/src/ts/components/buttons/CastToggleButton.ts
+++ b/src/ts/components/buttons/CastToggleButton.ts
@@ -39,7 +39,7 @@ export class CastToggleButton extends ToggleButton<ToggleButtonConfig> {
       }
     });
 
-    let castAvailableHander = () => {
+    const castAvailableHander = () => {
       if (player.isCastAvailable()) {
         this.show();
       } else {

--- a/src/ts/components/buttons/CloseButton.ts
+++ b/src/ts/components/buttons/CloseButton.ts
@@ -38,7 +38,7 @@ export class CloseButton extends Button<CloseButtonConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
+    const config = this.getConfig();
 
     this.onClick.subscribe(() => {
       config.target.hide();

--- a/src/ts/components/buttons/HugePlaybackToggleButton.ts
+++ b/src/ts/components/buttons/HugePlaybackToggleButton.ts
@@ -33,7 +33,7 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
       this.config.enterFullscreenOnInitialPlayback = uimanager.getConfig().enterFullscreenOnInitialPlayback;
     }
 
-    let togglePlayback = () => {
+    const togglePlayback = () => {
       if (player.isPlaying() || this.isPlayInitiated) {
         player.pause('ui');
       } else {
@@ -41,7 +41,7 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
       }
     };
 
-    let toggleFullscreen = () => {
+    const toggleFullscreen = () => {
       if (player.getViewMode() === player.exports.ViewMode.Fullscreen) {
         player.setViewMode(player.exports.ViewMode.Inline);
       } else {
@@ -88,7 +88,7 @@ export class HugePlaybackToggleButton extends PlaybackToggleButton {
         return;
       }
 
-      let now = Date.now();
+      const now = Date.now();
 
       if (now - clickTime < 200) {
         // We have a double click inside the 200ms interval, just toggle fullscreen mode

--- a/src/ts/components/buttons/PlaybackToggleButton.ts
+++ b/src/ts/components/buttons/PlaybackToggleButton.ts
@@ -54,7 +54,7 @@ export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfi
     let firstPlay = true;
 
     // Handler to update button state based on player state
-    let playbackStateHandler = () => {
+    const playbackStateHandler = () => {
       // If the UI is currently seeking, playback is temporarily stopped but the buttons should
       // not reflect that and stay as-is (e.g indicate playback while seeking).
       if (isSeeking) {
@@ -113,8 +113,8 @@ export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfi
     };
 
     // Detect absence of timeshifting on live streams and add tagging class to convert button icons to play/stop
-    let timeShiftDetector = new PlayerUtils.TimeShiftAvailabilityDetector(player);
-    let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
+    const timeShiftDetector = new PlayerUtils.TimeShiftAvailabilityDetector(player);
+    const liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
 
     timeShiftDetector.onTimeShiftAvailabilityChanged.subscribe(() => updateLiveState());
     liveStreamDetector.onLiveChanged.subscribe(() => updateLiveState());

--- a/src/ts/components/buttons/QuickSeekButton.ts
+++ b/src/ts/components/buttons/QuickSeekButton.ts
@@ -77,7 +77,7 @@ export class QuickSeekButton extends Button<QuickSeekButtonConfig> {
       },
     );
 
-    let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
+    const liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
     liveStreamDetector.onLiveChanged.subscribe((sender, args: PlayerUtils.LiveStreamDetectorEventArgs) => {
       isLive = args.live;
       switchVisibility(isLive, hasTimeShift);

--- a/src/ts/components/buttons/SmallCenteredPlaybackToggleButton.ts
+++ b/src/ts/components/buttons/SmallCenteredPlaybackToggleButton.ts
@@ -28,7 +28,7 @@ export class SmallCenteredPlaybackToggleButton extends PlaybackToggleButton {
       this.config.enterFullscreenOnInitialPlayback = uimanager.getConfig().enterFullscreenOnInitialPlayback;
     }
 
-    let togglePlayback = () => {
+    const togglePlayback = () => {
       if (player.isPlaying() || this.isPlayInitiated) {
         player.pause('ui');
       } else {

--- a/src/ts/components/buttons/VRToggleButton.ts
+++ b/src/ts/components/buttons/VRToggleButton.ts
@@ -25,7 +25,7 @@ export class VRToggleButton extends ToggleButton<ToggleButtonConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let isVRConfigured = () => {
+    const isVRConfigured = () => {
       // VR availability cannot be checked through getVRStatus() because it is asynchronously populated and not
       // available at UI initialization. As an alternative, we check the VR settings in the config.
       // TODO use getVRStatus() through isVRStereoAvailable() once the player has been rewritten and the status is
@@ -34,12 +34,12 @@ export class VRToggleButton extends ToggleButton<ToggleButtonConfig> {
       return source && Boolean(source.vr);
     };
 
-    let isVRStereoAvailable = () => {
+    const isVRStereoAvailable = () => {
       const source = player.getSource();
       return player.vr && Boolean(source.vr);
     };
 
-    let vrStateHandler = (ev: PlayerEventBase) => {
+    const vrStateHandler = (ev: PlayerEventBase) => {
       if (
         ev.type === player.exports.PlayerEvent.Warning &&
         (ev as WarningEvent).code !== player.exports.WarningCode.VR_RENDERING_ERROR
@@ -60,7 +60,7 @@ export class VRToggleButton extends ToggleButton<ToggleButtonConfig> {
       }
     };
 
-    let vrButtonVisibilityHandler = () => {
+    const vrButtonVisibilityHandler = () => {
       if (isVRConfigured()) {
         this.show();
       } else {

--- a/src/ts/components/buttons/VolumeControlButton.ts
+++ b/src/ts/components/buttons/VolumeControlButton.ts
@@ -61,8 +61,8 @@ export class VolumeControlButton extends Container<VolumeControlButtonConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let volumeToggleButton = this.getVolumeToggleButton();
-    let volumeSlider = this.getVolumeSlider();
+    const volumeToggleButton = this.getVolumeToggleButton();
+    const volumeSlider = this.getVolumeSlider();
 
     this.volumeSliderHideTimeout = new Timeout(this.getConfig().hideDelay, () => {
       volumeSlider.hide();

--- a/src/ts/components/labels/Label.ts
+++ b/src/ts/components/labels/Label.ts
@@ -81,7 +81,7 @@ export class Label<Config extends LabelConfig> extends Component<Config> {
 
   protected toDomElement(): DOM {
     const tagName = this.config.for != null ? 'label' : 'span';
-    let textElement = new DOM(
+    const textElement = new DOM(
       'span',
       {
         class: this.prefixCss('ui-label-text'),

--- a/src/ts/components/labels/MetadataLabel.ts
+++ b/src/ts/components/labels/MetadataLabel.ts
@@ -49,10 +49,10 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
-    let uiconfig = uimanager.getConfig();
+    const config = this.getConfig();
+    const uiconfig = uimanager.getConfig();
 
-    let init = () => {
+    const init = () => {
       switch (config.content) {
         case MetadataLabelContent.Title:
           this.setText(uiconfig.metadata.title);
@@ -63,7 +63,7 @@ export class MetadataLabel extends Label<MetadataLabelConfig> {
       }
     };
 
-    let unload = () => {
+    const unload = () => {
       this.setText(null);
     };
 

--- a/src/ts/components/labels/PlaybackTimeLabel.ts
+++ b/src/ts/components/labels/PlaybackTimeLabel.ts
@@ -67,17 +67,17 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
+    const config = this.getConfig();
     let live = false;
-    let liveCssClass = this.prefixCss('ui-playbacktimelabel-live');
-    let liveEdgeCssClass = this.prefixCss('ui-playbacktimelabel-live-edge');
+    const liveCssClass = this.prefixCss('ui-playbacktimelabel-live');
+    const liveEdgeCssClass = this.prefixCss('ui-playbacktimelabel-live-edge');
     let minWidth = 0;
 
-    let liveClickHandler = () => {
+    const liveClickHandler = () => {
       player.timeShift(0);
     };
 
-    let updateLiveState = () => {
+    const updateLiveState = () => {
       // Player is playing a live stream when the duration is infinite
       live = player.isLive();
 
@@ -98,7 +98,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       }
     };
 
-    let updateLiveTimeshiftState = () => {
+    const updateLiveTimeshiftState = () => {
       if (!live) {
         return;
       }
@@ -117,14 +117,14 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       }
     };
 
-    let playbackTimeHandler = () => {
+    const playbackTimeHandler = () => {
       if (!live && player.getDuration() !== Infinity) {
         this.setTime(PlayerUtils.getCurrentTimeRelativeToSeekableRange(player), player.getDuration());
       }
 
       // To avoid 'jumping' in the UI by varying label sizes due to non-monospaced fonts,
       // we gradually increase the min-width with the content to reach a stable size.
-      let width = this.getDomElement().width();
+      const width = this.getDomElement().width();
       if (width > minWidth) {
         minWidth = width;
         this.getDomElement().css({
@@ -133,7 +133,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       }
     };
 
-    let updateTimeFormatBasedOnDuration = () => {
+    const updateTimeFormatBasedOnDuration = () => {
       // Set time format depending on source duration
       this.timeFormat =
         Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600
@@ -142,7 +142,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       playbackTimeHandler();
     };
 
-    let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
+    const liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
     liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
       live = args.live;
       playbackTimeHandler();
@@ -162,7 +162,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     player.on(player.exports.PlayerEvent.StallStarted, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.StallEnded, updateLiveTimeshiftState);
 
-    let init = () => {
+    const init = () => {
       // Reset min-width when a new source is ready (especially for switching VOD/Live modes where the label content
       // changes)
       minWidth = 0;
@@ -183,8 +183,8 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
    * @param durationSeconds the total duration in seconds
    */
   setTime(playbackSeconds: number, durationSeconds: number) {
-    let currentTime = StringUtils.secondsToTime(playbackSeconds, this.timeFormat);
-    let totalTime = StringUtils.secondsToTime(durationSeconds, this.timeFormat);
+    const currentTime = StringUtils.secondsToTime(playbackSeconds, this.timeFormat);
+    const totalTime = StringUtils.secondsToTime(durationSeconds, this.timeFormat);
 
     switch ((<PlaybackTimeLabelConfig>this.config).timeLabelMode) {
       case PlaybackTimeLabelMode.CurrentTime:

--- a/src/ts/components/lists/ItemSelectionList.ts
+++ b/src/ts/components/lists/ItemSelectionList.ts
@@ -28,7 +28,7 @@ export class ItemSelectionList extends ListSelector<ListSelectorConfig> {
   }
 
   protected toDomElement(): DOM {
-    let listElement = new DOM(
+    const listElement = new DOM(
       'ul',
       {
         id: this.config.id,
@@ -57,8 +57,8 @@ export class ItemSelectionList extends ListSelector<ListSelectorConfig> {
       listItem.removeClass(this.prefixCss(ItemSelectionList.CLASS_SELECTED));
     };
 
-    for (let item of this.items) {
-      let listItem = new DOM('li', {
+    for (const item of this.items) {
+      const listItem = new DOM('li', {
         type: 'li',
         class: this.prefixCss('ui-selectionlistitem'),
       }).append(new DOM('a', {}).html(i18n.performLocalization(item.label)));

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -150,7 +150,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    * @returns {boolean} true if removal was successful, false if the item is not part of this selector
    */
   removeItem(key: string): boolean {
-    let index = this.getItemIndex(key);
+    const index = this.getItemIndex(key);
     if (index > -1) {
       ArrayUtils.remove(this.items, this.items[index]);
       this.onItemRemovedEvent(key);
@@ -171,7 +171,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
       return true;
     }
 
-    let index = this.getItemIndex(key);
+    const index = this.getItemIndex(key);
 
     if (index > -1) {
       this.selectedItem = key;
@@ -220,7 +220,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    */
   clearItems() {
     // local copy for iteration after clear
-    let items = this.items;
+    const items = this.items;
     // clear items
     this.items = [];
 
@@ -228,7 +228,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     this.selectedItem = null;
 
     // fire events
-    for (let item of items) {
+    for (const item of items) {
       this.onItemRemovedEvent(item.key);
     }
   }

--- a/src/ts/components/overlays/CastStatusOverlay.ts
+++ b/src/ts/components/overlays/CastStatusOverlay.ts
@@ -34,7 +34,7 @@ export class CastStatusOverlay extends Container<ContainerConfig> {
     player.on(player.exports.PlayerEvent.CastWaitingForDevice, (event: CastWaitingForDeviceEvent) => {
       this.show();
       // Get device name and update status text while connecting
-      let castDeviceName = event.castPayload.deviceName;
+      const castDeviceName = event.castPayload.deviceName;
       this.statusLabel.setText(i18n.getLocalizer('connectingTo', { castDeviceName }));
     });
     player.on(player.exports.PlayerEvent.CastStarted, (event: CastStartedEvent) => {
@@ -42,7 +42,7 @@ export class CastStatusOverlay extends Container<ContainerConfig> {
       // For cases when a session is resumed, we do not receive the previous events and therefore show the status panel
       // here too
       this.show();
-      let castDeviceName = event.deviceName;
+      const castDeviceName = event.deviceName;
       this.statusLabel.setText(i18n.getLocalizer('playingOn', { castDeviceName }));
     });
     player.on(player.exports.PlayerEvent.CastStopped, event => {

--- a/src/ts/components/overlays/ClickOverlay.ts
+++ b/src/ts/components/overlays/ClickOverlay.ts
@@ -35,7 +35,7 @@ export class ClickOverlay extends Button<ClickOverlayConfig> {
     super.initialize();
 
     this.setUrl((<ClickOverlayConfig>this.config).url);
-    let element = this.getDomElement();
+    const element = this.getDomElement();
     element.on('click', () => {
       if (element.data('url')) {
         window.open(element.data('url'), '_blank');

--- a/src/ts/components/overlays/DismissClickOverlay.ts
+++ b/src/ts/components/overlays/DismissClickOverlay.ts
@@ -33,7 +33,7 @@ export class DismissClickOverlay extends Container<DismissClickOverlayConfig> {
       this.hide();
     });
 
-    let element = this.getDomElement();
+    const element = this.getDomElement();
     element.on('click', () => {
       if (this.config.target instanceof SettingsPanel) {
         this.config.target.hideAndReset();

--- a/src/ts/components/overlays/ErrorMessageOverlay.ts
+++ b/src/ts/components/overlays/ErrorMessageOverlay.ts
@@ -113,7 +113,7 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
   configure(player: PlayerAPI | MobileV3PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
+    const config = this.getConfig();
 
     const handleErrorMessage = (
       event: ErrorEvent | MobileV3SourceErrorEvent | MobileV3PlayerErrorEvent,
@@ -137,7 +137,7 @@ export class ErrorMessageOverlay extends Container<ErrorMessageOverlayConfig> {
       player.on(MobileV3PlayerEvent.SourceError, errorEventHandler);
     } else {
       player.on(player.exports.PlayerEvent.Error, (event: ErrorEvent) => {
-        let message = ErrorUtils.defaultWebErrorMessageTranslator(event);
+        const message = ErrorUtils.defaultWebErrorMessageTranslator(event);
         handleErrorMessage(event, message);
       });
     }

--- a/src/ts/components/overlays/RecommendationOverlay.ts
+++ b/src/ts/components/overlays/RecommendationOverlay.ts
@@ -42,13 +42,13 @@ export class RecommendationOverlay extends Container<ContainerConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let clearRecommendations = () => {
+    const clearRecommendations = () => {
       this.recommendationContainer.removeComponents();
       this.recommendationContainer.updateComponents();
       this.getDomElement().removeClass(this.prefixCss(RecommendationOverlay.CLASS_HAS_RECOMMENDATIONS));
     };
 
-    let setupRecommendations = () => {
+    const setupRecommendations = () => {
       clearRecommendations();
 
       const recommendations = uimanager.getConfig().metadata.recommendations;

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -66,7 +66,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let subtitleManager = new ActiveSubtitleManager();
+    const subtitleManager = new ActiveSubtitleManager();
     this.subtitleManager = subtitleManager;
 
     this.subtitleContainerManager = new SubtitleRegionContainerManager(this);
@@ -107,7 +107,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     });
 
     player.on(player.exports.PlayerEvent.CueExit, (event: SubtitleCueEvent) => {
-      let labelToRemove = subtitleManager.cueExit(event);
+      const labelToRemove = subtitleManager.cueExit(event);
 
       if (labelToRemove) {
         this.subtitleContainerManager.removeLabel(labelToRemove);
@@ -124,7 +124,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
     });
 
-    let subtitleClearHandler = () => {
+    const subtitleClearHandler = () => {
       this.hide();
       this.subtitleContainerManager.clear();
       subtitleManager.clear();
@@ -405,7 +405,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         label.regionStyle = `line-height: ${fontSize}px;`;
       };
 
-      for (let label of this.getComponents()) {
+      for (const label of this.getComponents()) {
         if (label instanceof SubtitleRegionContainer) {
           label.getComponents().forEach((l: SubtitleLabel) => {
             updateLabel(l);
@@ -595,7 +595,7 @@ class ActiveSubtitleManager {
   }
 
   private addCueToMap(event: SubtitleCueEvent, label: SubtitleLabel): void {
-    let id = ActiveSubtitleManager.calculateId(event);
+    const id = ActiveSubtitleManager.calculateId(event);
 
     // Create array for id if it does not exist
     this.activeSubtitleCueMap[id] = this.activeSubtitleCueMap[id] || [];
@@ -606,8 +606,8 @@ class ActiveSubtitleManager {
   }
 
   private popCueFromMap(event: SubtitleCueEvent): SubtitleLabel | undefined {
-    let id = ActiveSubtitleManager.calculateId(event);
-    let activeSubtitleCues = this.activeSubtitleCueMap[id];
+    const id = ActiveSubtitleManager.calculateId(event);
+    const activeSubtitleCues = this.activeSubtitleCueMap[id];
 
     if (activeSubtitleCues && activeSubtitleCues.length > 0) {
       // Remove cue
@@ -618,7 +618,7 @@ class ActiveSubtitleManager {
        * cue end time (which can change between CueEnter and CueExit IN CueUpdate) and use it as an
        * additional hint to try and remove the correct one of the colliding cues.
        */
-      let activeSubtitleCue = activeSubtitleCues.shift();
+      const activeSubtitleCue = activeSubtitleCues.shift();
       this.activeSubtitleCueCount--;
 
       return activeSubtitleCue.label;
@@ -661,8 +661,8 @@ class ActiveSubtitleManager {
    * @return {SubtitleLabel}
    */
   getCues(event: SubtitleCueEvent): SubtitleLabel[] | undefined {
-    let id = ActiveSubtitleManager.calculateId(event);
-    let activeSubtitleCues = this.activeSubtitleCueMap[id];
+    const id = ActiveSubtitleManager.calculateId(event);
+    const activeSubtitleCues = this.activeSubtitleCueMap[id];
     if (activeSubtitleCues && activeSubtitleCues.length > 0) {
       return activeSubtitleCues.map(cue => cue.label);
     }

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -315,7 +315,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     let suspension: GroupPlaybackSuspension | undefined;
 
     // Update playback and buffer positions
-    let playbackPositionHandler = (event: PlayerEventBase = null, forceUpdate: boolean = false) => {
+    const playbackPositionHandler = (event: PlayerEventBase = null, forceUpdate: boolean = false) => {
       if (this.isUserSeeking) {
         // We caught a seek preview seek, do not update the seekbar
         return;
@@ -385,13 +385,13 @@ export class SeekBar extends Component<SeekBarConfig> {
     this.configureLivePausedTimeshiftUpdater(player, uimanager, playbackPositionHandler);
 
     // Seek handling
-    let onPlayerSeek = () => {
+    const onPlayerSeek = () => {
       isPlayerSeeking = true;
       this.setSeeking(true);
       scrubbing = false;
     };
 
-    let onPlayerSeeked = (event: PlayerEventBase = null) => {
+    const onPlayerSeeked = (event: PlayerEventBase = null) => {
       isPlayerSeeking = false;
       this.setSeeking(false);
 
@@ -399,7 +399,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       playbackPositionHandler(event, true);
     };
 
-    let restorePlayingState = function () {
+    const restorePlayingState = function () {
       // Continue playback after seek if player was playing when seek started
       if (isPlaying) {
         // use the same issuer here as in the pause on seek
@@ -412,7 +412,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     player.on(player.exports.PlayerEvent.TimeShift, onPlayerSeek);
     player.on(player.exports.PlayerEvent.TimeShifted, onPlayerSeeked);
 
-    let isGroupPlaybackAPIAvailable = (player: PlayerAPI): player is ExtendedPlayerAPI => {
+    const isGroupPlaybackAPIAvailable = (player: PlayerAPI): player is ExtendedPlayerAPI => {
       return !!(player as ExtendedPlayerAPI).groupPlayback;
     };
 
@@ -481,7 +481,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     // Hide seekbar for live sources without timeshift
     let isLive = false;
     let hasTimeShift = false;
-    let switchVisibility = (isLive: boolean, hasTimeShift: boolean) => {
+    const switchVisibility = (isLive: boolean, hasTimeShift: boolean) => {
       if (isLive && !hasTimeShift) {
         this.hide();
       } else {
@@ -490,7 +490,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       playbackPositionHandler(null, true);
       this.refreshLayout();
     };
-    let liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
+    const liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
     liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
       isLive = args.live;
       if (isLive && this.smoothPlaybackPositionUpdater != null) {
@@ -501,7 +501,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       }
       switchVisibility(isLive, hasTimeShift);
     });
-    let timeShiftDetector = new PlayerUtils.TimeShiftAvailabilityDetector(player);
+    const timeShiftDetector = new PlayerUtils.TimeShiftAvailabilityDetector(player);
     timeShiftDetector.onTimeShiftAvailabilityChanged.subscribe((sender, args: TimeShiftAvailabilityChangedArgs) => {
       hasTimeShift = args.timeShiftAvailable;
       switchVisibility(isLive, hasTimeShift);
@@ -627,8 +627,8 @@ export class SeekBar extends Component<SeekBarConfig> {
      */
     let currentTimeSeekBar = 0;
     let currentTimePlayer = 0;
-    let updateIntervalMs = 50;
-    let currentTimeUpdateDeltaSecs = updateIntervalMs / 1000;
+    const updateIntervalMs = 50;
+    const currentTimeUpdateDeltaSecs = updateIntervalMs / 1000;
 
     this.smoothPlaybackPositionUpdater = new Timeout(
       updateIntervalMs,
@@ -659,7 +659,7 @@ export class SeekBar extends Component<SeekBarConfig> {
         }
 
         // Sync currentTime of seekbar to player
-        let currentTimeDelta = currentTimeSeekBar - currentTimePlayer;
+        const currentTimeDelta = currentTimeSeekBar - currentTimePlayer;
         // If the delta is larger that 2 secs, directly jump the seekbar to the
         // player time instead of smoothly fast forwarding/rewinding.
         if (Math.abs(currentTimeDelta) > 2) {
@@ -676,20 +676,20 @@ export class SeekBar extends Component<SeekBarConfig> {
           currentTimeSeekBar -= currentTimeUpdateDeltaSecs;
         }
 
-        let playbackPositionPercentage = (100 / player.getDuration()) * currentTimeSeekBar;
+        const playbackPositionPercentage = (100 / player.getDuration()) * currentTimeSeekBar;
         this.setPlaybackPosition(playbackPositionPercentage);
       },
       true,
     );
 
-    let startSmoothPlaybackPositionUpdater = () => {
+    const startSmoothPlaybackPositionUpdater = () => {
       if (!player.isLive()) {
         currentTimeSeekBar = this.getRelativeCurrentTime();
         this.smoothPlaybackPositionUpdater.start();
       }
     };
 
-    let stopSmoothPlaybackPositionUpdater = () => {
+    const stopSmoothPlaybackPositionUpdater = () => {
       this.smoothPlaybackPositionUpdater.clear();
     };
 
@@ -733,7 +733,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.config.cssClasses.push('vertical');
     }
 
-    let seekBarContainer = new DOM(
+    const seekBarContainer = new DOM(
       'div',
       {
         id: this.config.id,
@@ -745,7 +745,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       this,
     );
 
-    let seekBar = new DOM('div', {
+    const seekBar = new DOM('div', {
       class: this.prefixCss('seekbar'),
     });
     this.seekBar = seekBar;
@@ -755,36 +755,36 @@ export class SeekBar extends Component<SeekBarConfig> {
     });
 
     // Indicator that shows the buffer fill level
-    let seekBarBufferLevel = new DOM('div', {
+    const seekBarBufferLevel = new DOM('div', {
       class: this.prefixCss('seekbar-bufferlevel'),
     });
     this.seekBarBufferPosition = seekBarBufferLevel;
 
     // Indicator that shows the current playback position
-    let seekBarPlaybackPosition = new DOM('div', {
+    const seekBarPlaybackPosition = new DOM('div', {
       class: this.prefixCss('seekbar-playbackposition'),
     });
     this.seekBarPlaybackPosition = seekBarPlaybackPosition;
 
     // A marker of the current playback position, e.g. a dot or line
-    let seekBarPlaybackPositionMarker = new DOM('div', {
+    const seekBarPlaybackPositionMarker = new DOM('div', {
       class: this.prefixCss('seekbar-playbackposition-marker'),
     });
     this.seekBarPlaybackPositionMarker = seekBarPlaybackPositionMarker;
 
     // Indicator that show where a seek will go to
-    let seekBarSeekPosition = new DOM('div', {
+    const seekBarSeekPosition = new DOM('div', {
       class: this.prefixCss('seekbar-seekposition'),
     });
     this.seekBarSeekPosition = seekBarSeekPosition;
 
     // Indicator that shows the full seekbar
-    let seekBarBackdrop = new DOM('div', {
+    const seekBarBackdrop = new DOM('div', {
       class: this.prefixCss('seekbar-backdrop'),
     });
     this.seekBarBackdrop = seekBarBackdrop;
 
-    let seekBarChapterMarkersContainer = new DOM('div', {
+    const seekBarChapterMarkersContainer = new DOM('div', {
       class: this.prefixCss('seekbar-markers'),
     });
     this.seekBarMarkersContainer = seekBarChapterMarkersContainer;
@@ -801,7 +801,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     let seeking = false;
 
     // Define handler functions so we can attach/remove them later
-    let mouseTouchMoveHandler = (e: MouseEvent | TouchEvent) => {
+    const mouseTouchMoveHandler = (e: MouseEvent | TouchEvent) => {
       e.preventDefault();
       // Avoid propagation to VR handler
       if (this.player.vr != null) {
@@ -817,7 +817,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.onSeekPreviewEvent(targetPercentage, seekPositionPx, true);
     };
 
-    let mouseTouchUpHandler = (e: MouseEvent | TouchEvent) => {
+    const mouseTouchUpHandler = (e: MouseEvent | TouchEvent) => {
       e.preventDefault();
 
       // Remove handlers, seek operation is finished
@@ -848,7 +848,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     // and mouseup handlers to the whole document. A seek is triggered when the user lifts the mouse key.
     // A seek mouse gesture is thus basically a click with a long time frame between down and up events.
     seekBar.on('touchstart mousedown', (e: MouseEvent | TouchEvent) => {
-      let isTouchEvent = BrowserUtils.isTouchSupported && this.isTouchEvent(e);
+      const isTouchEvent = BrowserUtils.isTouchSupported && this.isTouchEvent(e);
 
       // Prevent selection of DOM elements (also prevents mousedown if current event is touchstart)
       e.preventDefault();
@@ -914,10 +914,10 @@ export class SeekBar extends Component<SeekBarConfig> {
    * @returns {number} a number in the range of [0, 1], where 0 is the left edge and 1 is the right edge
    */
   private getHorizontalOffset(eventPageX: number): number {
-    let elementOffsetPx = this.seekBar.offset().left;
-    let widthPx = this.seekBar.width();
-    let offsetPx = eventPageX - elementOffsetPx;
-    let offset = (1 / widthPx) * offsetPx;
+    const elementOffsetPx = this.seekBar.offset().left;
+    const widthPx = this.seekBar.width();
+    const offsetPx = eventPageX - elementOffsetPx;
+    const offset = (1 / widthPx) * offsetPx;
 
     return this.sanitizeOffset(offset);
   }
@@ -928,10 +928,10 @@ export class SeekBar extends Component<SeekBarConfig> {
    * @returns {number} a number in the range of [0, 1], where 0 is the bottom edge and 1 is the top edge
    */
   private getVerticalOffset(eventPageY: number): number {
-    let elementOffsetPx = this.seekBar.offset().top;
-    let widthPx = this.seekBar.height();
-    let offsetPx = eventPageY - elementOffsetPx;
-    let offset = (1 / widthPx) * offsetPx;
+    const elementOffsetPx = this.seekBar.offset().top;
+    const widthPx = this.seekBar.height();
+    const offsetPx = eventPageY - elementOffsetPx;
+    const offset = (1 / widthPx) * offsetPx;
 
     return 1 - this.sanitizeOffset(offset);
   }
@@ -997,7 +997,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     this.setPosition(this.seekBarPlaybackPosition, percent);
 
     // Set position of the marker
-    let totalSize = this.config.vertical
+    const totalSize = this.config.vertical
       ? this.seekBar.height() - this.seekBarPlaybackPositionMarker.height()
       : this.seekBar.width();
     let px = (totalSize / 100) * percent;
@@ -1005,7 +1005,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       px = this.seekBar.height() - px - this.seekBarPlaybackPositionMarker.height();
     }
 
-    let style = this.config.vertical
+    const style = this.config.vertical
       ? // -ms-transform required for IE9
         // -webkit-transform required for Android 4.4 WebView
         {
@@ -1081,7 +1081,7 @@ export class SeekBar extends Component<SeekBarConfig> {
       scale = 0.99999;
     }
 
-    let style = this.config.vertical
+    const style = this.config.vertical
       ? // -ms-transform required for IE9
         // -webkit-transform required for Android 4.4 WebView
         {
@@ -1160,7 +1160,7 @@ export class SeekBar extends Component<SeekBarConfig> {
   }
 
   protected onSeekPreviewEvent(percentage: number, targetOffsetPx: number, scrubbing: boolean) {
-    let snappedMarker = this.timelineMarkersHandler && this.timelineMarkersHandler.getMarkerAtPosition(percentage);
+    const snappedMarker = this.timelineMarkersHandler && this.timelineMarkersHandler.getMarkerAtPosition(percentage);
 
     let seekPositionPercentage = percentage;
 

--- a/src/ts/components/seekbar/SeekBarLabel.ts
+++ b/src/ts/components/seekbar/SeekBarLabel.ts
@@ -68,7 +68,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     this.uiManager = uimanager;
     uimanager.onSeekPreview.subscribeRateLimited(this.handleSeekPreview, 100);
 
-    let init = () => {
+    const init = () => {
       // Set time format depending on source duration
       this.timeFormat =
         Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600
@@ -85,8 +85,8 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
 
   private handleSeekPreview = (sender: SeekBar, args: SeekPreviewEventArgs) => {
     if (this.player.isLive()) {
-      let maxTimeShift = this.player.getMaxTimeShift();
-      let timeShiftPreview = maxTimeShift - maxTimeShift * (args.position / 100);
+      const maxTimeShift = this.player.getMaxTimeShift();
+      const timeShiftPreview = maxTimeShift - maxTimeShift * (args.position / 100);
 
       this.setTime(timeShiftPreview);
 
@@ -103,7 +103,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
       const wallClockTime = convertTimeShiftPreviewToWallClockTime(timeShiftPreview);
       this.setThumbnail(this.player.getThumbnail(wallClockTime));
     } else {
-      let time = this.player.getDuration() * (args.position / 100);
+      const time = this.player.getDuration() * (args.position / 100);
       this.setTime(time);
 
       const seekableRangeStart = PlayerUtils.getSeekableRangeStart(this.player, 0);
@@ -184,7 +184,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
    * @param thumbnail the thumbnail to display on the label or null to remove a displayed thumbnail
    */
   setThumbnail(thumbnail: Thumbnail = null) {
-    let thumbnailElement = this.thumbnail.getDomElement();
+    const thumbnailElement = this.thumbnail.getDomElement();
 
     if (thumbnail == null) {
       thumbnailElement.css({
@@ -209,19 +209,19 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
   }
 
   private thumbnailCssSprite(thumbnail: Thumbnail, width: number, height: number): CssProperties {
-    let thumbnailCountX = width / thumbnail.width;
-    let thumbnailCountY = height / thumbnail.height;
+    const thumbnailCountX = width / thumbnail.width;
+    const thumbnailCountY = height / thumbnail.height;
 
-    let thumbnailIndexX = thumbnail.x / thumbnail.width;
-    let thumbnailIndexY = thumbnail.y / thumbnail.height;
+    const thumbnailIndexX = thumbnail.x / thumbnail.width;
+    const thumbnailIndexY = thumbnail.y / thumbnail.height;
 
-    let sizeX = 100 * thumbnailCountX;
-    let sizeY = 100 * thumbnailCountY;
+    const sizeX = 100 * thumbnailCountX;
+    const sizeY = 100 * thumbnailCountY;
 
-    let offsetX = 100 * thumbnailIndexX;
-    let offsetY = 100 * thumbnailIndexY;
+    const offsetX = 100 * thumbnailIndexX;
+    const offsetY = 100 * thumbnailIndexY;
 
-    let aspectRatio = (1 / thumbnail.width) * thumbnail.height;
+    const aspectRatio = (1 / thumbnail.width) * thumbnail.height;
 
     // The thumbnail size is set by setting the CSS 'width' and 'padding-bottom' properties. 'padding-bottom' is
     // used because it is relative to the width and can be used to set the aspect ratio of the thumbnail.
@@ -236,7 +236,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
   }
 
   private thumbnailCssSingleImage(thumbnail: Thumbnail, width: number, height: number): CssProperties {
-    let aspectRatio = (1 / width) * height;
+    const aspectRatio = (1 / width) * height;
 
     return {
       display: 'inherit',

--- a/src/ts/components/seekbar/VolumeSlider.ts
+++ b/src/ts/components/seekbar/VolumeSlider.ts
@@ -61,7 +61,7 @@ export class VolumeSlider extends SeekBar {
 
     this.setAriaSliderMinMax('0', '100');
 
-    let config = <VolumeSliderConfig>this.getConfig();
+    const config = <VolumeSliderConfig>this.getConfig();
 
     const volumeController = uimanager.getConfig().volumeController;
 

--- a/src/ts/components/settings/AudioQualitySelectBox.ts
+++ b/src/ts/components/settings/AudioQualitySelectBox.ts
@@ -25,12 +25,12 @@ export class AudioQualitySelectBox extends SelectBox {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let selectCurrentAudioQuality = () => {
+    const selectCurrentAudioQuality = () => {
       this.selectItem(player.getAudioQuality().id);
     };
 
-    let updateAudioQualities = () => {
-      let audioQualities = player.getAvailableAudioQualities();
+    const updateAudioQualities = () => {
+      const audioQualities = player.getAvailableAudioQualities();
 
       this.clearItems();
 
@@ -38,7 +38,7 @@ export class AudioQualitySelectBox extends SelectBox {
       this.addItem('auto', i18n.getLocalizer('auto'));
 
       // Add audio qualities
-      for (let audioQuality of audioQualities) {
+      for (const audioQuality of audioQualities) {
         this.addItem(audioQuality.id, audioQuality.label);
       }
 

--- a/src/ts/components/settings/DynamicSettingsPanelItem.ts
+++ b/src/ts/components/settings/DynamicSettingsPanelItem.ts
@@ -92,7 +92,7 @@ export class DynamicSettingsPanelItem extends InteractiveSettingsPanelItem<Dynam
     }
 
     const handleSelectedItemChanged = () => {
-      let selectedItem = this.settingComponent.getItemForKey(this.settingComponent.getSelectedItem());
+      const selectedItem = this.settingComponent.getItemForKey(this.settingComponent.getSelectedItem());
       if (selectedItem == null) {
         this.selectedOptionLabel.setText('-');
         return;
@@ -100,7 +100,7 @@ export class DynamicSettingsPanelItem extends InteractiveSettingsPanelItem<Dynam
 
       let selectedOptionLabelText = selectedItem.label;
       if (this.settingComponent instanceof SubtitleSelectBox) {
-        let availableSettings = this.settingComponent.getItems().length;
+        const availableSettings = this.settingComponent.getItems().length;
         selectedOptionLabelText =
           i18n.performLocalization(selectedOptionLabelText) + ' (' + (availableSettings - 1) + ')';
       }
@@ -164,7 +164,7 @@ export class DynamicSettingsPanelItem extends InteractiveSettingsPanelItem<Dynam
   }
 
   public displayItemsSubPage(): void {
-    let page = this.buildSubPanelPage();
+    const page = this.buildSubPanelPage();
     this.config.container.addPage(page);
     this.config.container.setActivePage(page);
   }

--- a/src/ts/components/settings/SelectBox.ts
+++ b/src/ts/components/settings/SelectBox.ts
@@ -93,7 +93,7 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
   }
 
   private readonly onChange = () => {
-    let value = this.selectElement.val();
+    const value = this.selectElement.val();
     this.onItemSelectedEvent(value, false);
   };
 
@@ -110,8 +110,8 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
     this.selectElement.empty();
 
     // Add updated children
-    for (let item of this.items) {
-      let optionElement = new DOM('option', {
+    for (const item of this.items) {
+      const optionElement = new DOM('option', {
         value: String(item.key),
       }).html(i18n.performLocalization(item.label));
 

--- a/src/ts/components/settings/SettingsPanel.ts
+++ b/src/ts/components/settings/SettingsPanel.ts
@@ -118,7 +118,7 @@ export class SettingsPanel<Config extends SettingsPanelConfig> extends Container
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
+    const config = this.getConfig();
 
     uimanager.onControlsHide.subscribe(() => this.hideHoveredSelectBoxes());
     uimanager.onComponentViewModeChanged.subscribe((_, { mode }) => this.trackComponentViewMode(mode));
@@ -573,7 +573,7 @@ export class SettingsPanel<Config extends SettingsPanelConfig> extends Container
   // collect all items from all pages (see hideHoveredSelectBoxes)
   private getComputedItems(): SettingsPanelItem<SettingsPanelItemConfig>[] {
     const allItems: SettingsPanelItem<SettingsPanelItemConfig>[] = [];
-    for (let page of this.getPages()) {
+    for (const page of this.getPages()) {
       allItems.push(...page.getItems());
     }
     return allItems;

--- a/src/ts/components/settings/SettingsPanelItem.ts
+++ b/src/ts/components/settings/SettingsPanelItem.ts
@@ -95,7 +95,7 @@ export class SettingsPanelItem<Config extends SettingsPanelItemConfig> extends C
     }
 
     if (this.settingComponent instanceof ListSelector) {
-      let handleConfigItemChanged = () => {
+      const handleConfigItemChanged = () => {
         if (!(this.settingComponent instanceof ListSelector)) {
           return;
         }

--- a/src/ts/components/settings/SettingsPanelPage.ts
+++ b/src/ts/components/settings/SettingsPanelPage.ts
@@ -50,12 +50,12 @@ export class SettingsPanelPage extends Container<SettingsPanelPageConfig> {
     super.configure(player, uimanager);
 
     // Fire event when the state of a settings-item has changed
-    let settingsStateChangedHandler = () => {
+    const settingsStateChangedHandler = () => {
       this.onSettingsStateChangedEvent();
 
       // Attach marker class to last visible item
       let lastShownItem: SettingsPanelItem<SettingsPanelItemConfig> = null;
-      for (let component of this.getItems()) {
+      for (const component of this.getItems()) {
         component.getDomElement().removeClass(this.prefixCss(SettingsPanelPage.CLASS_LAST));
         if (component.isShown()) {
           lastShownItem = component;
@@ -65,13 +65,13 @@ export class SettingsPanelPage extends Container<SettingsPanelPageConfig> {
         lastShownItem.getDomElement().addClass(this.prefixCss(SettingsPanelPage.CLASS_LAST));
       }
     };
-    for (let component of this.getItems()) {
+    for (const component of this.getItems()) {
       component.onActiveChanged.subscribe(settingsStateChangedHandler);
     }
   }
 
   hasActiveSettings(): boolean {
-    for (let component of this.getItems()) {
+    for (const component of this.getItems()) {
       if (component.getConfig().isSetting && component.isActive()) {
         return true;
       }

--- a/src/ts/components/settings/SettingsPanelSelectOption.ts
+++ b/src/ts/components/settings/SettingsPanelSelectOption.ts
@@ -50,7 +50,7 @@ export class SettingsPanelSelectOption extends InteractiveSettingsPanelItem<Sett
     super.configure(player, uimanager);
 
     const handleSelectedOptionChanged = () => {
-      let selectedItem = this.settingComponent.getSelectedItem();
+      const selectedItem = this.settingComponent.getSelectedItem();
 
       if (this.settingsValue === selectedItem) {
         this.getDomElement().addClass(this.prefixCss('selected'));

--- a/src/ts/components/settings/SettingsToggleButton.ts
+++ b/src/ts/components/settings/SettingsToggleButton.ts
@@ -65,8 +65,8 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let config = this.getConfig();
-    let settingsPanel = config.settingsPanel;
+    const config = this.getConfig();
+    const settingsPanel = config.settingsPanel;
 
     this.onClick.subscribe(() => {
       // only hide other `SettingsPanel`s if a new one will be opened
@@ -99,7 +99,7 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
     // Handle automatic hiding of the button if there are no settings for the user to interact with
     if (config.autoHideWhenNoActiveSettings) {
       // Setup handler to show/hide button when the settings change
-      let settingsPanelItemsChangedHandler = () => {
+      const settingsPanelItemsChangedHandler = () => {
         if (settingsPanel.rootPageHasActiveSettings()) {
           if (this.isHidden()) {
             this.show();

--- a/src/ts/components/settings/VideoQualitySelectBox.ts
+++ b/src/ts/components/settings/VideoQualitySelectBox.ts
@@ -27,12 +27,12 @@ export class VideoQualitySelectBox extends SelectBox {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    let selectCurrentVideoQuality = () => {
+    const selectCurrentVideoQuality = () => {
       this.selectItem(player.getVideoQuality().id);
     };
 
-    let updateVideoQualities = () => {
-      let videoQualities = player.getAvailableVideoQualities();
+    const updateVideoQualities = () => {
+      const videoQualities = player.getAvailableVideoQualities();
 
       this.clearItems();
 
@@ -45,7 +45,7 @@ export class VideoQualitySelectBox extends SelectBox {
       }
 
       // Add video qualities
-      for (let videoQuality of videoQualities) {
+      for (const videoQuality of videoQualities) {
         this.addItem(videoQuality.id, videoQuality.label);
       }
 

--- a/src/ts/components/settings/subtitlesettings/BackgroundColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/BackgroundColorSelectBox.ts
@@ -34,7 +34,7 @@ export class BackgroundColorSelectBox extends SubtitleSettingSelectBox {
     this.addItem('yellow', i18n.getLocalizer('colors.yellow'));
     this.addItem('magenta', i18n.getLocalizer('colors.magenta'));
 
-    let setColorAndOpacity = () => {
+    const setColorAndOpacity = () => {
       if (this.settingsManager.backgroundColor.isSet() && this.settingsManager.backgroundOpacity.isSet()) {
         this.toggleOverlayClass(
           'bgcolor-' + this.settingsManager.backgroundColor.value + this.settingsManager.backgroundOpacity.value,

--- a/src/ts/components/settings/subtitlesettings/FontColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontColorSelectBox.ts
@@ -34,7 +34,7 @@ export class FontColorSelectBox extends SubtitleSettingSelectBox {
     this.addItem('yellow', i18n.getLocalizer('colors.yellow'));
     this.addItem('magenta', i18n.getLocalizer('colors.magenta'));
 
-    let setColorAndOpacity = () => {
+    const setColorAndOpacity = () => {
       if (this.settingsManager.fontColor.isSet() && this.settingsManager.fontOpacity.isSet()) {
         this.toggleOverlayClass(
           'fontcolor-' + this.settingsManager.fontColor.value + this.settingsManager.fontOpacity.value,

--- a/src/ts/components/settings/subtitlesettings/WindowColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/WindowColorSelectBox.ts
@@ -34,7 +34,7 @@ export class WindowColorSelectBox extends SubtitleSettingSelectBox {
     this.addItem('yellow', i18n.getLocalizer('colors.yellow'));
     this.addItem('magenta', i18n.getLocalizer('colors.magenta'));
 
-    let setColorAndOpacity = () => {
+    const setColorAndOpacity = () => {
       if (this.settingsManager.windowColor.isSet() && this.settingsManager.windowOpacity.isSet()) {
         this.toggleOverlayClass(
           'windowcolor-' + this.settingsManager.windowColor.value + this.settingsManager.windowOpacity.value,

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -148,9 +148,9 @@ if (typeof Object.assign !== 'function') {
 
     target = Object(target);
     for (let index = 1; index < arguments.length; index++) {
-      let source = arguments[index];
+      const source = arguments[index];
       if (source != null) {
-        for (let key in source) {
+        for (const key in source) {
           if (Object.prototype.hasOwnProperty.call(source, key)) {
             target[key] = source[key];
           }

--- a/src/ts/spatialnavigation/NavigationGroup.ts
+++ b/src/ts/spatialnavigation/NavigationGroup.ts
@@ -58,7 +58,7 @@ export class NavigationGroup {
 
   // Dynamically resolve all components within this group respecting FocusableContainers.
   protected getComponents(): Focusable[] {
-    let componentsToConsider: Focusable[] = [];
+    const componentsToConsider: Focusable[] = [];
     const focusableContainers = this._components
       .filter(component => component instanceof FocusableContainer)
       .map(component => component as FocusableContainer);
@@ -263,7 +263,7 @@ export class NavigationGroup {
   private trackElementHover(): void {
     this.removeElementHoverEventListeners();
 
-    let componentsToConsider: Component<ComponentConfig>[] = [];
+    const componentsToConsider: Component<ComponentConfig>[] = [];
     this.getComponents().forEach(component => {
       let elementsToConsider: Component<ComponentConfig>[];
       if (component instanceof Container) {

--- a/src/ts/spatialnavigation/SettingsPanelNavigationGroup.ts
+++ b/src/ts/spatialnavigation/SettingsPanelNavigationGroup.ts
@@ -55,7 +55,7 @@ export class SettingsPanelNavigationGroup extends NavigationGroup {
     const activeSettingsPanelPage = this.settingsPanel.getActivePage();
     const pageComponents = activeSettingsPanelPage.getItems();
 
-    let componentsToConsider: Focusable[] = [];
+    const componentsToConsider: Focusable[] = [];
     pageComponents.forEach(component => {
       if (component instanceof SettingsPanelSelectOption) {
         componentsToConsider.push(component);

--- a/src/ts/utils/ArrayUtils.ts
+++ b/src/ts/utils/ArrayUtils.ts
@@ -9,7 +9,7 @@ export namespace ArrayUtils {
    * @returns {any} the removed item or null if it wasn't part of the array
    */
   export function remove<T>(array: T[], item: T): T | null {
-    let index = array.indexOf(item);
+    const index = array.indexOf(item);
 
     if (index > -1) {
       return array.splice(index, 1)[0];

--- a/src/ts/utils/AudioTrackUtils.ts
+++ b/src/ts/utils/AudioTrackUtils.ts
@@ -59,7 +59,7 @@ export class AudioTrackSwitchHandler {
   };
 
   private selectCurrentAudioTrack = () => {
-    let currentAudioTrack = this.player.getAudio();
+    const currentAudioTrack = this.player.getAudio();
 
     // HLS streams don't always provide this, so we have to check
     if (currentAudioTrack) {

--- a/src/ts/utils/ImageLoader.ts
+++ b/src/ts/utils/ImageLoader.ts
@@ -30,7 +30,7 @@ export class ImageLoader {
     if (!this.state[url]) {
       // When the image was never attempted to be loaded before, we create a state and store it in the state map
       // for later use when the same image is requested to be loaded again.
-      let state: ImageLoaderState = {
+      const state: ImageLoaderState = {
         url: url,
         image: new DOM('img', {}),
         loadedCallback: loadedCallback,
@@ -53,7 +53,7 @@ export class ImageLoader {
       state.image.attr('src', state.url);
     } else {
       // We have a state for the requested image, so it is either already loaded or currently loading
-      let state = this.state[url];
+      const state = this.state[url];
 
       // We overwrite the callback to make sure that only the callback of the latest call gets executed.
       // Earlier callbacks become invalid once a new load call arrives, and they are not called as long as the image

--- a/src/ts/utils/PlayerUtils.ts
+++ b/src/ts/utils/PlayerUtils.ts
@@ -95,7 +95,7 @@ export namespace PlayerUtils {
       this.player = player;
       this.timeShiftAvailable = undefined;
 
-      let timeShiftDetector = () => {
+      const timeShiftDetector = () => {
         this.detect();
       };
       // Try to detect timeshift availability when source is loaded, which works for DASH streams
@@ -107,7 +107,7 @@ export namespace PlayerUtils {
 
     detect(): void {
       if (this.player.isLive()) {
-        let timeShiftAvailableNow = PlayerUtils.isTimeShiftAvailable(this.player);
+        const timeShiftAvailableNow = PlayerUtils.isTimeShiftAvailable(this.player);
 
         // When the availability changes, we fire the event
         if (timeShiftAvailableNow !== this.timeShiftAvailable) {
@@ -156,7 +156,7 @@ export namespace PlayerUtils {
       this.uimanager = uimanager;
       this.live = undefined;
 
-      let liveDetector = () => {
+      const liveDetector = () => {
         this.detect();
       };
       this.uimanager.getConfig().events.onUpdated.subscribe(liveDetector);
@@ -181,7 +181,7 @@ export namespace PlayerUtils {
     }
 
     detect(): void {
-      let liveNow = this.player.isLive();
+      const liveNow = this.player.isLive();
 
       // Compare current to previous live state flag and fire event when it changes. Since we initialize the flag
       // with undefined, there is always at least an initial event fired that tells listeners the live state.

--- a/src/ts/utils/StorageUtils.ts
+++ b/src/ts/utils/StorageUtils.ts
@@ -64,7 +64,7 @@ export namespace StorageUtils {
    * @param data the object to store
    */
   export function setObject<T>(key: string, data: T): void {
-    let json = JSON.stringify(data);
+    const json = JSON.stringify(data);
     setItem(key, json);
   }
 
@@ -77,10 +77,10 @@ export namespace StorageUtils {
    * @return {any} Returns the object if found, null otherwise
    */
   export function getObject<T>(key: string): T | null {
-    let json = getItem(key);
+    const json = getItem(key);
 
     if (json) {
-      let object = JSON.parse(json);
+      const object = JSON.parse(json);
       return <T>object;
     }
     return null;

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -5,8 +5,8 @@ import { i18n } from '../localization/i18n';
  * @category Utils
  */
 export namespace StringUtils {
-  export let FORMAT_HHMMSS: string = 'hh:mm:ss';
-  export let FORMAT_MMSS: string = 'mm:ss';
+  export const FORMAT_HHMMSS: string = 'hh:mm:ss';
+  export const FORMAT_MMSS: string = 'mm:ss';
 
   /**
    * Formats a number of seconds into a time string with the pattern hh:mm:ss.
@@ -16,7 +16,7 @@ export namespace StringUtils {
    * @returns {string} the formatted time string
    */
   export function secondsToTime(totalSeconds: number, format: string = FORMAT_HHMMSS): string {
-    let isNegative = totalSeconds < 0;
+    const isNegative = totalSeconds < 0;
 
     if (isNegative) {
       // If the time is negative, we make it positive for the calculation below
@@ -25,9 +25,9 @@ export namespace StringUtils {
     }
 
     // Split into separate time parts
-    let hours = Math.floor(totalSeconds / 3600);
-    let minutes = Math.floor(totalSeconds / 60) - hours * 60;
-    let seconds = Math.floor(totalSeconds) % 60;
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor(totalSeconds / 60) - hours * 60;
+    const seconds = Math.floor(totalSeconds) % 60;
 
     return (
       (isNegative ? '-' : '') +
@@ -69,8 +69,8 @@ export namespace StringUtils {
    * @returns {string} the padded number as string
    */
   function leftPadWithZeros(num: number | string, length: number): string {
-    let text = num + '';
-    let padding = '0000000000'.substr(0, length - text.length);
+    const text = num + '';
+    const padding = '0000000000'.substr(0, length - text.length);
     return padding + text;
   }
 
@@ -104,7 +104,7 @@ export namespace StringUtils {
    * @returns {string} the ad message with filled placeholders
    */
   export function replaceAdMessagePlaceholders(adMessage: string, skipOffset: number, player: PlayerAPI) {
-    let adMessagePlaceholderRegex = new RegExp(
+    const adMessagePlaceholderRegex = new RegExp(
       '\\{(remainingTime|playedTime|adDuration|adBreakRemainingTime)(}|%((0[1-9]\\d*(\\.\\d+(d|f)|d|f)|\\.\\d+f|d|f)|hh:mm:ss|mm:ss)})',
       'g',
     );
@@ -144,9 +144,9 @@ export namespace StringUtils {
   }
 
   function formatNumber(time: number, format: string) {
-    let formatStringValidationRegex = /%((0[1-9]\d*(\.\d+(d|f)|d|f)|\.\d+f|d|f)|hh:mm:ss|mm:ss)/;
-    let leadingZeroesRegex = /(%0[1-9]\d*)(?=(\.\d+f|f|d))/;
-    let decimalPlacesRegex = /\.\d*(?=f)/;
+    const formatStringValidationRegex = /%((0[1-9]\d*(\.\d+(d|f)|d|f)|\.\d+f|d|f)|hh:mm:ss|mm:ss)/;
+    const leadingZeroesRegex = /(%0[1-9]\d*)(?=(\.\d+f|f|d))/;
+    const decimalPlacesRegex = /\.\d*(?=f)/;
 
     if (!formatStringValidationRegex.test(format)) {
       // If the format is invalid, we set a default fallback format
@@ -155,14 +155,14 @@ export namespace StringUtils {
 
     // Determine the number of leading zeros
     let leadingZeroes = 0;
-    let leadingZeroesMatches = format.match(leadingZeroesRegex);
+    const leadingZeroesMatches = format.match(leadingZeroesRegex);
     if (leadingZeroesMatches) {
       leadingZeroes = parseInt(leadingZeroesMatches[0].substring(2));
     }
 
     // Determine the number of decimal places
     let numDecimalPlaces = null;
-    let decimalPlacesMatches = format.match(decimalPlacesRegex);
+    const decimalPlacesMatches = format.match(decimalPlacesRegex);
     if (decimalPlacesMatches && !isNaN(parseInt(decimalPlacesMatches[0].substring(1)))) {
       numDecimalPlaces = parseInt(decimalPlacesMatches[0].substring(1));
       if (numDecimalPlaces > 20) {
@@ -190,7 +190,7 @@ export namespace StringUtils {
     }
     // Time format
     else if (format.indexOf(':') > -1) {
-      let totalSeconds = Math.ceil(time);
+      const totalSeconds = Math.ceil(time);
 
       // hh:mm:ss format
       if (format.indexOf('hh') > -1) {
@@ -198,8 +198,8 @@ export namespace StringUtils {
       }
       // mm:ss format
       else {
-        let minutes = Math.floor(totalSeconds / 60);
-        let seconds = totalSeconds % 60;
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
 
         return leftPadWithZeros(minutes, 2) + ':' + leftPadWithZeros(seconds, 2);
       }

--- a/src/ts/utils/SubtitleSettingsManager.ts
+++ b/src/ts/utils/SubtitleSettingsManager.ts
@@ -48,7 +48,7 @@ export class SubtitleSettingsManager {
   }
 
   public reset(): void {
-    for (let propertyName in this._properties) {
+    for (const propertyName in this._properties) {
       this._properties[propertyName].clear();
     }
   }
@@ -98,7 +98,7 @@ export class SubtitleSettingsManager {
   }
 
   public initialize() {
-    for (let propertyName in this._properties) {
+    for (const propertyName in this._properties) {
       this._properties[propertyName].onChanged.subscribe((sender, property) => {
         if (property.isSet()) {
           (<any>this.userSettings)[propertyName] = property.value;
@@ -129,7 +129,7 @@ export class SubtitleSettingsManager {
     this.userSettings = StorageUtils.getObject<SubtitleSettings>(this.localStorageKey) || {};
 
     // Apply the loaded settings
-    for (let property in this.userSettings) {
+    for (const property in this.userSettings) {
       this._properties[property].value = (<any>this.userSettings)[property];
     }
   }

--- a/src/ts/utils/SubtitleUtils.ts
+++ b/src/ts/utils/SubtitleUtils.ts
@@ -78,7 +78,7 @@ export class SubtitleSwitchHandler {
       return;
     }
 
-    let currentSubtitle = this.player.subtitles
+    const currentSubtitle = this.player.subtitles
       .list()
       .filter(subtitle => subtitle.enabled)
       .pop();

--- a/src/ts/utils/UIUtils.ts
+++ b/src/ts/utils/UIUtils.ts
@@ -10,12 +10,12 @@ export namespace UIUtils {
   }
 
   export function traverseTree(component: Component<ComponentConfig>, visit: TreeTraversalCallback): void {
-    let recursiveTreeWalker = (component: Component<ComponentConfig>, parent?: Component<ComponentConfig>) => {
+    const recursiveTreeWalker = (component: Component<ComponentConfig>, parent?: Component<ComponentConfig>) => {
       visit(component, parent);
 
       // If the current component is a container, visit it's children
       if (component instanceof Container) {
-        for (let childComponent of component.getComponents()) {
+        for (const childComponent of component.getComponents()) {
           recursiveTreeWalker(childComponent, component);
         }
       }


### PR DESCRIPTION
## Description

We are using `let` for non-reassigned variables in a bunch of places. The linter rule to prefer `const` is disabled, which allows new usages to slip into the code base.

=> Enabling the linter rule and ran the eslint autofixer to replace `let` with `const` wherever possible.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- / `CHANGELOG` entry - no, just a chore
