### PR TITLE
Add option to use Shadow DOM rendering of the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `ShadowDomConfig` via `UIConfig.shadowDomConfig` to configure Shadow DOM rendering.
+  - Set `uiConfig = { shadowDomConfig: { enabled: true } }` to enable rendering the UI in a Shadow DOM.
+
 ## [4.5.0] - 2025-12-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "4.4.0",
+  "version": "4.6.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitmovin-player-ui",
-      "version": "4.4.0",
+      "version": "4.6.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-ui",
-  "version": "4.5.0",
+  "version": "4.6.0-beta.1",
   "description": "Bitmovin Player UI Framework",
   "main": "./dist/js/framework/main.js",
   "types": "./dist/js/framework/main.d.ts",

--- a/spec/components/settings/SelectBox.spec.ts
+++ b/spec/components/settings/SelectBox.spec.ts
@@ -209,6 +209,9 @@ describe('SelectBox', () => {
     beforeEach(() => {
       selectElement = { on: jest.fn(), off: jest.fn() } as unknown as DOM;
       selectBox['selectElement'] = selectElement;
+      selectBox['element'] = selectElement;
+
+      selectBox.configure(playerMock, uiManagerMock);
     });
 
     it('should remove existing close listeners', () => {
@@ -229,7 +232,7 @@ describe('SelectBox', () => {
     });
 
     it('should add close event listeners to the document', () => {
-      const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+      const addEventListenerSpy = jest.spyOn(uiManagerMock.uiWrapperElement, 'on');
 
       selectBox['addDropdownCloseListeners']();
 
@@ -259,11 +262,15 @@ describe('SelectBox', () => {
     beforeEach(() => {
       selectElement = { on: jest.fn(), off: jest.fn() } as unknown as DOM;
       selectBox['selectElement'] = selectElement;
+      selectBox['element'] = selectElement;
+
+      selectBox.configure(playerMock, uiManagerMock);
+
       selectBox['addDropdownCloseListeners']();
     });
 
     it('should remove close event listeners to the document', () => {
-      const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+      const removeEventListenerSpy = jest.spyOn(uiManagerMock.uiWrapperElement, 'off');
 
       selectBox['removeDropdownCloseListeners']();
 

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -49,6 +49,7 @@ export namespace MockHelper {
       onSeeked: getEventDispatcherMock(),
       onRelease: getEventDispatcherMock(),
       onComponentViewModeChanged: getEventDispatcherMock(),
+      uiWrapperElement: generateDOMMock(),
     }));
 
     return new UiInstanceManagerMockClass();
@@ -59,6 +60,7 @@ export namespace MockHelper {
       addClass: jest.fn(),
       removeClass: jest.fn(),
       on: jest.fn(),
+      off: jest.fn(),
       html: jest.fn(),
       css: jest.fn(),
       width: jest.fn(),

--- a/spec/utils/FocusVisibilityTracker.spec.ts
+++ b/spec/utils/FocusVisibilityTracker.spec.ts
@@ -1,5 +1,7 @@
 import { JSDOM } from 'jsdom';
 import { FocusVisibilityTracker } from '../../src/ts/utils/FocusVisibilityTracker';
+import { MockHelper } from '../helper/MockHelper';
+import { DOM } from '../../src/ts/DOM';
 
 describe('FocusVisibilityTracker', () => {
   const bitmovinUIPrefix = 'bmpui';
@@ -9,13 +11,15 @@ describe('FocusVisibilityTracker', () => {
   let uiButton: HTMLElement;
   let nonUiButton: HTMLElement;
   let tracker: FocusVisibilityTracker;
+  let uiWrapperElement: DOM;
 
   beforeEach(() => {
     const { window } = new JSDOM();
     global.document = window.document;
     uiButton = createAndAddButton(document, uiButtonId);
     nonUiButton = createAndAddButton(document, nonUiButtonId);
-    tracker = new FocusVisibilityTracker(bitmovinUIPrefix);
+    uiWrapperElement = new DOM(global.document);
+    tracker = new FocusVisibilityTracker(bitmovinUIPrefix, uiWrapperElement);
   });
 
   it('adds the focus-visible class on a UI button that gets focus w/o initial interaction', () => {
@@ -65,7 +69,7 @@ describe('FocusVisibilityTracker', () => {
   });
 
   it('removes event listeners upon release', () => {
-    const spy = jest.spyOn(global.document, 'removeEventListener');
+    const spy = jest.spyOn(uiWrapperElement, 'off');
     expect(spy).toHaveBeenCalledTimes(0);
 
     tracker.release();

--- a/spec/utils/ShadowDomManager.spec.ts
+++ b/spec/utils/ShadowDomManager.spec.ts
@@ -1,0 +1,93 @@
+import { ShadowDomManager } from '../../src/ts/utils/ShadowDomManager';
+import { ShadowDomConfig } from '../../src/ts/UIConfig';
+import { DOM } from '../../src/ts/DOM';
+
+describe('ShadowDomManager', () => {
+  const appendLink = (href: string) => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    document.head.appendChild(link);
+    return link;
+  };
+
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  describe('isShadowDomSupported', () => {
+    it('returns true when attachShadow is available', () => {
+      expect(ShadowDomManager.isShadowDomSupported()).toBe(true);
+    });
+
+    it('returns false and warns when Shadow DOM APIs are missing', () => {
+      const originalAttachShadow = (HTMLElement.prototype as any).attachShadow;
+      const originalShadowRoot = (global as any).ShadowRoot;
+      delete (HTMLElement.prototype as any).attachShadow;
+      (global as any).ShadowRoot = undefined;
+
+      expect(ShadowDomManager.isShadowDomSupported()).toBe(false);
+
+      if (originalAttachShadow) {
+        (HTMLElement.prototype as any).attachShadow = originalAttachShadow;
+      }
+      (global as any).ShadowRoot = originalShadowRoot;
+    });
+  });
+
+  describe('initialize', () => {
+    let manager: ShadowDomManager;
+    let container: DOM;
+
+    beforeEach(() => {
+      manager = new ShadowDomManager();
+      container = new DOM('div', {});
+      document.body.appendChild(container.get(0));
+    });
+
+    it('attaches a shadow root and injects main stylesheet by filename', () => {
+      appendLink('https://cdn.example.com/bitmovinplayer-ui.css');
+      const config: ShadowDomConfig = { enabled: true, uiStylesheetName: 'bitmovinplayer-ui' };
+
+      manager.initialize(container, config);
+
+      const shadowRoot = manager.getShadowRoot();
+      expect(shadowRoot).toBeDefined();
+      const links = shadowRoot.querySelectorAll('link[rel="stylesheet"]');
+      expect(links.length).toBe(1);
+      expect((links[0] as HTMLLinkElement).href).toContain('bitmovinplayer-ui');
+    });
+
+    it('injects additional stylesheets', () => {
+      appendLink('https://cdn.example.com/bitmovinplayer-ui.css');
+      const config: ShadowDomConfig = {
+        enabled: true,
+        uiStylesheetName: 'bitmovinplayer-ui',
+        additionalStylesheets: ['https://cdn.example.com/custom.css', 'other.css'],
+      };
+      appendLink('https://example.com/other.css');
+
+      manager.initialize(container, config);
+
+      const links = manager.getShadowRoot().querySelectorAll('link[rel="stylesheet"]');
+      const hrefs = Array.from(links).map(link => (link as HTMLLinkElement).href);
+      expect(hrefs).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('bitmovinplayer-ui.css'),
+          'https://cdn.example.com/custom.css',
+          expect.stringContaining('other.css'),
+        ]),
+      );
+    });
+
+    it('releases host and shadow root', () => {
+      appendLink('https://cdn.example.com/bitmovinplayer-ui.css');
+      manager.initialize(container, { enabled: true, uiStylesheetName: 'bitmovinplayer-ui' });
+
+      manager.release();
+
+      expect(manager.getShadowRoot()).toBeUndefined();
+    });
+  });
+});

--- a/spec/utils/ShadowDomManager.spec.ts
+++ b/spec/utils/ShadowDomManager.spec.ts
@@ -46,7 +46,7 @@ describe('ShadowDomManager', () => {
 
     it('attaches a shadow root and injects main stylesheet by filename', () => {
       appendLink('https://cdn.example.com/bitmovinplayer-ui.css');
-      const config: ShadowDomConfig = { enabled: true, uiStylesheetName: 'bitmovinplayer-ui' };
+      const config: ShadowDomConfig = { enabled: true, uiStylesheet: 'bitmovinplayer-ui' };
 
       manager.initialize(container, config);
 
@@ -61,7 +61,7 @@ describe('ShadowDomManager', () => {
       appendLink('https://cdn.example.com/bitmovinplayer-ui.css');
       const config: ShadowDomConfig = {
         enabled: true,
-        uiStylesheetName: 'bitmovinplayer-ui',
+        uiStylesheet: 'bitmovinplayer-ui',
         additionalStylesheets: ['https://cdn.example.com/custom.css', 'other.css'],
       };
       appendLink('https://example.com/other.css');
@@ -81,7 +81,7 @@ describe('ShadowDomManager', () => {
 
     it('releases host and shadow root', () => {
       appendLink('https://cdn.example.com/bitmovinplayer-ui.css');
-      manager.initialize(container, { enabled: true, uiStylesheetName: 'bitmovinplayer-ui' });
+      manager.initialize(container, { enabled: true, uiStylesheet: 'bitmovinplayer-ui' });
 
       manager.release();
 

--- a/spec/utils/ShadowDomManager.spec.ts
+++ b/spec/utils/ShadowDomManager.spec.ts
@@ -29,9 +29,7 @@ describe('ShadowDomManager', () => {
 
       expect(ShadowDomManager.isShadowDomSupported()).toBe(false);
 
-      if (originalAttachShadow) {
-        (HTMLElement.prototype as any).attachShadow = originalAttachShadow;
-      }
+      (HTMLElement.prototype as any).attachShadow = originalAttachShadow;
       (global as any).ShadowRoot = originalShadowRoot;
     });
   });

--- a/src/ts/DOM.ts
+++ b/src/ts/DOM.ts
@@ -33,7 +33,7 @@ export interface HTMLElementWithComponent extends HTMLElement {
  * Built with the help of: http://youmightnotneedjquery.com/
  */
 export class DOM {
-  private document: Document;
+  private readonly documentOrShadowRoot: Document | ShadowRoot;
 
   /**
    * The list of elements that the instance wraps. Take care that not all methods can operate on the whole list,
@@ -68,13 +68,16 @@ export class DOM {
    * @param document the document to wrap
    */
   constructor(document: Document);
+  /**
+   * Wraps the ShadowRoot with a DOM instance. Useful to attach event listeners to the ShadowRoot.
+   * @param shadowRoot the ShadowRoot to wrap
+   */
+  constructor(shadowRoot: ShadowRoot);
   constructor(
-    something: string | HTMLElement | HTMLElement[] | Document,
+    something: string | HTMLElement | HTMLElement[] | Document | ShadowRoot,
     attributes?: { [name: string]: string },
     component?: Component<ComponentConfig>,
   ) {
-    this.document = document; // Set the global document to the local document field
-
     if (something instanceof Array) {
       if (something.length > 0 && something[0] instanceof HTMLElement) {
         const elements = something as HTMLElementWithComponent[];
@@ -83,10 +86,11 @@ export class DOM {
     } else if (something instanceof HTMLElement) {
       const element = something as HTMLElementWithComponent;
       this.elements = [element];
-    } else if (something instanceof Document) {
-      // When a document is passed in, we do not do anything with it, but by setting this.elements to null
-      // we give the event handling method a means to detect if the events should be registered on the document
-      // instead of elements.
+    } else if (something instanceof Document || something instanceof ShadowRoot) {
+      // When a document or the ShadowRoot is passed in, we do not do anything with it, but by setting
+      // this.elements to null we give the event handling method a means to detect if the events should be
+      // registered on the document or ShadowRoot instead of elements.
+      this.documentOrShadowRoot = something;
       this.elements = null;
     } else if (attributes) {
       const tagName = something;
@@ -154,7 +158,7 @@ export class DOM {
     });
   }
 
-  private findChildElementsOfElement(element: HTMLElement | Document, selector: string): HTMLElement[] {
+  private findChildElementsOfElement(element: HTMLElement | Document | ShadowRoot, selector: string): HTMLElement[] {
     const childElements = element.querySelectorAll(selector);
 
     // Convert NodeList to Array
@@ -343,13 +347,19 @@ export class DOM {
    * @returns {DOM}
    */
   append(...childElements: DOM[]): DOM {
-    this.forEach(element => {
+    const appendElements = (node: Node) => {
       childElements.forEach(childElement => {
         childElement.elements.forEach((_, index) => {
-          element.appendChild(childElement.elements[index]);
+          node.appendChild(childElement.elements[index]);
         });
       });
-    });
+    };
+
+    if (this.elements) {
+      this.forEach(element => appendElements(element));
+    } else {
+      appendElements(this.documentOrShadowRoot);
+    }
     return this;
   }
 
@@ -359,13 +369,19 @@ export class DOM {
    * @returns {DOM}
    */
   prepend(...childElements: DOM[]): DOM {
-    this.forEach(element => {
+    const insertElements = (node: Node) => {
       childElements.forEach(childElement => {
         childElement.elements.forEach((_, index) => {
-          element.insertBefore(childElement.elements[index], element.firstChild);
+          node.insertBefore(childElement.elements[index], node.firstChild);
         });
       });
-    });
+    };
+
+    if (this.elements) {
+      this.forEach(element => insertElements(element));
+    } else {
+      insertElements(this.documentOrShadowRoot);
+    }
     return this;
   }
 
@@ -373,12 +389,18 @@ export class DOM {
    * Removes all elements from the DOM.
    */
   remove(): void {
-    this.forEach(element => {
-      const parent = element.parentNode;
+    const removeElements = (node: Node) => {
+      const parent = node.parentNode;
       if (parent) {
-        parent.removeChild(element);
+        parent.removeChild(node);
       }
-    });
+    };
+
+    if (this.elements) {
+      this.forEach(element => removeElements(element));
+    } else {
+      removeElements(this.documentOrShadowRoot);
+    }
   }
 
   /**
@@ -451,7 +473,7 @@ export class DOM {
 
     events.forEach(event => {
       if (this.elements == null) {
-        this.document.addEventListener(event, eventHandler, options);
+        this.documentOrShadowRoot.addEventListener(event, eventHandler, options);
       } else {
         this.forEach(element => {
           element.addEventListener(event, eventHandler, options);
@@ -478,7 +500,7 @@ export class DOM {
 
     events.forEach(event => {
       if (this.elements == null) {
-        this.document.removeEventListener(event, eventHandler, options);
+        this.documentOrShadowRoot.removeEventListener(event, eventHandler, options);
       } else {
         this.forEach(element => {
           element.removeEventListener(event, eventHandler, options);

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -172,11 +172,12 @@ export interface UIConfig {
   /**
    * Configure Shadow DOM rendering.
    * Enable it with:
-   * `shadowDomConfig: { enabled: true }`
+   * `shadowDom: true`
+   * `shadowDom: { enabled: true }` (especially if you need to set more configuration options)
    *
-   * Default: undefined (Shadow DOM disabled).
+   * Default: false
    */
-  shadowDomConfig?: ShadowDomConfig;
+  shadowDom?: ShadowDomConfig | boolean;
 }
 
 export interface ShadowDomConfig {

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -175,6 +175,9 @@ export interface UIConfig {
    * `shadowDom: true`
    * `shadowDom: { enabled: true }` (especially if you need to set more configuration options)
    *
+   * Enable ShadowDom rendering to prevent CSS from an enclosing website to interfere with the UI styles. Check
+   * the availability here: https://caniuse.com/shadowdomv1.
+   *
    * Default: false
    */
   shadowDom?: ShadowDomConfig | boolean;

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -193,14 +193,16 @@ export interface ShadowDomConfig {
    */
   enabled: boolean;
   /**
-   * Filename of the UI stylesheet to inject into the Shadow DOM.
+   * Filename or URL of the UI stylesheet to inject into the Shadow DOM.
    *
-   * When the Shadow DOM is created, the UI looks for a linked stylesheet whose `href` contains this
+   * If a non-URL value is provided, the UI looks for a linked stylesheet whose `href` contains this
    * value and reuses it inside the shadow root so the default styling is available.
+   *
+   * If a URL is provided, the value is used as it is.
    *
    * Default: 'bitmovinplayer-ui'
    */
-  uiStylesheetName?: string;
+  uiStylesheet?: string;
 
   /**
    * Additional stylesheets to inject into the Shadow DOM (array of filenames/URLs).

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -169,4 +169,41 @@ export interface UIConfig {
    * Default: false
    */
   includeWatermark?: boolean;
+  /**
+   * Configure Shadow DOM rendering.
+   * Enable it with:
+   * `shadowDomConfig: { enabled: true }`
+   *
+   * Default: undefined (Shadow DOM disabled).
+   */
+  shadowDomConfig?: ShadowDomConfig;
+}
+
+export interface ShadowDomConfig {
+  /**
+   * Render the UI inside a Shadow DOM.
+   * Enable this to keep player UI styles from being affected by host-page CSS and to keep the UI’s classes from
+   * affecting the page.
+   *
+   * Default: false
+   */
+  enabled: boolean;
+  /**
+   * Filename of the UI stylesheet to inject into the Shadow DOM.
+   *
+   * When the Shadow DOM is created, the UI looks for a linked stylesheet whose `href` contains this
+   * value and reuses it inside the shadow root so the default styling is available.
+   *
+   * Default: 'bitmovinplayer-ui'
+   */
+  uiStylesheetName?: string;
+
+  /**
+   * Additional stylesheets to inject into the Shadow DOM (array of filenames/URLs).
+   *
+   * Use this to include custom UI styles when Shadow DOM is enabled.
+   *
+   * Default: undefined
+   */
+  additionalStylesheets?: string[];
 }

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -253,14 +253,15 @@ export class UIManager {
       this.uiContainerElement = new DOM(player.getContainer());
     }
 
-    if (
-      this.config.shadowDom == true ||
-      (this.config.shadowDom && this.config.shadowDom.enabled && ShadowDomManager.isShadowDomSupported())
-    ) {
-      this.shadowDomManager.initialize(
-        this.uiContainerElement,
-        this.config.shadowDom === true ? { enabled: true } : this.config.shadowDom,
-      );
+    if (this.config.shadowDom == true || (this.config.shadowDom && this.config.shadowDom.enabled)) {
+      if (ShadowDomManager.isShadowDomSupported()) {
+        this.shadowDomManager.initialize(
+          this.uiContainerElement,
+          this.config.shadowDom === true ? { enabled: true } : this.config.shadowDom,
+        );
+      } else {
+        console.warn('Shadow DOM is not supported in this environment. Falling back to classic UI rendering.');
+      }
     }
 
     // Create UI instance managers for the UI variants

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -185,6 +185,7 @@ export class UIManager {
       autoUiVariantResolve: true, // Switch on auto UI resolving by default
       disableAutoHideWhenHovered: false, // Disable auto hide when UI is hovered
       enableSeekPreview: true,
+      shadowDom: false,
       ...uiconfig,
       events: {
         onUpdated: new EventDispatcher<UIManager, void>(),
@@ -252,8 +253,14 @@ export class UIManager {
       this.uiContainerElement = new DOM(player.getContainer());
     }
 
-    if (this.config.shadowDomConfig && this.config.shadowDomConfig.enabled && ShadowDomManager.isShadowDomSupported()) {
-      this.shadowDomManager.initialize(this.uiContainerElement, this.config.shadowDomConfig);
+    if (
+      this.config.shadowDom == true ||
+      (this.config.shadowDom && this.config.shadowDom.enabled && ShadowDomManager.isShadowDomSupported())
+    ) {
+      this.shadowDomManager.initialize(
+        this.uiContainerElement,
+        this.config.shadowDom === true ? { enabled: true } : this.config.shadowDom,
+      );
     }
 
     // Create UI instance managers for the UI variants

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -17,6 +17,7 @@ import { SpatialNavigation } from './spatialnavigation/SpatialNavigation';
 import { SubtitleSettingsManager } from './utils/SubtitleSettingsManager';
 import { StorageUtils } from './utils/StorageUtils';
 import { BufferingOverlay } from './components/overlays/BufferingOverlay';
+import { ShadowDomManager } from './utils/ShadowDomManager';
 
 /**
  * @category Configs
@@ -128,6 +129,7 @@ export class UIManager {
   private managerPlayerWrapper: PlayerWrapper;
   private focusVisibilityTracker: FocusVisibilityTracker;
   private subtitleSettingsManager: SubtitleSettingsManager;
+  private shadowDomManager: ShadowDomManager;
 
   private events = {
     onUiVariantResolve: new EventDispatcher<UIManager, UIConditionContext>(),
@@ -171,6 +173,7 @@ export class UIManager {
     }
 
     this.subtitleSettingsManager = new SubtitleSettingsManager();
+    this.shadowDomManager = new ShadowDomManager();
     this.player = player;
     this.managerPlayerWrapper = new PlayerWrapper(player);
 
@@ -249,6 +252,10 @@ export class UIManager {
       this.uiContainerElement = new DOM(player.getContainer());
     }
 
+    if (this.config.shadowDomConfig && this.config.shadowDomConfig.enabled && ShadowDomManager.isShadowDomSupported()) {
+      this.shadowDomManager.initialize(this.uiContainerElement, this.config.shadowDomConfig);
+    }
+
     // Create UI instance managers for the UI variants
     // The instance managers map to the corresponding UI variants by their array index
     this.uiInstanceManagers = [];
@@ -265,6 +272,7 @@ export class UIManager {
           uiVariant.ui,
           this.config,
           this.subtitleSettingsManager,
+          this.uiWrapperElement,
           uiVariant.spatialNavigation,
         ),
       );
@@ -525,6 +533,15 @@ export class UIManager {
     });
   }
 
+  /**
+   * The node the UI renders into. When Shadow DOM is enabled, this wraps the ShadowRoot; otherwise it wraps the
+   * provided `UIConfig.container` (or the `player.container`).
+   */
+  get uiWrapperElement(): DOM {
+    const shadowRoot = this.shadowDomManager.getShadowRoot();
+    return shadowRoot != undefined ? new DOM(shadowRoot) : this.uiContainerElement;
+  }
+
   private addUi(ui: InternalUIInstanceManager): void {
     const dom = ui.getUI().getDomElement();
     const player = ui.getWrappedPlayer();
@@ -533,7 +550,7 @@ export class UIManager {
     /* Append the UI DOM after configuration to avoid CSS transitions at initialization
      * Example: Components are hidden during configuration and these hides may trigger CSS transitions that are
      * undesirable at this time. */
-    this.uiContainerElement.append(dom);
+    this.uiWrapperElement.append(dom);
 
     // When the UI is loaded after a source was loaded, we need to tell the components to initialize themselves
     if (player.getSource()) {
@@ -572,6 +589,7 @@ export class UIManager {
     }
     this.managerPlayerWrapper.clearEventHandlers();
     this.focusVisibilityTracker.release();
+    this.shadowDomManager.release();
   }
 
   /**
@@ -649,6 +667,7 @@ export class UIInstanceManager {
   private config: InternalUIConfig;
   private subtitleSettingsManager: SubtitleSettingsManager;
   protected spatialNavigation?: SpatialNavigation;
+  readonly uiWrapperElement: DOM;
 
   private events = {
     onConfigured: new EventDispatcher<UIContainer, NoArgs>(),
@@ -671,12 +690,14 @@ export class UIInstanceManager {
     ui: UIContainer,
     config: InternalUIConfig,
     subtitleSettingsManager: SubtitleSettingsManager,
+    uiWrapperElement: DOM,
     spatialNavigation?: SpatialNavigation,
   ) {
     this.playerWrapper = new PlayerWrapper(player);
     this.ui = ui;
     this.config = config;
     this.subtitleSettingsManager = subtitleSettingsManager;
+    this.uiWrapperElement = uiWrapperElement;
     this.spatialNavigation = spatialNavigation;
   }
 

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -400,7 +400,7 @@ export class UIManager {
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.ViewModeChanged, resolveUiVariant);
     }
 
-    this.focusVisibilityTracker = new FocusVisibilityTracker('{{PREFIX}}');
+    this.focusVisibilityTracker = new FocusVisibilityTracker('{{PREFIX}}', this.uiWrapperElement);
 
     // Initialize the UI
     resolveUiVariant(null);

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -864,6 +864,8 @@ export class SeekBar extends Component<SeekBarConfig> {
       this.onSeekEvent();
 
       // Add handler to track the seek operation over the whole document
+      // This enables that scrubbing doesn't require the mouse to stay inside the UI elements itself and works
+      // on the whole document.
       new DOM(document).on(isTouchEvent ? 'touchmove' : 'mousemove', mouseTouchMoveHandler);
       new DOM(document).on(isTouchEvent ? 'touchend' : 'mouseup', mouseTouchUpHandler);
     });

--- a/src/ts/components/settings/SelectBox.ts
+++ b/src/ts/components/settings/SelectBox.ts
@@ -52,6 +52,7 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
   private removeDropdownCloseListeners = () => {};
   private uiContainer: UIContainer | undefined;
   private removeDropdownOpenedListeners = () => {};
+  private uiWrapperElement: DOM | undefined;
 
   constructor(config: ListSelectorConfig = {}) {
     super(config);
@@ -90,6 +91,7 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
     super.configure(player, uimanager);
     this.uiContainer = uimanager.getUI();
     this.uiContainer?.onPlayerStateChange().subscribe(this.onPlayerStateChange);
+    this.uiWrapperElement = uimanager.uiWrapperElement;
   }
 
   private readonly onChange = () => {
@@ -176,11 +178,11 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
 
     clearTimeout(this.dropdownCloseListenerTimeoutId);
 
-    DocumentDropdownClosedEvents.forEach(event => document.addEventListener(event, this.onDropdownClosed, true));
+    DocumentDropdownClosedEvents.forEach(event => this.uiWrapperElement.on(event, this.onDropdownClosed, true));
     SelectDropdownClosedEvents.forEach(event => this.selectElement.on(event, this.onDropdownClosed, true));
 
     this.removeDropdownCloseListeners = () => {
-      DocumentDropdownClosedEvents.forEach(event => document.removeEventListener(event, this.onDropdownClosed, true));
+      DocumentDropdownClosedEvents.forEach(event => this.uiWrapperElement.off(event, this.onDropdownClosed, true));
       SelectDropdownClosedEvents.forEach(event => this.selectElement.off(event, this.onDropdownClosed, true));
     };
   }

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -12,6 +12,7 @@ export { UIUtils } from './utils/UIUtils';
 export { BrowserUtils } from './utils/BrowserUtils';
 export { StorageUtils } from './utils/StorageUtils';
 export { ErrorUtils } from './utils/ErrorUtils';
+export { ShadowDomManager } from './utils/ShadowDomManager';
 // Localization
 export {
   i18n,

--- a/src/ts/utils/FocusVisibilityTracker.ts
+++ b/src/ts/utils/FocusVisibilityTracker.ts
@@ -1,10 +1,17 @@
+import { DOM } from '../DOM';
+
 const FocusVisibleCssClassName = '{{PREFIX}}-focus-visible';
 
 export class FocusVisibilityTracker {
   private readonly eventHandlerMap: { [eventName: string]: EventListenerOrEventListenerObject };
   private lastInteractionWasKeyboard: boolean = true;
+  private uiWrapperElement: DOM;
 
-  constructor(private bitmovinUiPrefix: string) {
+  constructor(
+    private bitmovinUiPrefix: string,
+    uiWrapperElement: DOM,
+  ) {
+    this.uiWrapperElement = uiWrapperElement;
     this.eventHandlerMap = {
       mousedown: this.onMouseOrPointerOrTouch,
       pointerdown: this.onMouseOrPointerOrTouch,
@@ -45,13 +52,13 @@ export class FocusVisibilityTracker {
 
   private registerEventListeners(): void {
     for (const event in this.eventHandlerMap) {
-      document.addEventListener(event, this.eventHandlerMap[event], true);
+      this.uiWrapperElement.on(event, this.eventHandlerMap[event], true);
     }
   }
 
   private unregisterEventListeners(): void {
     for (const event in this.eventHandlerMap) {
-      document.removeEventListener(event, this.eventHandlerMap[event], true);
+      this.uiWrapperElement.off(event, this.eventHandlerMap[event], true);
     }
   }
 

--- a/src/ts/utils/ShadowDomManager.ts
+++ b/src/ts/utils/ShadowDomManager.ts
@@ -16,16 +16,11 @@ export class ShadowDomManager {
   private shadowHost?: DOM;
 
   public static isShadowDomSupported(): boolean {
-    const shadowSupported =
+    return (
       typeof ShadowRoot !== 'undefined' &&
       typeof HTMLElement !== 'undefined' &&
-      typeof HTMLElement.prototype.attachShadow === 'function';
-
-    if (!shadowSupported) {
-      console.warn('Shadow DOM is not supported in this environment. Falling back to classic UI rendering.');
-    }
-
-    return shadowSupported;
+      typeof HTMLElement.prototype.attachShadow === 'function'
+    );
   }
 
   initialize(containerElement: DOM, shadowDomConfig: ShadowDomConfig) {

--- a/src/ts/utils/ShadowDomManager.ts
+++ b/src/ts/utils/ShadowDomManager.ts
@@ -77,7 +77,7 @@ export class ShadowDomManager {
     } else {
       console.warn(
         'Shadow DOM is enabled but no stylesheet was found. ' +
-          'Provide `shadowDomCss` (URL or filename) or include bitmovinplayer-ui.css on the page.',
+          'Provide `uiStylesheetName` (URL or filename) or include {{FILENAME}} on the page.',
       );
     }
 

--- a/src/ts/utils/ShadowDomManager.ts
+++ b/src/ts/utils/ShadowDomManager.ts
@@ -99,7 +99,12 @@ export class ShadowDomManager {
 }
 
 function resolveStylesheetHref(stylesheetName: string): string | null {
-  const isUrl = /^https?:\/\//.test(stylesheetName) || stylesheetName.startsWith('/');
+  const isUrl =
+    /^https?:\/\//.test(stylesheetName) ||
+    stylesheetName.startsWith('/') ||
+    stylesheetName.startsWith('./') ||
+    stylesheetName.startsWith('../');
+
   if (isUrl) {
     return stylesheetName;
   }

--- a/src/ts/utils/ShadowDomManager.ts
+++ b/src/ts/utils/ShadowDomManager.ts
@@ -65,6 +65,10 @@ export class ShadowDomManager {
     }
   }
 
+  /**
+   * Looks for existing stylesheets on the document for the given names and injects them into the ShadowRoot to include
+   * default UI styles (and custom additional styles).
+   */
   private injectStyles(shadowDomConfig: ShadowDomConfig): void {
     if (!this.shadowRoot) {
       return;

--- a/src/ts/utils/ShadowDomManager.ts
+++ b/src/ts/utils/ShadowDomManager.ts
@@ -69,7 +69,7 @@ export class ShadowDomManager {
       return;
     }
 
-    const stylesheetName = shadowDomConfig.uiStylesheetName || ShadowDomManager.DEFAULT_SHADOW_STYLESHEET_NAME;
+    const stylesheetName = shadowDomConfig.uiStylesheet || ShadowDomManager.DEFAULT_SHADOW_STYLESHEET_NAME;
     const mainHref = resolveStylesheetHref(stylesheetName);
 
     if (mainHref) {
@@ -77,7 +77,7 @@ export class ShadowDomManager {
     } else {
       console.warn(
         'Shadow DOM is enabled but no stylesheet was found. ' +
-          'Provide `uiStylesheetName` (URL or filename) or include {{FILENAME}} on the page.',
+          'Provide `uiStylesheet` (URL or filename) or include {{FILENAME}} on the page.',
       );
     }
 

--- a/src/ts/utils/ShadowDomManager.ts
+++ b/src/ts/utils/ShadowDomManager.ts
@@ -1,0 +1,120 @@
+import { DOM } from '../DOM';
+import { ShadowDomConfig } from '../UIConfig';
+import { prefixCss } from '../components/DummyComponent';
+
+/**
+ * Encapsulates Shadow DOM initialization.
+ */
+export class ShadowDomManager {
+  private static readonly DEFAULT_SHADOW_STYLESHEET_NAME = '{{FILENAME}}';
+
+  // The ShadowRoot element where the UI is rendered into
+  private shadowRoot?: ShadowRoot;
+
+  // The wrapper element in which the ShadowRoot is rendered into.
+  // This is needed to have a proper way to destroy the ShadowRoot on release.
+  private shadowHost?: DOM;
+
+  public static isShadowDomSupported(): boolean {
+    const shadowSupported =
+      typeof ShadowRoot !== 'undefined' &&
+      typeof HTMLElement !== 'undefined' &&
+      typeof HTMLElement.prototype.attachShadow === 'function';
+
+    if (!shadowSupported) {
+      console.warn('Shadow DOM is not supported in this environment. Falling back to classic UI rendering.');
+    }
+
+    return shadowSupported;
+  }
+
+  initialize(containerElement: DOM, shadowDomConfig: ShadowDomConfig) {
+    if (!ShadowDomManager.isShadowDomSupported()) {
+      return;
+    }
+
+    const shadowHost = new DOM('div', {
+      class: prefixCss('shadow-dom-container'),
+    });
+
+    shadowHost.css({
+      position: 'absolute',
+      top: '0',
+      left: '0',
+      width: '100%',
+      height: '100%',
+    });
+
+    containerElement.append(shadowHost);
+
+    this.shadowHost = shadowHost;
+    this.shadowRoot = shadowHost.get(0).attachShadow({ mode: 'open' });
+
+    this.injectStyles(shadowDomConfig);
+  }
+
+  getShadowRoot(): ShadowRoot | undefined {
+    return this.shadowRoot;
+  }
+
+  release(): void {
+    if (this.shadowHost) {
+      this.shadowHost.remove();
+      this.shadowHost = undefined;
+      this.shadowRoot = undefined;
+    }
+  }
+
+  private injectStyles(shadowDomConfig: ShadowDomConfig): void {
+    if (!this.shadowRoot) {
+      return;
+    }
+
+    const stylesheetName = shadowDomConfig.uiStylesheetName || ShadowDomManager.DEFAULT_SHADOW_STYLESHEET_NAME;
+    const mainHref = resolveStylesheetHref(stylesheetName);
+
+    if (mainHref) {
+      appendStylesheet(this.shadowRoot, mainHref);
+    } else {
+      console.warn(
+        'Shadow DOM is enabled but no stylesheet was found. ' +
+          'Provide `shadowDomCss` (URL or filename) or include bitmovinplayer-ui.css on the page.',
+      );
+    }
+
+    // Inject additional stylesheets
+    if (shadowDomConfig.additionalStylesheets && shadowDomConfig.additionalStylesheets.length > 0) {
+      shadowDomConfig.additionalStylesheets.forEach(stylesheetName => {
+        const href = resolveStylesheetHref(stylesheetName);
+        if (href) {
+          appendStylesheet(this.shadowRoot!, href);
+        } else {
+          console.warn(
+            `Shadow DOM: Could not resolve additional stylesheet '${stylesheetName}'. ` +
+              'Check the URL or ensure the stylesheet is linked on the page.',
+          );
+        }
+      });
+    }
+  }
+}
+
+function resolveStylesheetHref(stylesheetName: string): string | null {
+  const isUrl = /^https?:\/\//.test(stylesheetName) || stylesheetName.startsWith('/');
+  if (isUrl) {
+    return stylesheetName;
+  }
+
+  // Search for filename/substring in existing stylesheets
+  const stylesheetLinks = Array.from(document.querySelectorAll('link[rel~="stylesheet"]')) as HTMLLinkElement[];
+
+  const matchingLink = stylesheetLinks.find(link => link.href && link.href.indexOf(stylesheetName) !== -1);
+  return matchingLink?.href || null;
+}
+
+function appendStylesheet(shadowRoot: ShadowRoot, href: string): void {
+  const linkElement = document.createElement('link');
+  linkElement.rel = 'stylesheet';
+  linkElement.href = href;
+  shadowRoot.appendChild(linkElement);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,7 @@ module.exports = (env, { mode }) => {
             multiple: [
               { search: '{{VERSION}}', replace: JSON.stringify(require('./package.json').version), flags: 'g' },
               { search: '{{PREFIX}}', replace: outputnames.cssPrefix, flags: 'g' },
+              { search: '{{FILENAME}}', replace: outputnames.filename, flags: 'g' },
             ],
           },
         },


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
In v4, the CSS selectors changed, resulting in a problem where specificity is not as strong as before. Therefore, we wanted to add an option to render our UI inside a Shadow DOM to eliminate potential CSS conflicts with an enclosing page.

### Changes
To enable that, this PR adds a ShadowDomConfig to the `UIConfig`, which can be used to enable and configure the ShadowDOM rendering.

### Manual Testing
You can add some conflicting CSS styles to the index.html and check the result w/ and w/o Shadow DOM rendering enabled:
```
<style>
  .container div > span {
    font-size: 1rem;
    line-height: 1.6;
    margin-bottom: 1rem;
    margin-top: 0.5rem;
    color: rgb(80 95 121);
  }
</style>
```

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
