### PR TITLE
Fix TimelineMarkersHandler not reseting on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Missing localization keys in the `Vocabulary` interface
 - Missing translations for certain localization keys in `de.json` and `nl.json` to ensure all language files are complete
+- TimelineMarkersHandler not releasing properly
 
 ## [4.8.1] - 2026-02-09
 

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -104,9 +104,10 @@ export class TimelineMarkersHandler {
     liveStreamDetector.detect(); // Initial detection
 
     this.uimanager.getConfig().events.onUpdated.subscribe(() => this.updateMarkers());
-    this.uimanager.onRelease.subscribe(() =>
-      this.uimanager.getConfig().events.onUpdated.unsubscribe(() => this.updateMarkers()),
-    );
+    this.uimanager.onRelease.subscribe(() => {
+      this.uimanager.getConfig().events.onUpdated.unsubscribe(() => this.updateMarkers());
+      reset();
+    });
 
     // Refresh timeline markers when the player is resized or the UI is configured. Timeline markers
     // are positioned absolutely and must therefore be updated when the size of the seekbar changes.


### PR DESCRIPTION
## Description
as discussed in internal ticket 29089 the timelinemarkerhandler does not release properly

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
