### PR TITLE
[PW-31280] Catch unhandled PlayerAPI call exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Unhandled exceptions from player API calls after `player.destroy()`
+
 ## [4.9.0] - 2026-02-20
 
 ### Added

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -637,16 +637,16 @@ export class SeekBar extends Component<SeekBarConfig> {
           return;
         }
 
-        // Reset the currentTimeSeekBar and set the position to 0 if the player has no duration
-        if (this.player.getDuration() === 0) {
-          this.setPlaybackPosition(0);
-          currentTimeSeekBar = 0;
-          return;
-        }
-
-        currentTimeSeekBar += currentTimeUpdateDeltaSecs;
-
         try {
+          // Reset the currentTimeSeekBar and set the position to 0 if the player has no duration
+          if (this.player.getDuration() === 0) {
+            this.setPlaybackPosition(0);
+            currentTimeSeekBar = 0;
+            return;
+          }
+
+          currentTimeSeekBar += currentTimeUpdateDeltaSecs;
+
           currentTimePlayer = this.getRelativeCurrentTime();
         } catch (error) {
           // Detect if the player has been destroyed and stop updating if so


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Since the `UIManager` never releases the UI after `player.destroy()` is called, we need to make sure that calls to the PlayerAPI are properly handled. An initial temporary fix is to surround it with try-catch to properly clear the timeout, in this case related to the `SeekBar`.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
