### PR TITLE
don't stop propagation unless using component wants it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Removed
+
+- Button no longer calls stopPropagation on its click, focusin and focusout Events
+
 ## [4.4.0] - 2025-11-27
 
 ### Fixed

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -55,20 +55,6 @@ export interface ButtonConfig extends ComponentConfig {
    * Default: {@link ButtonStyle.Icon}
    */
   buttonStyle?: ButtonStyle;
-
-  /**
-   * Specifics wether the focusin and focusout event propagation should be stopped.
-   *
-   * Default: false
-   */
-  stopPropagationFocus?: boolean;
-
-  /**
-   * Specifics wether the click event propagation should be stopped.
-   *
-   * Default: false
-   */
-  stopPropagationClick?: boolean;
 }
 
 /**
@@ -146,16 +132,7 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
     // Listen for the click event on the button element and trigger the corresponding event on the button component
     buttonElement.on('click', e => {
       e.preventDefault();
-      if (this.config.stopPropagationClick) {
-        e.stopPropagation();
-      }
       this.onClickEvent();
-    });
-
-    buttonElement.on('focusin focusout', e => {
-      if (this.config.stopPropagationFocus) {
-        e.stopPropagation();
-      }
     });
 
     buttonElement.on('touchstart', e => {

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -146,7 +146,7 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
     // Listen for the click event on the button element and trigger the corresponding event on the button component
     buttonElement.on('click', e => {
       e.preventDefault();
-      if (this.config.stopPropagationFocus) {
+      if (this.config.stopPropagationClick) {
         e.stopPropagation();
       }
       this.onClickEvent();

--- a/src/ts/components/buttons/Button.ts
+++ b/src/ts/components/buttons/Button.ts
@@ -55,6 +55,20 @@ export interface ButtonConfig extends ComponentConfig {
    * Default: {@link ButtonStyle.Icon}
    */
   buttonStyle?: ButtonStyle;
+
+  /**
+   * Specifics wether the focusin and focusout event propagation should be stopped.
+   *
+   * Default: false
+   */
+  stopPropagationFocus?: boolean;
+
+  /**
+   * Specifics wether the click event propagation should be stopped.
+   *
+   * Default: false
+   */
+  stopPropagationClick?: boolean;
 }
 
 /**
@@ -132,12 +146,16 @@ export class Button<Config extends ButtonConfig> extends Component<Config> {
     // Listen for the click event on the button element and trigger the corresponding event on the button component
     buttonElement.on('click', e => {
       e.preventDefault();
-      e.stopPropagation();
+      if (this.config.stopPropagationFocus) {
+        e.stopPropagation();
+      }
       this.onClickEvent();
     });
 
     buttonElement.on('focusin focusout', e => {
-      e.stopPropagation();
+      if (this.config.stopPropagationFocus) {
+        e.stopPropagation();
+      }
     });
 
     buttonElement.on('touchstart', e => {


### PR DESCRIPTION
afaiu this change is only relevant for key-handling in [InteractiveSettingsPanelItem](https://github.com/bitmovin/bitmovin-player-ui/blob/75d84c8010f4430df49db0b9f5625082e0c13475/src/ts/components/settings/InteractiveSettingsPanelItem.ts#L43)

and i think this still works with this PR? if you can give me a case where it doesn't work, i will continue working on the PR. maybe look into blur/focus or see if we can pass the new stopPropagationFocus down to where it's needed.

## Description
stopping propagation on click and focusin/focusout should only happen if the parent component wants it.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
