### PR TITLE
Update player version to fix type warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Incorrect sytnax of CSS `URL` functions, leading to problems with URLs containing special characters like `(` or `)`
+- Type incompatibility warnings with Player version 8.235.0 and higher
 
 ## [3.103.1] - 2025-10-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "3.102.0",
+  "version": "3.103.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmovin-player-ui",
-      "version": "3.102.0",
+      "version": "3.103.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -14,7 +14,7 @@
         "@types/jest": "^29.5.0",
         "@types/jsdom": "^21.1.0",
         "autoprefixer": "^10.4.14",
-        "bitmovin-player": "^8.129.0",
+        "bitmovin-player": "^8.237.0",
         "browser-sync": "^2.29.0",
         "browserify": "^17.0.0",
         "cssnano": "^5.1.15",
@@ -5137,9 +5137,9 @@
       }
     },
     "node_modules/bitmovin-player": {
-      "version": "8.129.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.129.0.tgz",
-      "integrity": "sha512-4/bOVjPRa8MtJDeur1cWs2IjIOn5vg3NOwQMcEms6OwurjcPTPP7AWGahlPl6cPf1X7Y83ce5S+V4yfvoAfBQQ==",
+      "version": "8.237.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.237.0.tgz",
+      "integrity": "sha512-Pg9NJ7+qQHSkkrQk3mlqkeCdfdK1eT0uZJsf14oi3Hsdn3nXV+J+EG4QKVQr3whcOYDeQznOhlGJxyt0w+tEzw==",
       "dev": true
     },
     "node_modules/bl": {
@@ -26545,9 +26545,9 @@
       "dev": true
     },
     "bitmovin-player": {
-      "version": "8.129.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.129.0.tgz",
-      "integrity": "sha512-4/bOVjPRa8MtJDeur1cWs2IjIOn5vg3NOwQMcEms6OwurjcPTPP7AWGahlPl6cPf1X7Y83ce5S+V4yfvoAfBQQ==",
+      "version": "8.237.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.237.0.tgz",
+      "integrity": "sha512-Pg9NJ7+qQHSkkrQk3mlqkeCdfdK1eT0uZJsf14oi3Hsdn3nXV+J+EG4QKVQr3whcOYDeQznOhlGJxyt0w+tEzw==",
       "dev": true
     },
     "bl": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "^29.5.0",
     "@types/jsdom": "^21.1.0",
     "autoprefixer": "^10.4.14",
-    "bitmovin-player": "^8.129.0",
+    "bitmovin-player": "^8.237.0",
     "browser-sync": "^2.29.0",
     "browserify": "^17.0.0",
     "cssnano": "^5.1.15",

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -30,9 +30,9 @@ export interface ViewModeAvailabilityChangedEvent extends PlayerEventBase {
 }
 
 export class PlayerEventEmitter {
-  private eventHandlers: { [eventType: string]: PlayerEventCallback[]; } = {};
+  private eventHandlers: { [eventType: string]: PlayerEventCallback<PlayerEvent>[]; } = {};
 
-  public on(eventType: PlayerEvent, callback: PlayerEventCallback) {
+  public on<T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>) {
     if (!this.eventHandlers[eventType]) {
       this.eventHandlers[eventType] = [];
     }
@@ -42,7 +42,7 @@ export class PlayerEventEmitter {
 
   public fireEvent<E extends PlayerEventBase>(event: E) {
     if (this.eventHandlers[event.type]) {
-      this.eventHandlers[event.type].forEach((callback: PlayerEventCallback) => callback(event));
+      this.eventHandlers[event.type].forEach(callback => callback(event));
     }
   }
 
@@ -75,6 +75,8 @@ export class PlayerEventEmitter {
       size: 1,
       duration: 1,
       isInit: false,
+      url: 'https://bitmovin.com/seg.m4s',
+      timeToFirstByte: 0.5,
     });
   }
 

--- a/src/ts/mobilev3playerapi.ts
+++ b/src/ts/mobilev3playerapi.ts
@@ -20,7 +20,8 @@ export interface MobileV3SourceErrorEvent extends PlayerEventBase {
 export type MobileV3PlayerEventType = PlayerEvent | MobileV3PlayerEvent;
 
 export interface MobileV3PlayerAPI extends PlayerAPI {
-  on(eventType: MobileV3PlayerEventType, callback: PlayerEventCallback): void;
+  on<T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>): void;
+  on<T extends MobileV3PlayerEvent>(eventType: T, callback: (event: PlayerEventBase) => void): void;
   exports: PlayerAPI['exports'] & { PlayerEvent: MobileV3PlayerEventType };
 }
 

--- a/src/ts/uimanager.ts
+++ b/src/ts/uimanager.ts
@@ -859,7 +859,7 @@ export class PlayerWrapper {
   private player: PlayerAPI;
   private wrapper: WrappedPlayer;
 
-  private eventHandlers: { [eventType: string]: PlayerEventCallback[]; } = {};
+  private eventHandlers: { [eventType: string]: PlayerEventCallback<PlayerEvent>[]; } = {};
 
   constructor(player: PlayerAPI) {
     this.player = player;
@@ -921,7 +921,7 @@ export class PlayerWrapper {
     }
 
     // Explicitly add a wrapper method for 'on' that adds added event handlers to the event list
-    wrapper.on = (eventType: PlayerEvent, callback: PlayerEventCallback) => {
+    wrapper.on = <T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>) => {
       player.on(eventType, callback);
 
       if (!this.eventHandlers[eventType]) {
@@ -934,7 +934,7 @@ export class PlayerWrapper {
     };
 
     // Explicitly add a wrapper method for 'off' that removes removed event handlers from the event list
-    wrapper.off = (eventType: PlayerEvent, callback: PlayerEventCallback) => {
+    wrapper.off = <T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>) => {
       player.off(eventType, callback);
 
       if (this.eventHandlers[eventType]) {


### PR DESCRIPTION
## Description

**Backporting https://github.com/bitmovin/bitmovin-player-ui/pull/800 to UI v3:**

Integrating the UI with a newer player version (8.235.0+) may result in warnings/errors logged by `tsc`, relating to incompatible interfaces. Specifically, the `PlayerEventCallback` type which was improved here: https://developer.bitmovin.com/playback/docs/release-notes-web#82350

Updating the Player to the latest version and adding generics to event map accesses to fix this.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
