### PR TITLE
Fix CEA caption rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Incorrect sytnax of CSS `URL` functions, leading to problems with URLs containing special characters like `(` or `)`
+- Incorrect CEA608 caption rendering
 
 ## [4.3.0] - 2025-11-05
 

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -91,6 +91,10 @@ describe('SubtitleOverlay', () => {
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
     });
 
+    it('should preserve default cea608FontSizeFactor of 1 if no font size value on settings present', () => {
+      expect(subtitleOverlay['cea608FontSizeFactor']).toBe(1);
+    });
+
     // Font size factor clamping
     test.each([
       [0.2, 0.5], // Clamped to minimum
@@ -99,60 +103,9 @@ describe('SubtitleOverlay', () => {
       [0.5, 0.5], // Exact minimum
       [2.0, 2.0], // Exact maximum
       [1.0, 1.0], // Default value
-    ])('setFontSizeFactor(%f) results in FONT_SIZE_FACTOR = %f', (inputFactor, expectedFactor) => {
+    ])('setFontSizeFactor(%f) results in cea608FontSizeFactor = %f', (inputFactor, expectedFactor) => {
       subtitleOverlay.setFontSizeFactor(inputFactor);
-      expect(subtitleOverlay['FONT_SIZE_FACTOR']).toBe(expectedFactor);
+      expect(subtitleOverlay['cea608FontSizeFactor']).toBe(expectedFactor);
     });
-
-    // Grid recalculations
-    test.each([
-      [1.0, 15 / 1.0, 32 / 1.0], // Standard grid
-      [2.0, 15 / 2.0, 32 / 2.0], // Larger factor, smaller grid
-      [0.5, 15 / 1.0, 32 / 0.5], // Factor <1 → rows stay 15, columns grow
-    ])('setFontSizeFactor(%f) recalculates grid: ROWS = %f, COLUMNS = %f', (factor, expectedRows, expectedColumns) => {
-      // We need to floor for whole rows as they are represented in precompiled sass styles
-      const expectedWholeRows = Math.floor(expectedRows);
-      subtitleOverlay.setFontSizeFactor(factor);
-      subtitleOverlay.recalculateCEAGrid();
-
-      expect(subtitleOverlay['CEA608_NUM_ROWS']).toBe(expectedWholeRows);
-      expect(subtitleOverlay['CEA608_NUM_COLUMNS']).toBe(expectedColumns);
-    });
-
-    test.each([
-      [1.0, 5, 5, 5], // Factor 1.0: grid remains 15 rows; row 5 remains unchanged.
-      [1.0, 14, 14, 14], // Factor 1.0: grid remains 15 rows; row 14 remains unchanged.
-      [2.0, 14, 14, 6], // Factor 2.0: grid becomes floor(15/2)=7 rows; rowDelta = 15-7=8; 14-8=6.
-      [1.5, 12, 12, 7], // Factor 1.5: grid becomes floor(15/1.5)=10 rows; 12 > 10 so rowDelta=15-10=5; 12-5=7.
-      [1.5, 8, 8, 8], // Factor 1.5: grid becomes 10 rows; 8 <= 10 so no clamping.
-      [2.0, 14, undefined, 6], // If no originalRow provided, falls back to initial row (14) and is clamped to 6.
-    ])(
-      'with fontSizeFactor=%f, initialRow=%d, labelOriginalRow=%s, expected new row=%d',
-      (fontSizeFactor, initialRow, labelOriginalRow, expectedRow) => {
-        const element = document.createElement('div');
-        const initialClass = `subtitle-position-cea608-row-${initialRow}`;
-        element.classList.add(initialClass);
-
-        const label = {
-          getConfig: () => (labelOriginalRow !== undefined ? { originalRowPosition: labelOriginalRow } : {}),
-        };
-
-        const regionContainer = {
-          getDomElement: jest.fn(() => ({ get: () => [element] })),
-          getComponents: jest.fn(() => [label]),
-        } as unknown as SubtitleRegionContainer;
-
-        subtitleOverlay.setFontSizeFactor(fontSizeFactor);
-        subtitleOverlay.updateRegionRowPosition(regionContainer);
-
-        const expectedClass = `subtitle-position-cea608-row-${expectedRow}`;
-        expect(element.classList.contains(expectedClass)).toBe(true);
-
-        // If the new class differs from the original, ensure the original is removed.
-        if (expectedClass !== initialClass) {
-          expect(element.classList.contains(initialClass)).toBe(false);
-        }
-      },
-    );
   });
 });

