### PR TITLE
Update labels on duration changed (Seekbar + PlabackTime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Time format will be updated when an `onDurationChanged` event is received
+- Time-related labels not properly updating the time format if the duration changes from below 1 hour to greater than 1 hour.
 
 ## [4.8.0] - 2026-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Time format will be updated when an `onDurationChanged` event is received
+
 ## [4.8.0] - 2026-01-29
 
 ### Added

--- a/src/ts/components/labels/PlaybackTimeLabel.ts
+++ b/src/ts/components/labels/PlaybackTimeLabel.ts
@@ -173,6 +173,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       updateTimeFormatBasedOnDuration();
     };
     uimanager.getConfig().events.onUpdated.subscribe(init);
+    player.on(player.exports.PlayerEvent.DurationChanged, init);
 
     init();
   }

--- a/src/ts/components/labels/PlaybackTimeLabel.ts
+++ b/src/ts/components/labels/PlaybackTimeLabel.ts
@@ -151,17 +151,6 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     });
     liveStreamDetector.detect(); // Initial detection
 
-    player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
-    player.on(player.exports.PlayerEvent.Ready, updateTimeFormatBasedOnDuration);
-    player.on(player.exports.PlayerEvent.Seeked, playbackTimeHandler);
-
-    player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);
-    player.on(player.exports.PlayerEvent.TimeShifted, updateLiveTimeshiftState);
-    player.on(player.exports.PlayerEvent.Playing, updateLiveTimeshiftState);
-    player.on(player.exports.PlayerEvent.Paused, updateLiveTimeshiftState);
-    player.on(player.exports.PlayerEvent.StallStarted, updateLiveTimeshiftState);
-    player.on(player.exports.PlayerEvent.StallEnded, updateLiveTimeshiftState);
-
     const init = () => {
       // Reset min-width when a new source is ready (especially for switching VOD/Live modes where the label content
       // changes)
@@ -172,8 +161,20 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
 
       updateTimeFormatBasedOnDuration();
     };
-    uimanager.getConfig().events.onUpdated.subscribe(init);
+
+    player.on(player.exports.PlayerEvent.TimeChanged, playbackTimeHandler);
+    player.on(player.exports.PlayerEvent.Ready, updateTimeFormatBasedOnDuration);
+    player.on(player.exports.PlayerEvent.Seeked, playbackTimeHandler);
+
+    player.on(player.exports.PlayerEvent.TimeShift, updateLiveTimeshiftState);
+    player.on(player.exports.PlayerEvent.TimeShifted, updateLiveTimeshiftState);
+    player.on(player.exports.PlayerEvent.Playing, updateLiveTimeshiftState);
+    player.on(player.exports.PlayerEvent.Paused, updateLiveTimeshiftState);
+    player.on(player.exports.PlayerEvent.StallStarted, updateLiveTimeshiftState);
+    player.on(player.exports.PlayerEvent.StallEnded, updateLiveTimeshiftState);
     player.on(player.exports.PlayerEvent.DurationChanged, init);
+
+    uimanager.getConfig().events.onUpdated.subscribe(init);
 
     init();
   }

--- a/src/ts/components/seekbar/SeekBarLabel.ts
+++ b/src/ts/components/seekbar/SeekBarLabel.ts
@@ -61,7 +61,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     );
   }
 
-  private init = () => {
+  private initializeTimeFormat = () => {
     // Set time format depending on source duration
     const player = this.player;
     if (player == null) {
@@ -83,9 +83,9 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     this.uiManager = uimanager;
     uimanager.onSeekPreview.subscribeRateLimited(this.handleSeekPreview, 100);
 
-    uimanager.getConfig().events.onUpdated.subscribe(this.init);
-    player.on(this.player.exports.PlayerEvent.DurationChanged, this.init);
-    this.init();
+    uimanager.getConfig().events.onUpdated.subscribe(this.initializeTimeFormat);
+    player.on(this.player.exports.PlayerEvent.DurationChanged, this.initializeTimeFormat);
+    this.initializeTimeFormat();
   }
 
   private handleSeekPreview = (sender: SeekBar, args: SeekPreviewEventArgs) => {
@@ -256,6 +256,6 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     super.release();
 
     this.uiManager.onSeekPreview.unsubscribe(this.handleSeekPreview);
-    this.player.off(this.player.exports.PlayerEvent.DurationChanged, this.init);
+    this.player.off(this.player.exports.PlayerEvent.DurationChanged, this.initializeTimeFormat);
   }
 }

--- a/src/ts/components/seekbar/SeekBarLabel.ts
+++ b/src/ts/components/seekbar/SeekBarLabel.ts
@@ -5,7 +5,7 @@ import { UIInstanceManager } from '../../UIManager';
 import { StringUtils } from '../../utils/StringUtils';
 import { ImageLoader } from '../../utils/ImageLoader';
 import { CssProperties } from '../../DOM';
-import { PlayerAPI, Thumbnail } from 'bitmovin-player';
+import { PlayerAPI, PlayerEvent, Thumbnail } from 'bitmovin-player';
 import { SeekBar, SeekPreviewEventArgs } from './SeekBar';
 import { PlayerUtils } from '../../utils/PlayerUtils';
 
@@ -61,6 +61,21 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     );
   }
 
