### PR TITLE
Adjust CI triggers to avoid duplicate PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - '**'
   pull_request:
+  workflow_call:
 
 concurrency:
-  group: ${{ format('ci-{0}', github.ref) }}
+  group: ${{ github.event_name == 'workflow_call' && format('ci-{0}', github.run_id) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 jobs:
@@ -19,7 +20,7 @@ jobs:
     steps:
       - id: eval
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "workflow_call" ]]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,17 @@ on:
       - '**'
   pull_request:
 
-  workflow_call:
-
 concurrency:
-  group: ${{ github.event_name == 'workflow_call' && format('release-ci-{0}', github.run_id) || format('ci-{0}', github.ref) }}
+  group: ${{ format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 jobs:
   test:
     name: Test
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
 
     steps:
@@ -29,6 +31,10 @@ jobs:
 
   build:
     name: Build
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
 
     steps:
@@ -43,6 +49,10 @@ jobs:
 
   lint:
     name: Lint
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.eval.outputs.should_run }}
+    steps:
+      - id: eval
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Test
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name != github.repository)
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -31,10 +45,8 @@ jobs:
 
   build:
     name: Build
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name != github.repository)
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -49,10 +61,8 @@ jobs:
 
   lint:
     name: Lint
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name != github.repository)
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The last change would lead to duplicate CI runs for commits on PRs coming from collaborators of this repo (vs external collaborators with repo forks): once for `push`, once for `pull_request`.

This iteration "guards" the CI jobs by checking whether the PR is coming from this same repo or from a fork if the trigger is `pull_request`.

TL;DR:

PRs from this repo:
- CI runs based on `push` trigger
- CI skips runs for `pull_request` trigger

PRs from forks:
- CI runs based on `pull_request` trigger (potentially pending approval of repo maintainers / Bitmovin org members)

<img width="812" height="387" alt="image" src="https://github.com/user-attachments/assets/47189b25-f9c3-4424-b3b9-1ebbd054a2c9" />
