### PR TITLE
v3: Incorrect url handling background-image URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Incorrect handling of thumbnail URLs
+
 ## [3.103.1] - 2025-10-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Incorrect handling of thumbnail URLs
+- Incorrect sytnax of CSS `URL` functions, leading to problems with URLs containing special characters like `(` or `)`
 
 ## [3.103.1] - 2025-10-07
 

--- a/src/ts/components/recommendationoverlay.ts
+++ b/src/ts/components/recommendationoverlay.ts
@@ -108,7 +108,7 @@ class RecommendationItem extends Component<RecommendationItemConfig> {
       'id': this.config.id,
       'class': this.getCssClasses(),
       'href': config.url,
-    }, this).css({ 'background-image': `url(${config.thumbnail})` });
+    }, this).css({ 'background-image': `url("${config.thumbnail}")` });
 
     let bgElement = new DOM('div', {
       'class': this.prefixCss('background'),

--- a/src/ts/components/seekbarlabel.ts
+++ b/src/ts/components/seekbarlabel.ts
@@ -232,7 +232,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     // A default value for width is set in the stylesheet and can be overwritten from there or anywhere else.
     return {
       'display': 'inherit',
-      'background-image': `url(${thumbnail.url})`,
+      'background-image': `url("${thumbnail.url}")`,
       'padding-bottom': `${100 * aspectRatio}%`,
       'background-size': `${sizeX}% ${sizeY}%`,
       'background-position': `-${offsetX}% -${offsetY}%`,
@@ -244,7 +244,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
 
     return {
       'display': 'inherit',
-      'background-image': `url(${thumbnail.url})`,
+      'background-image': `url("${thumbnail.url}")`,
       'padding-bottom': `${100 * aspectRatio}%`,
       'background-size': `100% 100%`,
       'background-position': `0 0`,


### PR DESCRIPTION
Backport of https://github.com/bitmovin/bitmovin-player-ui/pull/791

## Description
In the `recommendationoverlay.ts` and for thumbnail images in the `seekbarlabel.ts` the CSS property `background-image` is created using the `url()` CSS function. In those cases, the URL was not enclosed by quotes, which is invalid syntax. However, browser engines still support that, unless there are certain special characters in the URL, like `(` or `)`. In those cases, displaying the background image failed silently.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
