### PR TITLE
Forward port: Improve TimelineMarker handling in Live stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - The `TimelineMarkers` implementation was improved to fix the following problems:
-  - Duplicate `TimlineMarkers` after resizing the window
+  - Duplicate `TimelineMarkers` after resizing the window
   - `TimelineMarker`s no longer animate to its initial position after loading a Source
   - `TimelineMarker`s no longer move unexpected during time-shifting in a live stream
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- The `TimelineMarkers` implementation was improved to fix the following problems:
+  - Duplicate `TimlineMarkers` after resizing the window
+  - `TimelineMarker`s no longer animate to its initial position after loading a Source
+  - `TimelineMarker`s no longer move unexpected during time-shifting in a live stream
+
 ## [4.5.0] - 2025-12-10
 
 ### Added

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -15,6 +15,7 @@ export namespace MockHelper {
   export function getEventDispatcherMock() {
     return {
       subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
       subscribeRateLimited: jest.fn(),
       dispatch: jest.fn(),
     };
@@ -130,6 +131,7 @@ export namespace MockHelper {
         // Event faker
         eventEmitter: eventHelper,
         on: eventHelper.on.bind(eventHelper),
+        off: jest.fn(),
       };
     });
 

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -488,7 +488,7 @@ export class SeekBar extends Component<SeekBarConfig> {
         this.show();
       }
       playbackPositionHandler(null, true);
