### PR TITLE
Fix uncaught errors with live streams after player destruction (v3 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Uncaught JS errors after destroying the player while a live source is loaded
+
 ## [3.105.0] - 2025-12-16
 
 ### Added

--- a/src/ts/components/timelinemarkershandler.ts
+++ b/src/ts/components/timelinemarkershandler.ts
@@ -69,7 +69,7 @@ export class TimelineMarkersHandler {
       }
     };
 
-    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, () => {
+    const reset = () => {
       this.stopLiveMarkerUpdater();
       this.clearMarkers();
       this.isTimeShifting = false;
@@ -78,7 +78,9 @@ export class TimelineMarkersHandler {
       this.player.off(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
       this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
       this.uimanager.onSeekPreview.unsubscribe(onSeekPreview);
-    });
+    };
+    this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, reset);
+    this.player.on(this.player.exports.PlayerEvent.Destroy, reset);
 
     this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, () => this.clearMarkers());
     this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers());


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Backport of https://github.com/bitmovin/bitmovin-player-ui/pull/811

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
