### PR TITLE
[PW-20545] Clean up the UI after destroying the player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- UI not released and still showing after calling `player.destroy()`
+
 ## [4.9.1] - 2026-02-24
 
 ### Fixed

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -426,6 +426,10 @@ export class UIManager {
       this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.ViewModeChanged, resolveUiVariant);
     }
 
+    this.managerPlayerWrapper.getPlayer().on(this.player.exports.PlayerEvent.Destroy, () => {
+      this.release();
+    });
+
     this.focusVisibilityTracker = new FocusVisibilityTracker('{{PREFIX}}', this.uiWrapperElement);
 
     // Initialize the UI
@@ -599,21 +603,25 @@ export class UIManager {
   }
 
   private releaseUi(ui: InternalUIInstanceManager): void {
+    // Clear event handlers FIRST to prevent any player API calls during component release
+    ui.clearEventHandlers();
+
     ui.releaseControls();
 
     const uiContainer = ui.getUI();
     if (uiContainer.hasDomElement()) {
       uiContainer.getDomElement().remove();
     }
-
-    ui.clearEventHandlers();
   }
 
   release(): void {
+    // Clear all event handlers FIRST to prevent any player API calls during release
+    this.managerPlayerWrapper.clearEventHandlers();
+
     for (const uiInstanceManager of this.uiInstanceManagers) {
       this.releaseUi(uiInstanceManager);
     }
-    this.managerPlayerWrapper.clearEventHandlers();
+
     this.focusVisibilityTracker.release();
     this.shadowDomManager.release();
   }

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -690,7 +690,7 @@ export class SeekBar extends Component<SeekBarConfig> {
     };
 
     const onPlayerDestroy = () => {
-      this.release();
+      // this.release();
     };
 
     const stopSmoothPlaybackPositionUpdater = () => {

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -689,6 +689,10 @@ export class SeekBar extends Component<SeekBarConfig> {
       }
     };
 
+    const onPlayerDestroy = () => {
+      this.release();
+    };
+
     const stopSmoothPlaybackPositionUpdater = () => {
       this.smoothPlaybackPositionUpdater.clear();
     };
@@ -701,6 +705,8 @@ export class SeekBar extends Component<SeekBarConfig> {
       currentTimeSeekBar = this.getRelativeCurrentTime();
     });
     player.on(player.exports.PlayerEvent.SourceUnloaded, stopSmoothPlaybackPositionUpdater);
+
+    player.on(player.exports.PlayerEvent.Destroy, onPlayerDestroy);
 
     if (player.isPlaying()) {
       startSmoothPlaybackPositionUpdater();


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Issue: https://bitmovin.atlassian.net/browse/PW-20545
Also related to: 
- https://bitmovin.atlassian.net/browse/PW-6794
- https://bitmovin.atlassian.net/browse/PW-31280

This behavior is present in previous versions of the UI `v4` (and `v3`) as well. It generates from components of the UI (such as the `SeekBar`) calling the player APIs after the player has been destroyed. 
The proposed solution is to listen to the `PlayerEvent.Destroy` to release the UI and the event handlers in time.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
