### PR TITLE
Fix uncaught errors with live streams after player destruction 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Uncaught JS errors after destroying the player while a live source is loaded
+
 ## [4.6.0] - 2025-12-22
 
 ### Added

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -70,7 +70,7 @@ export class TimelineMarkersHandler {
       }
     };
 
-    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => {
+    const reset = () => {
       this.stopLiveMarkerUpdater();
       this.clearMarkers();
       this.isTimeShifting = false;
@@ -79,7 +79,9 @@ export class TimelineMarkersHandler {
       this.player.off(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
       this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
       this.uimanager.onSeekPreview.unsubscribe(onSeekPreview);
-    });
+    };
+    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, reset);
+    this.player.on(this.player.exports.PlayerEvent.Destroy, reset);
 
     this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, () => this.clearMarkers());
     this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers());


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

### Issue

The `TimelineMarkersHandler` and its polling logic for live streams are only reset based on the player's `sourceunloaded` event.

Destroying the player would cause uncaught JS errors, as the UI's polling logic would operate on a destroyed player.

### Fix

Add resetting `TimelineMarkersHandler` on player destroy

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