--- a/src/scss/components/overlays/_subtitle-overlay.scss
+++ b/src/scss/components/overlays/_subtitle-overlay.scss
@@ -7,13 +7,13 @@
 
     @include hidden;
 
-    bottom: 0;
-    left: 0;
+    bottom: env(safe-area-inset-bottom, 0);
+    left: env(safe-area-inset-left, 0);
     pointer-events: none;
     position: absolute;
-    right: 0;
+    right: env(safe-area-inset-right, 0);
     text-align: center;
-    top: 0;
+    top: env(safe-area-inset-top, 0);
     transition: bottom $animation-duration-short ease-out;
 
     * {
@@ -67,11 +67,6 @@
     &.#{$prefix}-controlbar-visible {
       bottom: 5em;
       transition: bottom $animation-duration-short ease-in;
-    }
-
-    &:not(.#{$prefix}-controlbar-visible) {
-      top: env(safe-area-inset-top, 0);
-      bottom: env(safe-area-inset-bottom, 0);
     }
   }
 }

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -33,23 +33,17 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   private static readonly CLASS_CONTROLBAR_VISIBLE = 'controlbar-visible';
   private static readonly CLASS_CEA_608 = 'cea608';
-  private static readonly DEFAULT_CEA608_NUM_ROWS = 15;
-  private static readonly DEFAULT_CEA608_NUM_COLUMNS = 32;
-
-  private FONT_SIZE_FACTOR: number = 1;
-  // The number of rows in a cea608 grid
-  private CEA608_NUM_ROWS = SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS;
-  // The number of columns in a cea608 grid
-  private CEA608_NUM_COLUMNS = SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS;
-  // The offset in percent for one column (which is also the width of a column)
-  private CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
+  private static readonly CEA608_NUM_ROWS = 15;
+  private static readonly CEA608_NUM_COLUMNS = 32;
+  private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
+  private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
 
   private cea608Enabled = false;
+  private cea608FontSizeFactor = 1;
+  private ensureCea608GridSizeUpdated: () => void;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
-
-    this.recalculateCEAGrid();
 
     this.previewSubtitleActive = false;
     this.previewSubtitle = new SubtitleLabel({ text: i18n.getLocalizer('subtitle.example') });
@@ -137,6 +131,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       removedActiveCues.forEach(toRemove => {
         this.subtitleContainerManager.removeLabel(toRemove.label);
       });
+      this.updateComponents();
     };
 
     player.on(player.exports.PlayerEvent.AudioChanged, subtitleClearHandler);
@@ -149,11 +144,20 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     uimanager.onComponentShow.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
+
+        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated) {
+          awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
+        }
       }
     });
+
     uimanager.onComponentHide.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
+
+        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated) {
+          awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
+        }
       }
     });
 
@@ -165,17 +169,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   setFontSizeFactor(factor: number): void {
     // We only allow range from 50% to 200% as suggested by spec
     // https://www.ecfr.gov/current/title-47/part-79/section-79.103#p-79.103(c)(4)
-    this.FONT_SIZE_FACTOR = Math.max(0.5, Math.min(2.0, factor));
-
-    this.recalculateCEAGrid();
-  }
-
-  recalculateCEAGrid() {
-    // Needs to get recalculated in case the font size will change also we need to floor this
-    // to always align to the whole number represented in styles.
-    this.CEA608_NUM_ROWS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS / Math.max(this.FONT_SIZE_FACTOR, 1));
-    this.CEA608_NUM_COLUMNS = Math.floor(SubtitleOverlay.DEFAULT_CEA608_NUM_COLUMNS / this.FONT_SIZE_FACTOR);
-    this.CEA608_COLUMN_OFFSET = 100 / this.CEA608_NUM_COLUMNS;
+    this.cea608FontSizeFactor = Math.max(0.5, Math.min(2, factor));
   }
 
   detectCroppedSubtitleLabel(labelElement: HTMLElement): SubtitleCropDetectionResult {
@@ -217,17 +211,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     }
   }
 
