### PR TITLE
Fix/handle undefined error smallscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Prevent runtime errors in `SettingsPanel` when `hideDelay` is set to `-1` (e.g. in `modernSmallScreenUI`) by only tracking component `ViewMode` changes when a hide timeout is configured.
+
 ## [3.105.2] - 2026-02-25
 
 ### Fixed

--- a/src/ts/components/settingspanel.ts
+++ b/src/ts/components/settingspanel.ts
@@ -90,9 +90,9 @@ export class SettingsPanel extends Container<SettingsPanelConfig> {
     let config = this.getConfig();
 
     uimanager.onControlsHide.subscribe(() => this.hideHoveredSelectBoxes());
-    uimanager.onComponentViewModeChanged.subscribe((_, { mode }) => this.trackComponentViewMode(mode));
 
     if (config.hideDelay > -1) {
+      uimanager.onComponentViewModeChanged.subscribe((_, { mode }) => this.trackComponentViewMode(mode));
       this.hideTimeout = new Timeout(config.hideDelay, () => {
         this.hide();
         this.hideHoveredSelectBoxes();


### PR DESCRIPTION
- SettingsPanel was always tracking component ViewMode, which triggered suspend/resume calls even when no hide timeout existed. Now SettingsPanel subscribes to onComponentViewModeChanged only if hideDelay > -1 (timeout enabled).


```
Uncaught TypeError: Cannot read properties of undefined (reading 'suspend')
      at exports.SettingsPanel.SettingsPanel.suspendHideTimeout
  (settingspanel.ts:254:22)
``` 