### PR TITLE
[PW-16803] Match key and label for proper audio tracks synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Time-related labels not properly updating the time format if the duration changes from below 1 hour to greater than 1 hour.
-- Audio tracks synchronization failing to update matching audio tracks with same key but different label.
+- Audio tracks not properly updating after CSAI ad.
 
 ## [4.8.0] - 2026-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Time-related labels not properly updating the time format if the duration changes from below 1 hour to greater than 1 hour.
+- Audio tracks synchronization failing to update matching audio tracks with same key but different label.
 
 ## [4.8.0] - 2026-01-29
 

--- a/spec/components/lists/ListSelector.spec.ts
+++ b/spec/components/lists/ListSelector.spec.ts
@@ -238,6 +238,32 @@ describe('ListSelector', () => {
       ]);
     });
 
+    it('match new items with same key but different label', () => {
+      const newItems: ListItem[] = [
+        {
+          key: 'I-1',
+          label: 'L-4',
+        },
+        {
+          key: 'I-2',
+          label: 'L-6',
+        },
+      ];
+
+      listSelector.synchronizeItems(newItems);
+
+      expect(listSelector.getItems()).toEqual([
+        {
+          key: 'I-1',
+          label: 'L-4',
+        },
+        {
+          key: 'I-2',
+          label: 'L-6',
+        },
+      ]);
+    });
+
     it('triggers onItemRemovedEvent only for really removed items', () => {
       const spy = jest.fn();
       listSelector.onItemRemoved.subscribe(spy);

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -79,10 +79,12 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     this.items = this.config.items;
   }
 
-  private getItemIndex(key: string): number {
+  private getItemIndex(key: string, label?: LocalizableText): number {
     for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].key === key) {
-        return i;
+        if (label === undefined || this.items[i].label === i18n.performLocalization(label)) {
+          return i;
+        }
       }
     }
 
@@ -100,10 +102,11 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
   /**
    * Checks if the specified item is part of this selector.
    * @param key the key of the item to check
+   * @param label the label of the item to check (optional)
    * @returns {boolean} true if the item is part of this selector, else false
    */
-  hasItem(key: string): boolean {
-    return this.getItemIndex(key) > -1;
+  hasItem(key: string, label?: LocalizableText): boolean {
+    return this.getItemIndex(key, label) > -1;
   }
 
   /**
@@ -207,7 +210,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    */
   synchronizeItems(newItems: ListItem[]): void {
     newItems
-      .filter(item => !this.hasItem(item.key))
+      .filter(item => !this.hasItem(item.key, item.label))
       .forEach(item => this.addItem(item.key, item.label, item.sortedInsert, item.ariaLabel));
 
     this.items


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Issue: https://bitmovin.atlassian.net/browse/PW-16803

(From the ticket) Audio tracks are mixed up in the main content audio track selector when multiple audio tracks are loaded across streams (e.g. pre-roll then content). 

The issue appears when audio tracks with the same key are matched in the synchronization function. When this happens, older audio tracks are retained, causing inconsistencies with the tracks prompted by the `playerAPI`. A simple fix would be to check for matching keys **and labels** when adding new tracks.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
