### PR TITLE
Improve TimelineMarker handling in Live stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `SeekBarConfig.markerUpdateIntervalMs` to customize the update interval of the TimeLine markers in a live stream
 
 ### Fixed
-- Incorrect sytnax of CSS `URL` functions, leading to problems with URLs containing special characters like `(` or `)`
-- `TimlineMarkers` no longer move unexpected during time-shifting in a live stream
+- Incorrect syntax of CSS `URL` functions, leading to problems with URLs containing special characters like `(` or `)`
+- `TimelineMarker`s no longer move unexpected during time-shifting in a live stream
 
 ## [3.103.1] - 2025-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `SeekBarConfig.markerUpdateIntervalMs` to customize the update interval of the TimeLine markers in a live stream
 
 ### Fixed
-- `TimelineMarker`s no longer move unexpected during time-shifting in a live stream
+- `TimelineMarker`s move unexpectedly during time-shifting in a live stream
 
 ## [3.104.0] - 2025-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `SeekBarConfig.markerUpdateIntervalMs` to customize the update interval of the TimeLine markers in a live stream
+
 ### Fixed
 - Incorrect sytnax of CSS `URL` functions, leading to problems with URLs containing special characters like `(` or `)`
+- `TimlineMarkers` no longer move unexpected during time-shifting in a live stream
 
 ## [3.103.1] - 2025-10-07
 

--- a/src/scss/skin-modern/components/_seekbar.scss
+++ b/src/scss/skin-modern/components/_seekbar.scss
@@ -86,7 +86,6 @@ $seekbar-height: .3125em;
         background-color: $color-primary;
         height: 100%;
         text-align: center;
-        transition-duration: 1s;
         transition-property: transform;
         transition-timing-function: linear;
         width: $marker-width;

