### PR TITLE
Commit `package-lock.json` on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           git config --global user.name 'Automated Release'
           git config --global user.email 'release-automation@bitmovin.com'
-          git add package.json CHANGELOG.md
+          git add package.json package-lock.json CHANGELOG.md
           git commit -m "[skip ci] Bump version to ${{ steps.version_number.outputs.version_number }}"
           git tag "${{ steps.version_number.outputs.tag_name }}"
           git push origin ${{ inputs.branch_name || github.ref_name }}


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
When bumping the version, the `package-lock.json` file is updated as well. We don't commit this file in the version bump, though.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **IMO not needed for hits change**
