### PR TITLE
Run CI workflow also on pull_requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
+    branches:
+      - develop
+      - main
 
   workflow_call:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - '**'
   pull_request:
-    branches:
-      - develop
-      - main
 
   workflow_call:
 


### PR DESCRIPTION
## Description
The ci.yaml Github Action workflow only runs for pushes at the moment, but not for pull requests. This means that for PRs from forked repos no CI runs happen. This should be fixed by adding the `pull_request` key in the `ci.yaml`.

Note that for external contributors, the CI runs may need to be approved by members of the Bitmovin org.

No changelog entry as this is no change to the UI itself.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- ~`CHANGELOG` entry~
