### PR TITLE
Update player version to fix type warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Button no longer calls stopPropagation on its click, focusin and focusout Events
 
+### Fixed
+
+- Type incompatibility warnings with Player version 8.235.0 and higher
+
 ## [4.4.0] - 2025-11-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmovin-player-ui",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -14,7 +14,7 @@
         "@types/jest": "^29.5.0",
         "@types/jsdom": "^21.1.0",
         "autoprefixer": "^10.4.21",
-        "bitmovin-player": "^8.129.0",
+        "bitmovin-player": "^8.237.0",
         "css-loader": "^7.1.2",
         "cssnano": "^7.1.1",
         "eslint": "^9.17.0",
@@ -4854,9 +4854,9 @@
       }
     },
     "node_modules/bitmovin-player": {
-      "version": "8.129.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.129.0.tgz",
-      "integrity": "sha512-4/bOVjPRa8MtJDeur1cWs2IjIOn5vg3NOwQMcEms6OwurjcPTPP7AWGahlPl6cPf1X7Y83ce5S+V4yfvoAfBQQ==",
+      "version": "8.237.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.237.0.tgz",
+      "integrity": "sha512-Pg9NJ7+qQHSkkrQk3mlqkeCdfdK1eT0uZJsf14oi3Hsdn3nXV+J+EG4QKVQr3whcOYDeQznOhlGJxyt0w+tEzw==",
       "dev": true
     },
     "node_modules/body-parser": {
@@ -22088,9 +22088,9 @@
       }
     },
     "bitmovin-player": {
-      "version": "8.129.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.129.0.tgz",
-      "integrity": "sha512-4/bOVjPRa8MtJDeur1cWs2IjIOn5vg3NOwQMcEms6OwurjcPTPP7AWGahlPl6cPf1X7Y83ce5S+V4yfvoAfBQQ==",
+      "version": "8.237.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.237.0.tgz",
+      "integrity": "sha512-Pg9NJ7+qQHSkkrQk3mlqkeCdfdK1eT0uZJsf14oi3Hsdn3nXV+J+EG4QKVQr3whcOYDeQznOhlGJxyt0w+tEzw==",
       "dev": true
     },
     "body-parser": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/jest": "^29.5.0",
     "@types/jsdom": "^21.1.0",
     "autoprefixer": "^10.4.21",
-    "bitmovin-player": "^8.129.0",
+    "bitmovin-player": "^8.237.0",
     "css-loader": "^7.1.2",
     "cssnano": "^7.1.1",
     "eslint": "^9.17.0",

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -30,9 +30,9 @@ export interface ViewModeAvailabilityChangedEvent extends PlayerEventBase {
 }
 
 export class PlayerEventEmitter {
-  private eventHandlers: { [eventType: string]: PlayerEventCallback[] } = {};
+  private eventHandlers: { [eventType: string]: PlayerEventCallback<PlayerEvent>[] } = {};
 
-  public on(eventType: PlayerEvent, callback: PlayerEventCallback) {
+  public on<T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>) {
     if (!this.eventHandlers[eventType]) {
       this.eventHandlers[eventType] = [];
     }
@@ -42,7 +42,7 @@ export class PlayerEventEmitter {
 
   public fireEvent<E extends PlayerEventBase>(event: E) {
     if (this.eventHandlers[event.type]) {
-      this.eventHandlers[event.type].forEach((callback: PlayerEventCallback) => callback(event));
+      this.eventHandlers[event.type].forEach(callback => callback(event));
     }
   }
 
@@ -75,6 +75,8 @@ export class PlayerEventEmitter {
       size: 1,
       duration: 1,
       isInit: false,
+      url: 'https://bitmovin.com/seg.m4s',
+      timeToFirstByte: 0.5,
     });
   }
 

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -911,7 +911,7 @@ export class PlayerWrapper {
   private player: PlayerAPI;
   private wrapper: WrappedPlayer;
 
-  private eventHandlers: { [eventType: string]: PlayerEventCallback[] } = {};
+  private eventHandlers: { [eventType: string]: PlayerEventCallback<PlayerEvent>[] } = {};
 
   constructor(player: PlayerAPI) {
     this.player = player;
@@ -973,7 +973,7 @@ export class PlayerWrapper {
     }
 
     // Explicitly add a wrapper method for 'on' that adds added event handlers to the event list
-    wrapper.on = (eventType: PlayerEvent, callback: PlayerEventCallback) => {
+    wrapper.on = <T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>) => {
       player.on(eventType, callback);
 
       if (!this.eventHandlers[eventType]) {
@@ -986,7 +986,7 @@ export class PlayerWrapper {
     };
 
     // Explicitly add a wrapper method for 'off' that removes removed event handlers from the event list
-    wrapper.off = (eventType: PlayerEvent, callback: PlayerEventCallback) => {
+    wrapper.off = <T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>) => {
       player.off(eventType, callback);
 
       if (this.eventHandlers[eventType]) {

--- a/src/ts/utils/MobileV3PlayerAPI.ts
+++ b/src/ts/utils/MobileV3PlayerAPI.ts
@@ -1,5 +1,6 @@
 import { PlayerAPI, PlayerEvent, PlayerEventBase, PlayerEventCallback } from 'bitmovin-player';
 import { WrappedPlayer } from '../UIManager';
+import type { PlayerEventMap } from 'bitmovin-player/types/core/Events';
 
 export enum MobileV3PlayerEvent {
   SourceError = 'sourceerror',
@@ -20,7 +21,8 @@ export interface MobileV3SourceErrorEvent extends PlayerEventBase {
 export type MobileV3PlayerEventType = PlayerEvent | MobileV3PlayerEvent;
 
 export interface MobileV3PlayerAPI extends PlayerAPI {
-  on(eventType: MobileV3PlayerEventType, callback: PlayerEventCallback): void;
+  on<T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>): void;
+  on<T extends MobileV3PlayerEvent>(eventType: T, callback: (event: PlayerEventBase) => void): void;
   exports: PlayerAPI['exports'] & { PlayerEvent: MobileV3PlayerEventType };
 }
 


### PR DESCRIPTION
## Description

Integrating the UI with a newer player version (8.235.0+) may result in warnings/errors logged by `tsc`, relating to incompatible interfaces. Specifically, the `PlayerEventCallback` type which was improved here: https://developer.bitmovin.com/playback/docs/release-notes-web#82350

Updating the Player to the latest version and adding generics to event map accesses to fix this.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
