### PR TITLE
Fix of ads UI not shown 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Type incompatibility warnings with Player version 8.235.0 and higher
+- Ads UI variant not shown
 
 ## [4.4.0] - 2025-11-27
 

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -45,7 +45,7 @@ export class AdMessageLabel extends Label<LabelConfig> {
     super.configure(player, uimanager);
 
     const config = this.getConfig();
-    let text = config.text;
+    let text = config.text || '';
 
     const updateMessageHandler = () => {
       this.setText(StringUtils.replaceAdMessagePlaceholders(i18n.performLocalization(text), null, player));
@@ -53,7 +53,7 @@ export class AdMessageLabel extends Label<LabelConfig> {
 
     const adStartHandler = (event: AdEvent) => {
       const uiConfig = (event.ad as LinearAd).uiConfig;
-      text = uiConfig?.message || config.text;
+      text = uiConfig?.message || config.text || '';
 
       updateMessageHandler();
 


### PR DESCRIPTION
## Description
Ads UI not shown because of an uncaught exception if the configuration for the AdMessageLabel has no text

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