+  private init = () => {
+    // Set time format depending on source duration
+    const player = this.player;
+    if (player == null) {
+      return;
+    }
+    this.timeFormat =
+      Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600
+        ? StringUtils.FORMAT_HHMMSS
+        : StringUtils.FORMAT_MMSS;
+    // Set initial state of title and thumbnail to handle sourceLoaded when switching to a live-stream
+    this.setTitleText(null);
+    this.setThumbnail(null);
+  };
+
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
@@ -68,19 +83,9 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     this.uiManager = uimanager;
     uimanager.onSeekPreview.subscribeRateLimited(this.handleSeekPreview, 100);
 
-    const init = () => {
-      // Set time format depending on source duration
-      this.timeFormat =
-        Math.abs(player.isLive() ? player.getMaxTimeShift() : player.getDuration()) >= 3600
-          ? StringUtils.FORMAT_HHMMSS
-          : StringUtils.FORMAT_MMSS;
-      // Set initial state of title and thumbnail to handle sourceLoaded when switching to a live-stream
-      this.setTitleText(null);
-      this.setThumbnail(null);
-    };
-
-    uimanager.getConfig().events.onUpdated.subscribe(init);
-    init();
+    uimanager.getConfig().events.onUpdated.subscribe(this.init);
+    player.on(PlayerEvent.DurationChanged, this.init);
+    this.init();
   }
 
   private handleSeekPreview = (sender: SeekBar, args: SeekPreviewEventArgs) => {
@@ -251,5 +256,6 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     super.release();
 
     this.uiManager.onSeekPreview.unsubscribe(this.handleSeekPreview);
+    this.player.on(PlayerEvent.DurationChanged, this.init);
   }
 }

--- a/src/ts/components/seekbar/SeekBarLabel.ts
+++ b/src/ts/components/seekbar/SeekBarLabel.ts
@@ -5,7 +5,7 @@ import { UIInstanceManager } from '../../UIManager';
 import { StringUtils } from '../../utils/StringUtils';
 import { ImageLoader } from '../../utils/ImageLoader';
 import { CssProperties } from '../../DOM';
-import { PlayerAPI, PlayerEvent, Thumbnail } from 'bitmovin-player';
+import { PlayerAPI, Thumbnail } from 'bitmovin-player';
 import { SeekBar, SeekPreviewEventArgs } from './SeekBar';
 import { PlayerUtils } from '../../utils/PlayerUtils';
 
@@ -84,7 +84,7 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     uimanager.onSeekPreview.subscribeRateLimited(this.handleSeekPreview, 100);
 
     uimanager.getConfig().events.onUpdated.subscribe(this.init);
-    player.on(PlayerEvent.DurationChanged, this.init);
+    player.on(this.player.exports.PlayerEvent.DurationChanged, this.init);
     this.init();
   }
 
@@ -256,6 +256,6 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     super.release();
 
     this.uiManager.onSeekPreview.unsubscribe(this.handleSeekPreview);
-    this.player.off(PlayerEvent.DurationChanged, this.init);
+    this.player.off(this.player.exports.PlayerEvent.DurationChanged, this.init);
   }
 }

--- a/src/ts/components/seekbar/SeekBarLabel.ts
+++ b/src/ts/components/seekbar/SeekBarLabel.ts
@@ -256,6 +256,6 @@ export class SeekBarLabel extends Container<SeekBarLabelConfig> {
     super.release();
 
     this.uiManager.onSeekPreview.unsubscribe(this.handleSeekPreview);
-    this.player.on(PlayerEvent.DurationChanged, this.init);
+    this.player.off(PlayerEvent.DurationChanged, this.init);
   }
 }


### PR DESCRIPTION
## Description
When casting VOD streams >1h the duration will be displayed without hours.

This is because the duration is not yet available with the initial "ready" event (`duration=0.0`).
As the duration gets available with a following cast event, the time format for the `SeekBarLabel` and `PlaybackTimeLabel` are already fixed and will not change.

With this change we are listening to `onDurationChanged` events in the `SeekBarLabel` and `PlaybackTimeLabel` and will update the time format accordingly

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
