### PR TITLE
Fix subtitle font size preference from local storage not restored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Incorrect sytnax of CSS `URL` functions, leading to problems with URLs containing special characters like `(` or `)`
 - Removed `aria-label` from `Icon` and subsequently fixed duplication of `Button`'s aria-label being duplicated into (optional) Icon
 - Incorrect CEA608 caption rendering
+- Subtitle font size preference from local storage is not restored upon UI initialization
 
 ## [4.3.0] - 2025-11-05
 

--- a/src/ts/components/settings/subtitlesettings/FontSizeSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontSizeSelectBox.ts
@@ -56,12 +56,6 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    this.populateItemsWithFilter();
-
-    this.onShow.subscribe(() => {
-      this.populateItemsWithFilter();
-    });
-
     this.settingsManager.fontSize.onChanged.subscribe((sender, property) => {
       if (property.isSet()) {
         this.toggleOverlayClass('fontsize-' + property.value);
@@ -75,5 +69,12 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
     this.onItemSelected.subscribe((sender, key: string) => {
       this.settingsManager.fontSize.value = key;
     });
+
+    this.onShow.subscribe(() => {
+      this.populateItemsWithFilter();
+    });
+
+    // init
+    this.populateItemsWithFilter();
   }
 }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Follow up PR from #793 where additinoal changes were lost when forward porting changes to v4. This PR is forward porting the missing initial font size selection from: #730

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