-  resolveRowNumber(row: number): number {
-    // In case there is a font size factor and the row from event would overflow
-    // we need to apply an offset so it gets rendered to visible area.
-    if (this.FONT_SIZE_FACTOR > 1 && row > this.CEA608_NUM_ROWS) {
-      const rowDelta = SubtitleOverlay.DEFAULT_CEA608_NUM_ROWS - this.CEA608_NUM_ROWS;
-      return row - rowDelta;
-    }
-
-    return row;
-  }
-
   generateLabel(event: SubtitleCueEvent): SubtitleLabel {
     // Sanitize cue data (must be done before the cue ID is generated in subtitleManager.cueEnter / update)
     let region = event.region;
@@ -236,8 +219,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     // We need to keep track of the original row position in case of recalculation.
     const originalRowNumber = event.position?.row || 0;
 
-    if (event.position) {
-      event.position.row = this.resolveRowNumber(event.position.row) || 0;
+    if (isCea608SubtitleCue(event)) {
+      event.position.row = event.position.row || 0;
       event.position.column = event.position.column || 0;
 
       region = region || `cea608-row-${event.position.row}`;
@@ -269,45 +252,32 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     return parseInt(value) / 100;
   }
 
-  updateRegionRowPosition(r: SubtitleRegionContainer): void {
-    const element = r.getDomElement().get()[0];
-    const label = r.getComponents()[0];
-
-    if (!element || !label) {
-      return;
-    }
-
-    const rowClassList = element.classList;
-    const originalRow = (label.getConfig() as SubtitleLabelConfig)?.originalRowPosition;
-    const rowClassRegex = /subtitle-position-cea608-row-(\d+)/;
-
-    const currentClass = Array.from(rowClassList).find(cls => rowClassRegex.test(cls));
-
-    if (!currentClass) {
-      return;
-    }
-
-    const match = rowClassRegex.exec(currentClass);
-    const rowNumber = match ? parseInt(match[1], 10) : null;
-    const newRowNum = this.resolveRowNumber(originalRow ?? rowNumber);
-    const newClass = currentClass.replace(rowClassRegex, `subtitle-position-cea608-row-${newRowNum}`);
-
-    rowClassList.replace(currentClass, newClass);
-  }
-
   configureCea608Captions(player: PlayerAPI, uimanager: UIInstanceManager): void {
-    // The calculated font size
+    /** The calculated row height in px */
+    let rowHeight = 0;
+    /** The calculated font size in px */
     let fontSize = 0;
-    // The required letter spacing spread the text characters evenly across the grid
+    /**
+     * The ratio of the font size of 100% to the row height.
+     * e.g. font size 100% fills up 75% of the available row height
+     */
+    const fontSize100PercentRatio = 0.75;
+    /** The required letter spacing spread the text characters evenly across the grid */
     let fontLetterSpacing = 0;
-    // Flag telling if a font size calculation is required of if the current values are valid
-    let fontSizeCalculationRequired = true;
-    // Flag telling if the CEA-608 mode is enabled
+    /** The ratio of the caption window/row height that is used as margin so that the window encloses the caption */
+    const windowMarginRatio = 0.2;
+    /** The calculated window margin in px */
+    let windowMargin: number;
+    /** Flag telling if the CEA-608 rendering mode is currently enabled */
     this.cea608Enabled = false;
+    /** Track last known grid params to avoid unnecessary recalculations */
+    let lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
 
     const settingsManager = uimanager.getSubtitleSettingsManager();
-    const fontSizeFactorSettings = this.resolveFontSizeFactor(settingsManager.fontSize.value);
-    this.setFontSizeFactor(fontSizeFactorSettings);
+    if (settingsManager.fontSize.value != null) {
+      const fontSizeFactorSettings = this.resolveFontSizeFactor(settingsManager.fontSize.value);
+      this.setFontSizeFactor(fontSizeFactorSettings);
+    }
 
     settingsManager.fontSize.onChanged.subscribe((_sender, property) => {
       if (property.isSet()) {
@@ -317,10 +287,39 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       } else {
         this.setFontSizeFactor(1);
       }
-      updateCEA608FontSize();
+
+      if (this.cea608Enabled) {
+        this.ensureCea608GridSizeUpdated();
+      }
     });
 
-    const updateCEA608FontSize = () => {
+    this.onShow?.subscribe(() => {
+      // ensure CEA grid is updated whenever the overlay becomes visible
+      if (this.cea608Enabled) {
+        this.ensureCea608GridSizeUpdated();
+      }
+    });
+
+    this.ensureCea608GridSizeUpdated = () => {
+      const overlayElement = this.getDomElement();
+      const currentWidth = overlayElement.width();
+      const currentHeight = overlayElement.height();
+      const hasOverlaySizeChanged =
+        currentWidth !== lastCeaGridRecalculation.overlayWidth ||
+        currentHeight !== lastCeaGridRecalculation.overlayHeight;
+      const hasFontSizeFactorChanged = this.cea608FontSizeFactor !== lastCeaGridRecalculation.fontSizeFactor;
+
+      if (!hasOverlaySizeChanged && !hasFontSizeFactorChanged) {
+        // none of the input variables changed, no need to recalculate
+        return;
+      }
+
+      lastCeaGridRecalculation = {
+        overlayWidth: currentWidth,
+        overlayHeight: currentHeight,
+        fontSizeFactor: this.cea608FontSizeFactor,
+      };
+
       const dummyLabel = new SubtitleLabel({ text: 'X' });
       dummyLabel.getDomElement().css({
         // By using a large font size we do not need to use multiple letters and can get still an
@@ -333,8 +332,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       this.updateComponents();
       this.show();
 
-      const dummyLabelCharWidth = dummyLabel.getDomElement().width() * this.FONT_SIZE_FACTOR;
-      const dummyLabelCharHeight = dummyLabel.getDomElement().height() * this.FONT_SIZE_FACTOR;
+      const dummyLabelCharWidth = dummyLabel.getDomElement().width();
+      const dummyLabelCharHeight = dummyLabel.getDomElement().height();
       const fontSizeRatio = dummyLabelCharWidth / dummyLabelCharHeight;
 
       this.removeComponent(dummyLabel);
@@ -348,87 +347,81 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // layouting, but the actual reason could not be determined. Aiming for a target width - 1px would work in
       // most browsers, but Safari has a "quantized" font size rendering with huge steps in between so we need
       // to subtract some more pixels to avoid line breaks there as well.
-      const overlayElement = this.getDomElement();
-      const subtitleOverlayWidth = overlayElement.width() - 10;
-      const subtitleOverlayHeight = overlayElement.height();
+      const subtitleOverlayWidthUsableRatio = 1 - parseFloat(SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET) / 100;
+      const subtitleOverlayWidth = Math.floor(subtitleOverlayWidthUsableRatio * currentWidth) - 10;
+      const subtitleOverlayHeight = currentHeight;
 
       // The size ratio of the letter grid
       const fontGridSizeRatio =
-        (dummyLabelCharWidth * this.CEA608_NUM_COLUMNS) / (dummyLabelCharHeight * this.CEA608_NUM_ROWS);
+        (dummyLabelCharWidth * SubtitleOverlay.CEA608_NUM_COLUMNS) /
+        (dummyLabelCharHeight * SubtitleOverlay.CEA608_NUM_ROWS);
       // The size ratio of the available space for the grid
       const subtitleOverlaySizeRatio = subtitleOverlayWidth / subtitleOverlayHeight;
 
       if (subtitleOverlaySizeRatio > fontGridSizeRatio) {
         // When the available space is wider than the text grid, the font size is simply
         // determined by the height of the available space.
-        fontSize = subtitleOverlayHeight / this.CEA608_NUM_ROWS;
-
+        rowHeight = subtitleOverlayHeight / SubtitleOverlay.CEA608_NUM_ROWS;
+        const fontSize100Percent = rowHeight * (1 - windowMarginRatio) * fontSize100PercentRatio;
+        fontSize = fontSize100Percent * this.cea608FontSizeFactor;
         // Calculate the additional letter spacing required to evenly spread the text across the grid's width
-        const gridSlotWidth = subtitleOverlayWidth / this.CEA608_NUM_COLUMNS;
+        const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
         const fontCharWidth = fontSize * fontSizeRatio;
         fontLetterSpacing = Math.max(gridSlotWidth - fontCharWidth, 0);
       } else {
         // When the available space is not wide enough, texts would vertically overlap if we take
         // the height as a base for the font size, so we need to limit the height. We do that
         // by determining the font size by the width of the available space.
-        fontSize = subtitleOverlayWidth / this.CEA608_NUM_COLUMNS / fontSizeRatio;
+        rowHeight = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS / fontSizeRatio;
+        const fontSize100Percent = rowHeight * (1 - windowMarginRatio) * fontSize100PercentRatio;
+        fontSize = fontSize100Percent * this.cea608FontSizeFactor;
         fontLetterSpacing = 0;
       }
 
-      // After computing overlay dimensions:
-      const newRowHeight = fontSize;
-
-      // Update row position of regions
-      const regions = this.getComponents();
-      regions.forEach(r => {
-        if (r instanceof SubtitleRegionContainer) {
-          this.updateRegionRowPosition(r);
-        }
-      });
+      windowMargin = rowHeight * windowMarginRatio;
 
       // Update the CSS custom property on the overlay DOM element
       overlayElement.get().forEach(el => {
-        el.style.setProperty('--cea608-row-height', `${newRowHeight}px`);
+        el.style.setProperty('--cea608-row-height', `${rowHeight}px`);
       });
 
       // Update font-size of all active subtitle labels
       const updateLabel = (label: SubtitleLabel) => {
-        const isLargerFontSize = this.FONT_SIZE_FACTOR > 1;
         label.getDomElement().css({
           'font-size': `${fontSize}px`,
-          'line-height': `${fontSize}px`,
-          'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
-          'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
-          left: isLargerFontSize && '0%',
+          'line-height': `${rowHeight - windowMargin}px`,
+          'letter-spacing': `${fontLetterSpacing}px`,
         });
 
-        label.regionStyle = `line-height: ${fontSize}px;`;
+        label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
       };
 
-      for (const label of this.getComponents()) {
-        if (label instanceof SubtitleRegionContainer) {
-          label.getComponents().forEach((l: SubtitleLabel) => {
+      for (const childComponent of this.getComponents()) {
+        if (childComponent instanceof SubtitleRegionContainer) {
+          childComponent.getDomElement().css({
+            margin: `${windowMargin / 2}px`,
+            height: `${rowHeight}px`,
+          });
+
+          childComponent.getComponents().forEach((l: SubtitleLabel) => {
             updateLabel(l);
           });
         }
 
-        if (label instanceof SubtitleLabel) {
-          updateLabel(label);
+        if (childComponent instanceof SubtitleLabel) {
+          updateLabel(childComponent);
         }
       }
     };
 
     player.on(player.exports.PlayerEvent.PlayerResized, () => {
       if (this.cea608Enabled) {
-        updateCEA608FontSize();
-      } else {
-        fontSizeCalculationRequired = true;
+        this.ensureCea608GridSizeUpdated();
       }
     });
 
     this.preprocessLabelEventCallback.subscribe((event: SubtitleCueEvent, label: SubtitleLabel) => {
-      const isCEA608 = event.position != null;
-      if (!isCEA608) {
+      if (!isCea608SubtitleCue(event)) {
         // Skip all non-CEA608 cues
         return;
       }
@@ -436,28 +429,22 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       if (!this.cea608Enabled) {
         this.cea608Enabled = true;
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
-
-        // We conditionally update the font size by this flag here to avoid updating every time a subtitle
-        // is added into an empty overlay. Because we reset the overlay when all subtitles are gone, this
-        // would trigger an unnecessary update every time, but it's only required under certain conditions,
-        // e.g. after the player size has changed.
-        if (fontSizeCalculationRequired) {
-          updateCEA608FontSize();
-          fontSizeCalculationRequired = false;
-        }
       }
 
-      // We disable the grid and wrapping in case enlarged font size is used to prevent
-      // line and characters overflows
-      const isLargerFontSize = this.FONT_SIZE_FACTOR > 1;
+      let leftOffset = event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET + '%';
+      if (leftOffset === '0%') {
+        // ensure that a little of the window still shows for better readability
+        leftOffset = SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET;
+      }
+
       label.getDomElement().css({
-        left: `${isLargerFontSize ? 0 : event.position.column * this.CEA608_COLUMN_OFFSET}%`,
+        left: leftOffset,
         'font-size': `${fontSize}px`,
-        'letter-spacing': `${isLargerFontSize ? 0 : fontLetterSpacing}px`,
-        'white-space': `${isLargerFontSize ? 'nowrap' : 'normal'}`,
+        'letter-spacing': `${fontLetterSpacing}px`,
+        'line-height': `${rowHeight - windowMargin}px`,
       });
 
-      label.regionStyle = `line-height: ${fontSize}px;`;
+      label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
     });
 
     const reset = () => {
@@ -750,16 +737,14 @@ export class SubtitleRegionContainerManager {
 
       if (label.regionStyle) {
         regionContainer.getDomElement().attr('style', label.regionStyle);
-      } else if (label.vtt && !label.vtt.region) {
-        /**
-         * If there is no region present to wrap the Cue Box, the Cue box becomes the
-         * region itself. Therefore the positioning values have to come from the box.
-         */
-        regionContainer.getDomElement().css('position', 'static');
-      } else {
-        // getDomElement needs to be called at least once to ensure the component exists
-        regionContainer.getDomElement();
       }
+
+      if (label.vtt) {
+        regionContainer.getDomElement().css('position', 'static');
+      }
+
+      // getDomElement needs to be called at least once to ensure the component exists
+      regionContainer.getDomElement();
 
       for (const regionContainerId in this.subtitleRegionContainers) {
         this.subtitleOverlay.addComponent(this.subtitleRegionContainers[regionContainerId]);
@@ -848,4 +833,26 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
   public isEmpty(): boolean {
     return this.labelCount === 0;
   }
+}
+
+function isCea608SubtitleCue(cue: SubtitleCueEvent): boolean {
+  return cue.position != null;
+}
+
+function awaitTransitionEnd(domElement: DOM) {
+  const hasTransition = getComputedStyle(domElement.get(0)).transitionProperty !== 'none';
+
+  if (!hasTransition) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>(resolve => {
+    const transitionHandler = () => {
+      domElement.off('transitionend', transitionHandler);
+      domElement.off('transitioncancel', transitionHandler);
+      resolve();
+    };
+    domElement.on('transitionend', transitionHandler);
+    domElement.on('transitioncancel', transitionHandler);
+  });
 }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
The latest CEA caption rendering changes were missing in v4. This was due to wrongly resolved merge conflicts when forward porting them (probably happened in this PR: https://github.com/bitmovin/bitmovin-player-ui/pull/697).

_Use any of the CEA subtitle test patterns for manual testing and compare it with v3._

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