-      this.refreshLayout();
+      this.refreshPlaybackPosition();
     };
     const liveStreamDetector = new PlayerUtils.LiveStreamDetector(player, uimanager);
     liveStreamDetector.onLiveChanged.subscribe((sender, args: LiveStreamDetectorEventArgs) => {
@@ -513,17 +513,17 @@ export class SeekBar extends Component<SeekBarConfig> {
     // Refresh the playback position when the player resized or the UI is configured. The playback position marker
     // is positioned absolutely and must therefore be updated when the size of the seekbar changes.
     player.on(player.exports.PlayerEvent.PlayerResized, () => {
-      this.refreshLayout();
+      this.refreshPlaybackPosition();
       this.uiBoundingRect = this.uiManager.getUI().getDomElement().get(0).getBoundingClientRect();
     });
     // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
     // resulting in a wrong initial position of the marker. Refreshing it once the UI is configured solved this issue.
     uimanager.onConfigured.subscribe(() => {
-      this.refreshLayout();
+      this.refreshPlaybackPosition();
     });
     // It can also happen when a new source is loaded
     player.on(player.exports.PlayerEvent.SourceLoaded, () => {
-      this.refreshLayout();
+      this.refreshPlaybackPosition();
     });
     // Add markers when a source is loaded or update when a marker is added or removed
     uimanager.getConfig().events.onUpdated.subscribe(() => {
@@ -1030,24 +1030,6 @@ export class SeekBar extends Component<SeekBarConfig> {
   }
 
   /**
-   * Refreshes the layout of the seek bar.
-   *
-   * This includes:
-   * - Re-positioning the playback marker
-   * - Reinitializing timeline markers
-   *
-   * Should be called after UI resizes or layout-affecting events like showing the component.
-   * Subclasses may override this if they introduce custom layout logic.
-   */
-  protected refreshLayout(): void {
-    this.refreshPlaybackPosition();
-
-    if (this.player && this.uiManager) {
-      this.initializeTimelineMarkers(this.player, this.uiManager);
-    }
-  }
-
-  /**
    * Sets the position until which media is buffered.
    * @param percent a number between 0 and 100
    */
@@ -1231,14 +1213,12 @@ export class SeekBar extends Component<SeekBarConfig> {
   protected onShowEvent(): void {
     super.onShowEvent();
 
-    // Refresh the layout when the seek bar becomes visible.
-    // To correctly position the playback marker and timeline markers,
-    // the DOM element must be fully initialized and have its size calculated,
-    // as their positions are based on absolute values derived from the element's dimensions.
-    // When hidden (e.g., via `display: none`), these dimensions are not available.
-    // By refreshing the layout here in `onShow`, we ensure the component knows its size
-    // and can place the playback and timeline markers accurately.
-    this.refreshLayout();
+    // Refresh the position of the playback position when the seek bar becomes visible. To correctly set the position,
+    // the DOM element must be fully initialized an have its size calculated, because the position is set as an absolute
+    // value calculated from the size. This required size is not known when it is hidden.
+    // For such cases, we refresh the position here in onShow because here it is guaranteed that the component knows
+    // its size and can set the position correctly.
+    this.refreshPlaybackPosition();
   }
 
   /**

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -1214,8 +1214,8 @@ export class SeekBar extends Component<SeekBarConfig> {
     super.onShowEvent();
 
     // Refresh the position of the playback position when the seek bar becomes visible. To correctly set the position,
-    // the DOM element must be fully initialized an have its size calculated, because the position is set as an absolute
-    // value calculated from the size. This required size is not known when it is hidden.
+    // the DOM element must be fully initialized and have its size calculated, because the position is set as an
+    // absolute value calculated from the size. This required size is not known when it is hidden.
     // For such cases, we refresh the position here in onShow because here it is guaranteed that the component knows
     // its size and can set the position correctly.
     this.refreshPlaybackPosition();

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -6,6 +6,7 @@ import { TimelineMarker } from '../UIConfig';
 import { SeekBar, SeekBarMarker, SeekPreviewEventArgs } from '../components/seekbar/SeekBar';
 import { PlayerUtils } from './PlayerUtils';
 import { Timeout } from './Timeout';
+import { prefixCss } from '../components/DummyComponent';
 
 const defaultMarkerUpdateIntervalMs = 1000;
 
@@ -242,14 +243,14 @@ export class TimelineMarkersHandler {
   private createMarkerDOM(marker: SeekBarMarker): void {
     const markerClasses = ['seekbar-marker']
       .concat(marker.marker.cssClasses || [])
-      .map(cssClass => this.prefixCss(cssClass));
+      .map(cssClass => prefixCss(cssClass));
 
     const markerStartIndicator = new DOM('div', {
-      class: this.prefixCss('seekbar-marker-indicator'),
+      class: prefixCss('seekbar-marker-indicator'),
     });
 
     const markerEndIndicator = new DOM('div', {
-      class: this.prefixCss('seekbar-marker-indicator'),
+      class: prefixCss('seekbar-marker-indicator'),
     });
 
     const markerElement = new DOM('div', {
@@ -267,7 +268,7 @@ export class TimelineMarkersHandler {
       };
 
       const imageElement = new DOM('img', {
-        class: this.prefixCss('seekbar-marker-image'),
+        class: prefixCss('seekbar-marker-image'),
         src: marker.marker.imageUrl,
       }).on('error', removeImage);
 
@@ -292,10 +293,6 @@ export class TimelineMarkersHandler {
         this.createMarkerDOM(marker);
       }
     });
-  }
-
-  protected prefixCss(cssClassOrId: string): string {
-    return this.config.cssPrefix + '-' + cssClassOrId;
   }
 
   private startLiveMarkerUpdater(): void {

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -74,6 +74,7 @@ export class TimelineMarkersHandler {
       this.stopLiveMarkerUpdater();
       this.clearMarkers();
       this.isTimeShifting = false;
+      this.seekableRangeSnapshot = null;
 
       this.player.off(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
       this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -81,21 +81,35 @@ export class TimelineMarkersHandler {
 
     this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, () => this.clearMarkers());
     this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers());
-    // Update markers when the size of the seekbar changes
-    this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkersDOM());
 
-    this.player.on(this.player.exports.PlayerEvent.SourceLoaded, () => {
-      if (this.player.isLive()) {
-        // Update marker position as timeshift range changes
-        this.player.on(this.player.exports.PlayerEvent.TimeChanged, () => this.updateMarkers());
-        // Update marker postion when paused as timeshift range changes
-        this.configureLivePausedTimeshiftUpdater(() => this.updateMarkers());
+    const liveStreamDetector = new PlayerUtils.LiveStreamDetector(this.player, this.uimanager);
+    liveStreamDetector.onLiveChanged.subscribe((sender, args: PlayerUtils.LiveStreamDetectorEventArgs) => {
+      if (args.live) {
+        this.player.on(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
+        this.player.on(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
+        this.uimanager.onSeekPreview.subscribe(onSeekPreview);
+
+        this.startLiveMarkerUpdater();
       }
     });
+    liveStreamDetector.detect(); // Initial detection
+
     this.uimanager.getConfig().events.onUpdated.subscribe(() => this.updateMarkers());
     this.uimanager.onRelease.subscribe(() =>
       this.uimanager.getConfig().events.onUpdated.unsubscribe(() => this.updateMarkers()),
     );
+
+    // Refresh the playback position when the player resized or the UI is configured. The playback position marker
+    // is positioned absolutely and must therefore be updated when the size of the seekbar changes.
+    this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkersDOM());
+    // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
+    // resulting in a wrong initial position of the marker. Refreshing it once the UI is configured solved this issue.
+    this.uimanager.onConfigured.subscribe(() => {
+      this.updateMarkers();
+    });
+    this.player.on(this.player.exports.PlayerEvent.SourceLoaded, () => {
+      this.updateMarkers();
+    });
 
     // Init markers at startup
     this.updateMarkers();
@@ -152,6 +166,13 @@ export class TimelineMarkersHandler {
   }
 
   private updateMarkers(): void {
+    const seekBarWidth = this.getSeekBarWidth();
+    if (seekBarWidth === 0) {
+      // Skip marker update when the seekBarWidth is not yet available.
+      // Will be updated by PlayerResized/onConfigured events once dimensions are available.
+      return;
+    }
+
     if (!shouldProcessMarkers(this.player, this.uimanager)) {
       this.clearMarkers();
       return;

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -1,11 +1,13 @@
-import { PlayerAPI } from 'bitmovin-player';
+import { PlayerAPI, TimeRange } from 'bitmovin-player';
 import { UIInstanceManager } from '../UIManager';
 import { DOM } from '../DOM';
 import { ComponentConfig } from '../components/Component';
 import { TimelineMarker } from '../UIConfig';
-import { SeekBarMarker } from '../components/seekbar/SeekBar';
+import { SeekBar, SeekBarMarker, SeekPreviewEventArgs } from '../components/seekbar/SeekBar';
 import { PlayerUtils } from './PlayerUtils';
 import { Timeout } from './Timeout';
+
+const defaultMarkerUpdateIntervalMs = 1000;
 
 /**
  * @category Configs
@@ -15,6 +17,12 @@ export interface MarkersConfig extends ComponentConfig {
    * Used for seekBar marker snapping range percentage
    */
   snappingRange?: number;
+
+  /**
+   * The interval in milliseconds in which marker positions will be updated for live streams.
+   * Default: 1000
+   */
+  markerUpdateIntervalMs?: number;
 }
 
 export class TimelineMarkersHandler {
@@ -22,9 +30,16 @@ export class TimelineMarkersHandler {
   private timelineMarkers: SeekBarMarker[];
   private player: PlayerAPI;
   private uimanager: UIInstanceManager;
-  private pausedTimeshiftUpdater: Timeout;
+  private markerPositionUpdater: Timeout | null = null;
   private getSeekBarWidth: () => number;
   protected config: MarkersConfig;
+  private isTimeShifting: boolean = false;
+  // On some platforms, there are inconsistencies between the timeShift and currentTime values during time-shifting
+  // in a live stream. Those values are used to calculate a seekable-range during a live stream.
+  // To properly calculate the marker position, we rely on the seekable range of the DVR window.
+  // To work around the mentioned inconsistencies, we store the last known seekableRange and use
+  // it for marker position calculation during time-shifting/scrubbing.
+  private seekableRangeSnapshot: { start: number; end: number; timestampMs: number } | null = null;
 
   constructor(config: MarkersConfig, getSeekBarWidth: () => number, markersContainer: DOM) {
     this.config = config;
@@ -40,9 +55,30 @@ export class TimelineMarkersHandler {
   }
 
   private configureMarkers(): void {
-    this.clearMarkers();
-    // Remove markers when unloaded
-    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => this.clearMarkers());
+    const onTimeShift = () => {
+      this.isTimeShifting = true;
+    };
+
+    const onTimeShifted = () => {
+      this.isTimeShifting = false;
+    };
+
+    const onSeekPreview = (_: SeekBar, args: SeekPreviewEventArgs) => {
+      if (args.scrubbing) {
+        onTimeShift();
+      }
+    };
+
+    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => {
+      this.stopLiveMarkerUpdater();
+      this.clearMarkers();
+      this.isTimeShifting = false;
+
+      this.player.off(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
+      this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
+      this.uimanager.onSeekPreview.unsubscribe(onSeekPreview);
+    });
+
     this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, () => this.clearMarkers());
     this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers());
     // Update markers when the size of the seekbar changes
@@ -124,7 +160,11 @@ export class TimelineMarkersHandler {
     this.filterRemovedMarkers();
 
     this.uimanager.getConfig().metadata.markers.forEach(marker => {
-      const { markerPosition, markerDuration } = getMarkerPositions(this.player, marker);
+      const { markerPosition, markerDuration } = getMarkerPositions(
+        this.player,
+        this.getSeekableRangeRespectingSnapshot(),
+        marker,
+      );
 
       if (shouldRemoveMarker(markerPosition, markerDuration)) {
         this.removeMarkerFromConfig(marker);
@@ -146,13 +186,23 @@ export class TimelineMarkersHandler {
     });
   }
 
-  private getMarkerCssProperties(marker: SeekBarMarker): { [propertyName: string]: string } {
+  private getMarkerCssProperties(
+    marker: SeekBarMarker,
+    includeTransition: boolean = true,
+  ): { [propertyName: string]: string } {
     const seekBarWidthPx = this.getSeekBarWidth();
 
     const positionInPx = (seekBarWidthPx / 100) * (marker.position < 0 ? 0 : marker.position);
     const cssProperties: { [propertyName: string]: string } = {
       transform: `translateX(${positionInPx}px)`,
     };
+
+    if (includeTransition) {
+      const updateIntervalMs = this.config.markerUpdateIntervalMs || defaultMarkerUpdateIntervalMs;
+      cssProperties['transition-duration'] = `${updateIntervalMs}ms`;
+    } else {
+      cssProperties['transition'] = 'none';
+    }
 
     if (marker.duration > 0) {
       const markerWidthPx = Math.round((seekBarWidthPx / 100) * marker.duration);
@@ -163,7 +213,9 @@ export class TimelineMarkersHandler {
   }
 
   private updateMarkerDOM(marker: SeekBarMarker): void {
-    marker.element.css(this.getMarkerCssProperties(marker));
+    // Removing the 'transition: none' value from the initial creation when updating the marker position.
+    marker.element.removeCss('transition');
+    marker.element.css(this.getMarkerCssProperties(marker, true));
   }
 
   private createMarkerDOM(marker: SeekBarMarker): void {
@@ -183,7 +235,10 @@ export class TimelineMarkersHandler {
       class: markerClasses.join(' '),
       'data-marker-time': String(marker.marker.time),
       'data-marker-title': String(marker.marker.title),
-    }).css(this.getMarkerCssProperties(marker));
+    })
+      // We do not want to animate the initial creation of a marker to prevent a 'fly in' animation.
+      // Only updating the marker position will be animated.
+      .css(this.getMarkerCssProperties(marker, false));
 
     if (marker.marker.imageUrl) {
       const removeImage = () => {
@@ -218,30 +273,72 @@ export class TimelineMarkersHandler {
     });
   }
 
-  private configureLivePausedTimeshiftUpdater(handler: () => void): void {
-    // Regularly update the marker position while the timeout is active
-    this.pausedTimeshiftUpdater = new Timeout(1000, handler, true);
-
-    this.player.on(this.player.exports.PlayerEvent.Paused, () => {
-      if (this.player.isLive() && this.player.getMaxTimeShift() < 0) {
-        this.pausedTimeshiftUpdater.start();
-      }
-    });
-
-    // Stop updater when playback continues (no matter if the updater was started before)
-    this.player.on(this.player.exports.PlayerEvent.Play, () => this.pausedTimeshiftUpdater.clear());
-    this.player.on(this.player.exports.PlayerEvent.Destroy, () => this.pausedTimeshiftUpdater.clear());
-  }
-
   protected prefixCss(cssClassOrId: string): string {
     return this.config.cssPrefix + '-' + cssClassOrId;
   }
+
+  private startLiveMarkerUpdater(): void {
+    const updateIntervalMs = this.config.markerUpdateIntervalMs || defaultMarkerUpdateIntervalMs;
+
+    this.stopLiveMarkerUpdater();
+    this.captureSeekableRangeSnapshot();
+
+    this.markerPositionUpdater = new Timeout(
+      updateIntervalMs,
+      () => {
+        if (!this.isTimeShifting) {
+          this.captureSeekableRangeSnapshot();
+        }
+
+        this.updateMarkers();
+      },
+      true,
+    );
+
+    this.markerPositionUpdater.start();
+  }
+
+  private stopLiveMarkerUpdater(): void {
+    if (this.markerPositionUpdater) {
+      this.markerPositionUpdater.clear();
+      this.markerPositionUpdater = null;
+    }
+  }
+
+  private captureSeekableRangeSnapshot(): void {
+    const seekableRange = PlayerUtils.getSeekableRangeRespectingLive(this.player);
+
+    this.seekableRangeSnapshot = {
+      start: seekableRange.start,
+      end: seekableRange.end,
+      timestampMs: Date.now(),
+    };
+  }
+
+  private getSeekableRangeRespectingSnapshot(): TimeRange {
+    const seekableRange = PlayerUtils.getSeekableRangeRespectingLive(this.player);
+
+    if (!this.player.isLive()) {
+      return seekableRange;
+    }
+
+    if (this.isTimeShifting && this.seekableRangeSnapshot) {
+      // Interpolate the last snapshot so the sliding DVR window keeps moving while time-shifting.
+      const elapsedSeconds = (Date.now() - this.seekableRangeSnapshot.timestampMs) / 1000;
+      return {
+        start: this.seekableRangeSnapshot.start + elapsedSeconds,
+        end: this.seekableRangeSnapshot.end + elapsedSeconds,
+      };
+    }
+
+    return seekableRange;
+  }
 }
 
-function getMarkerPositions(player: PlayerAPI, marker: TimelineMarker) {
-  const duration = getDuration(player);
+function getMarkerPositions(player: PlayerAPI, seekableRange: TimeRange, marker: TimelineMarker) {
+  const duration = getDuration(player, seekableRange);
 
-  const markerPosition = (100 / duration) * getMarkerTime(marker, player, duration); // convert absolute time to percentage
+  const markerPosition = (100 / duration) * getMarkerTime(marker, player, duration, seekableRange); // convert absolute time to percentage
   let markerDuration = (100 / duration) * marker.duration;
 
   if (markerPosition < 0 && !isNaN(markerDuration)) {
@@ -257,19 +354,19 @@ function getMarkerPositions(player: PlayerAPI, marker: TimelineMarker) {
   return { markerDuration, markerPosition };
 }
 
-function getMarkerTime(marker: TimelineMarker, player: PlayerAPI, duration: number): number {
+function getMarkerTime(marker: TimelineMarker, player: PlayerAPI, duration: number, seekableRange: TimeRange): number {
   if (!player.isLive()) {
     return marker.time;
   }
 
-  return duration - (PlayerUtils.getSeekableRangeRespectingLive(player).end - marker.time);
+  return duration - (seekableRange.end - marker.time);
 }
 
-function getDuration(player: PlayerAPI): number {
+function getDuration(player: PlayerAPI, seekableRange: TimeRange): number {
   if (!player.isLive()) {
     return player.getDuration();
   }
-  const { start, end } = PlayerUtils.getSeekableRangeRespectingLive(player);
+  const { start, end } = seekableRange;
 
   return end - start;
 }

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -100,8 +100,8 @@ export class TimelineMarkersHandler {
       this.uimanager.getConfig().events.onUpdated.unsubscribe(() => this.updateMarkers()),
     );
 
-    // Refresh the playback position when the player resized or the UI is configured. The playback position marker
-    // is positioned absolutely and must therefore be updated when the size of the seekbar changes.
+    // Refresh timeline markers when the player is resized or the UI is configured. Timeline markers
+    // are positioned absolutely and must therefore be updated when the size of the seekbar changes.
     this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkersDOM());
     // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
     // resulting in a wrong initial position of the marker. Refreshing it once the UI is configured solved this issue.

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -92,6 +92,11 @@ export class TimelineMarkersHandler {
         this.uimanager.onSeekPreview.subscribe(onSeekPreview);
 
         this.startLiveMarkerUpdater();
+      } else {
+        this.stopLiveMarkerUpdater();
+        this.uimanager.onSeekPreview.unsubscribe(onSeekPreview);
+        this.player.off(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
+        this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
       }
     });
     liveStreamDetector.detect(); // Initial detection


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
_See #805 for a detailed problem description._

### Changed
Additional changes that were needed to make the forward port work:
- In v4 we introduce an additional `UIVariant` for the initial empty state. This causes the difference in initialization flow of the `SeekBar`. We resolve to the regular `UIVariant` from the `SourceLoaded` event resulting in the `SeekBar` and the `TimelineMarkersHandler` missing the event. While the SeekBar implementation can handle this, the `TimelineMarkersHandler` could not. To address this, the initialization flow of the TimelineMarkersHandler was adapted to match the `Seekbar` implementation:
  - Using the `LiveStreamDetector` instead of listening to the `SourceLoaded` event to have a proper initial detection if the source is already loaded
  - Reverting #718 and utilizing the `onConfigured` event to detect initial layouting
    - #718 addressed this initial layouting problem but not in the proper way. Before this PR, every layout change resulted in a new `TimelineMarkersHandler` instance resulting in many many duplicated markers.
    - The `onConfigured` exists for exactly such a use-case and is the same approach that the `SeekBar` uses.
- No `TimelineMarkers` are added unless we have a proper Seekbar width to prevent the initial 'fly-in animation' problem. This was triggered by initially rendering all markers at position 0 and updating them once the `SeekBar` width was available.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