--- a/src/ts/components/seekbar.ts
+++ b/src/ts/components/seekbar.ts
@@ -57,6 +57,12 @@ export interface SeekBarConfig extends ComponentConfig {
   snappingRange?: number;
 
   /**
+   * The interval in milliseconds in which marker positions will be updated for live streams.
+   * Default: 1000
+   */
+  markerUpdateIntervalMs?: number;
+
+  /**
    * Used to enable/disable seek preview
    */
   enableSeekPreview?: boolean;
@@ -514,6 +520,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     const timelineMarkerConfig = {
       cssPrefix: this.config.cssPrefix,
       snappingRange: this.config.snappingRange,
+      markerUpdateIntervalMs: this.config.markerUpdateIntervalMs,
     };
     this.timelineMarkersHandler = new TimelineMarkersHandler(timelineMarkerConfig, () => this.seekBar.width(), this.seekBarMarkersContainer);
     this.timelineMarkersHandler.initialize(player, uimanager);

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -73,6 +73,7 @@ export class TimelineMarkersHandler {
       this.stopLiveMarkerUpdater();
       this.clearMarkers();
       this.isTimeShifting = false;
+      this.seekableRangeSnapshot = null;
 
       this.player.off(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
       this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -173,7 +173,7 @@ export class TimelineMarkersHandler {
 
           this.updateMarkerDOM(matchingMarker);
         } else {
-          const newMarker: SeekBarMarker = {marker, position: markerPosition, duration: markerDuration};
+          const newMarker: SeekBarMarker = { marker, position: markerPosition, duration: markerDuration };
           this.timelineMarkers.push(newMarker);
 
           this.createMarkerDOM(newMarker);

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -57,17 +57,17 @@ export class TimelineMarkersHandler {
   private configureMarkers(): void {
     const onTimeShift = () => {
       this.isTimeShifting = true;
-    }
+    };
 
     const onTimeShifted = () => {
       this.isTimeShifting = false;
-    }
+    };
 
     const onSeekPreview = (_: SeekBar, args: SeekPreviewEventArgs) => {
       if (args.scrubbing) {
         onTimeShift();
       }
-    }
+    };
 
     this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => {
       this.stopLiveMarkerUpdater();

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -1,11 +1,13 @@
-import { PlayerAPI } from 'bitmovin-player';
+import { PlayerAPI, TimeRange } from 'bitmovin-player';
 import { UIInstanceManager } from '../uimanager';
 import { DOM } from '../dom';
 import { ComponentConfig } from './component';
 import { TimelineMarker } from '../uiconfig';
-import { SeekBarMarker } from './seekbar';
+import { SeekBar, SeekBarMarker, SeekPreviewEventArgs } from './seekbar';
 import { PlayerUtils } from '../playerutils';
 import { Timeout } from '../timeout';
+
+const defaultMarkerUpdateIntervalMs = 1000;
 
 /**
  * @category Configs
@@ -15,6 +17,12 @@ export interface MarkersConfig extends ComponentConfig {
    * Used for seekBar marker snapping range percentage
    */
   snappingRange?: number;
+
+  /**
+   * The interval in milliseconds in which marker positions will be updated for live streams.
+   * Default: 1000
+   */
+  markerUpdateIntervalMs?: number;
 }
 
 export class TimelineMarkersHandler {
@@ -22,9 +30,16 @@ export class TimelineMarkersHandler {
   private timelineMarkers: SeekBarMarker[];
   private player: PlayerAPI;
   private uimanager: UIInstanceManager;
-  private pausedTimeshiftUpdater: Timeout;
+  private markerPositionUpdater: Timeout | null = null;
   private getSeekBarWidth: () => number;
   protected config: MarkersConfig;
+  private isTimeShifting: boolean = false;
+  // On some platforms, there are inconsistencies between the timeShift and currentTime values during time-shifting
+  // in a live stream. Those values are used to calculate a seekable-range during a live stream.
+  // To properly calculate the marker position, we rely on the seekable range of the DVR window.
+  // To work around the mentioned inconsistencies, we store the last known seekableRange and use
+  // it for marker position calculation during time-shifting/scrubbing.
+  private seekableRangeSnapshot: { start: number, end: number, timestampMs: number } | null = null;
 
   constructor(config: MarkersConfig, getSeekBarWidth: () => number, markersContainer: DOM) {
     this.config = config;
@@ -40,8 +55,30 @@ export class TimelineMarkersHandler {
   }
 
   private configureMarkers(): void {
-    // Remove markers when unloaded
-    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => this.clearMarkers());
+    const onTimeShift = () => {
+      this.isTimeShifting = true;
+    }
+
+    const onTimeShifted = () => {
+      this.isTimeShifting = false;
+    }
+
+    const onSeekPreview = (_: SeekBar, args: SeekPreviewEventArgs) => {
+      if (args.scrubbing) {
+        onTimeShift();
+      }
+    }
+
+    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => {
+      this.stopLiveMarkerUpdater();
+      this.clearMarkers();
+      this.isTimeShifting = false;
+
+      this.player.off(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
+      this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
+      this.uimanager.onSeekPreview.unsubscribe(onSeekPreview);
+    });
+
     this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, () => this.clearMarkers());
     this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers());
     // Update markers when the size of the seekbar changes
@@ -49,10 +86,11 @@ export class TimelineMarkersHandler {
 
     this.player.on(this.player.exports.PlayerEvent.SourceLoaded, () => {
       if (this.player.isLive()) {
-        // Update marker position as timeshift range changes
-        this.player.on(this.player.exports.PlayerEvent.TimeChanged, () => this.updateMarkers());
-        // Update marker postion when paused as timeshift range changes
-        this.configureLivePausedTimeshiftUpdater(() => this.updateMarkers());
+        this.player.on(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
+        this.player.on(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
+        this.uimanager.onSeekPreview.subscribe(onSeekPreview);
+
+        this.startLiveMarkerUpdater();
       }
     });
     this.uimanager.getConfig().events.onUpdated.subscribe(() => this.updateMarkers());
@@ -118,7 +156,11 @@ export class TimelineMarkersHandler {
     this.filterRemovedMarkers();
 
     this.uimanager.getConfig().metadata.markers.forEach(marker => {
-      const { markerPosition, markerDuration } = getMarkerPositions(this.player, marker);
+      const { markerPosition, markerDuration } = getMarkerPositions(
+        this.player,
+        this.getSeekableRangeRespectingSnapshot(),
+        marker,
+      );
 
       if (shouldRemoveMarker(markerPosition, markerDuration)) {
         this.removeMarkerFromConfig(marker);
@@ -131,7 +173,7 @@ export class TimelineMarkersHandler {
 
           this.updateMarkerDOM(matchingMarker);
         } else {
-          const newMarker: SeekBarMarker = { marker, position: markerPosition, duration: markerDuration };
+          const newMarker: SeekBarMarker = {marker, position: markerPosition, duration: markerDuration};
           this.timelineMarkers.push(newMarker);
 
           this.createMarkerDOM(newMarker);
@@ -140,13 +182,23 @@ export class TimelineMarkersHandler {
     });
   }
 
-  private getMarkerCssProperties(marker: SeekBarMarker): { [propertyName: string]: string } {
+  private getMarkerCssProperties(
+    marker: SeekBarMarker,
+    includeTransition: boolean = true
+  ): { [propertyName: string]: string } {
     const seekBarWidthPx = this.getSeekBarWidth();
 
     const positionInPx = (seekBarWidthPx / 100) * (marker.position < 0 ? 0 : marker.position);
     const cssProperties: { [propertyName: string]: string } = {
       'transform': `translateX(${positionInPx}px)`,
     };
+
+    if (includeTransition) {
+      const updateIntervalMs = this.config.markerUpdateIntervalMs || defaultMarkerUpdateIntervalMs;
+      cssProperties['transition-duration'] = `${updateIntervalMs}ms`;
+    } else {
+      cssProperties['transition'] = 'none';
+    }
 
     if (marker.duration > 0) {
       const markerWidthPx = Math.round(seekBarWidthPx / 100 * marker.duration);
@@ -157,7 +209,9 @@ export class TimelineMarkersHandler {
   }
 
   private updateMarkerDOM(marker: SeekBarMarker): void {
-    marker.element.css(this.getMarkerCssProperties(marker));
+    // Removing the 'transition: none' value from the initial creation when updating the marker position.
+    marker.element.removeCss('transition');
+    marker.element.css(this.getMarkerCssProperties(marker, true));
   }
 
   private createMarkerDOM(marker: SeekBarMarker): void {
@@ -168,7 +222,10 @@ export class TimelineMarkersHandler {
       'class': markerClasses.join(' '),
       'data-marker-time': String(marker.marker.time),
       'data-marker-title': String(marker.marker.title),
-    }).css(this.getMarkerCssProperties(marker));
+    })
+    // We do not want to animate the initial creation of a marker to prevent a 'fly in' animation.
+    // Only updating the marker position will be animated.
+    .css(this.getMarkerCssProperties(marker, false));
 
     if (marker.marker.imageUrl) {
       const removeImage = () => {
@@ -197,32 +254,68 @@ export class TimelineMarkersHandler {
     });
   }
 
-  private configureLivePausedTimeshiftUpdater(
-    handler: () => void,
-  ): void {
-    // Regularly update the marker position while the timeout is active
-    this.pausedTimeshiftUpdater = new Timeout(1000, handler, true);
-
-    this.player.on(this.player.exports.PlayerEvent.Paused, () => {
-      if (this.player.isLive() && this.player.getMaxTimeShift() < 0) {
-        this.pausedTimeshiftUpdater.start();
-      }
-    });
-
-    // Stop updater when playback continues (no matter if the updater was started before)
-    this.player.on(this.player.exports.PlayerEvent.Play, () => this.pausedTimeshiftUpdater.clear());
-    this.player.on(this.player.exports.PlayerEvent.Destroy, () => this.pausedTimeshiftUpdater.clear());
-  }
-
   protected prefixCss(cssClassOrId: string): string {
     return this.config.cssPrefix + '-' + cssClassOrId;
   }
+
+  private startLiveMarkerUpdater(): void {
+    const updateIntervalMs = this.config.markerUpdateIntervalMs || defaultMarkerUpdateIntervalMs;
+
+    this.stopLiveMarkerUpdater();
+    this.captureSeekableRangeSnapshot();
+
+    this.markerPositionUpdater = new Timeout(updateIntervalMs, () => {
+      if (!this.isTimeShifting) {
+        this.captureSeekableRangeSnapshot();
+      }
+
+      this.updateMarkers();
+    }, true);
+
+    this.markerPositionUpdater.start();
+  }
+
+  private stopLiveMarkerUpdater(): void {
+    if (this.markerPositionUpdater) {
+      this.markerPositionUpdater.clear();
+      this.markerPositionUpdater = null;
+    }
+  }
+
+  private captureSeekableRangeSnapshot(): void {
+    const seekableRange = PlayerUtils.getSeekableRangeRespectingLive(this.player);
+
+    this.seekableRangeSnapshot = {
+      start: seekableRange.start,
+      end: seekableRange.end,
+      timestampMs: Date.now(),
+    };
+  }
+
+  private getSeekableRangeRespectingSnapshot(): TimeRange {
+    const seekableRange = PlayerUtils.getSeekableRangeRespectingLive(this.player);
+
+    if (!this.player.isLive()) {
+      return seekableRange;
+    }
+
+    if (this.isTimeShifting && this.seekableRangeSnapshot) {
+      // Interpolate the last snapshot so the sliding DVR window keeps moving while time-shifting.
+      const elapsedSeconds = (Date.now() - this.seekableRangeSnapshot.timestampMs) / 1000;
+      return {
+        start: this.seekableRangeSnapshot.start + elapsedSeconds,
+        end: this.seekableRangeSnapshot.end + elapsedSeconds,
+      };
+    }
+
+    return seekableRange;
+  }
 }
 
-function getMarkerPositions(player: PlayerAPI, marker: TimelineMarker) {
-  const duration = getDuration(player);
+function getMarkerPositions(player: PlayerAPI, seekableRange: TimeRange, marker: TimelineMarker) {
+  const duration = getDuration(player, seekableRange);
 
-  const markerPosition = 100 / duration * getMarkerTime(marker, player, duration); // convert absolute time to percentage
+  const markerPosition = 100 / duration * getMarkerTime(marker, player, duration, seekableRange); // convert absolute time to percentage
   let markerDuration = 100 / duration * marker.duration;
 
   if (markerPosition < 0 && !isNaN(markerDuration)) {
@@ -238,19 +331,19 @@ function getMarkerPositions(player: PlayerAPI, marker: TimelineMarker) {
   return { markerDuration, markerPosition };
 }
 
-function getMarkerTime(marker: TimelineMarker, player: PlayerAPI, duration: number): number {
+function getMarkerTime(marker: TimelineMarker, player: PlayerAPI, duration: number, seekableRange: TimeRange): number {
   if (!player.isLive()) {
     return marker.time;
   }
 
-  return duration - (PlayerUtils.getSeekableRangeRespectingLive(player).end - marker.time);
+  return duration - (seekableRange.end - marker.time);
 }
 
-function getDuration(player: PlayerAPI): number {
+function getDuration(player: PlayerAPI, seekableRange: TimeRange): number {
   if (!player.isLive()) {
     return player.getDuration();
   }
-  const { start, end } = PlayerUtils.getSeekableRangeRespectingLive(player);
+  const { start, end } = seekableRange;
 
   return end - start;
 }


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
When using `TimelineMarkers` in a live stream, there were some unexpected behaviours observed on certain Player platforms. In particular, on Android, a problem was observed where the timeline markers were 'moving' during seeking (see video below). The root cause is a combination of an inconsistent `timeShift` and `currentTime` value reported by the Player and our animation for the timeline markers.

https://github.com/user-attachments/assets/6e529b6d-2ab7-4e69-b556-417d977578e4

On Android, during seeking the `timeShift` value and the `currentTime` values are not updated on the same 'update tick'. This results in an inconsistent seekable range calculation, which is the foundation for the marker positioning calculation. The seekable range needs to be calculated dynamically as no player provides it for live streams.

### Changes
This PR does not fix the root cause just mitigates the problem by addressing the symptom. This was done by caching the seekable range within the UI and using it during `timeShift` operations instead of always calculating it on the fly. In addition, we interpolate the seekable range to have a consistent 'moving' DVR window.

https://github.com/user-attachments/assets/bb2c7636-190f-4eca-b636-6f882d0b0e3b

Additional Changes:
- Migrated from using the `TimeChanged` event to a Timeout to periodically update the timers with a given update interval. This was done as the Timeout was already needed when being paused, to properly slide the Markers.
  - The mentioned update interval is configurable now. This was done as someone might want to update the interval depending on the DVR window length.

_This will also be forward ported to v4_

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
