### PR TITLE
Incorrect url handling background-image URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Incorrect sytnax of CSS `URL` functions, leading to problems with URLs containing special characters like `(` or `)`
+
 ## [4.3.0] - 2025-11-05
 
 ### Added

--- a/src/ts/components/RecommendationItem.ts
+++ b/src/ts/components/RecommendationItem.ts
@@ -80,7 +80,7 @@ export class RecommendationItem extends Component<RecommendationItemConfig> {
     );
 
     if (posterUrl) {
-      itemElement.css({ 'background-image': `url(${posterUrl})` });
+      itemElement.css({ 'background-image': `url("${posterUrl}")` });
     }
 
     const titleElement = new DOM(

--- a/src/ts/components/seekbar/SeekBarLabel.ts
+++ b/src/ts/components/seekbar/SeekBarLabel.ts
@@ -228,7 +228,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     // A default value for width is set in the stylesheet and can be overwritten from there or anywhere else.
     return {
       display: 'inherit',
-      'background-image': `url(${thumbnail.url})`,
+      'background-image': `url("${thumbnail.url}")`,
       'padding-bottom': `${100 * aspectRatio}%`,
       'background-size': `${sizeX}% ${sizeY}%`,
       'background-position': `-${offsetX}% -${offsetY}%`,
@@ -240,7 +240,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
 
     return {
       display: 'inherit',
-      'background-image': `url(${thumbnail.url})`,
+      'background-image': `url("${thumbnail.url}")`,
       'padding-bottom': `${100 * aspectRatio}%`,
       'background-size': `100% 100%`,
       'background-position': `0 0`,


### PR DESCRIPTION
## Description
In the `RecommendationItem.ts` and for thumbnail images in the `SeekBarLabel.ts` the CSS property `background-image` is created using the `url()` CSS function. In those cases, the URL was not enclosed by quotes, which is invalid syntax. However, browser engines still support that, unless there are certain special characters in the URL, like `(` or `)`. In those cases, displaying the background image failed silently.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
