### PR TITLE
Feature/fix fcc window color

### DIFF
--- a/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
+++ b/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
@@ -70,9 +70,7 @@
     @each $opacity-name, $opacity-value in $opacities {
       &.#{$prefix}-windowcolor-#{$color-name}#{$opacity-name} {
         .#{$prefix}-subtitle-region-container {
-          .#{$prefix}-ui-subtitle-label {
             background-color: transparentize($color-value, 1 - $opacity-value);
-          }
         }
       }
     }

--- a/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
+++ b/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
@@ -70,7 +70,9 @@
     @each $opacity-name, $opacity-value in $opacities {
       &.#{$prefix}-windowcolor-#{$color-name}#{$opacity-name} {
         .#{$prefix}-subtitle-region-container {
-          background-color: transparentize($color-value, 1 - $opacity-value);
+          .#{$prefix}-ui-subtitle-label {
+            background-color: transparentize($color-value, 1 - $opacity-value);
+          }
         }
       }
     }

--- a/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
+++ b/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
@@ -66,15 +66,17 @@
   }
 
   // Window color + opacity
-  @each $color-name, $color-value in $colors {
-    @each $opacity-name, $opacity-value in $opacities {
-      &.#{$prefix}-windowcolor-#{$color-name}#{$opacity-name} {
-        .#{$prefix}-subtitle-region-container {
-            background-color: transparentize($color-value, 1 - $opacity-value);
+    @each $color-name,
+    $color-value in $colors {
+        @each $opacity-name,
+        $opacity-value in $opacities {
+            &.#{$prefix}-windowcolor-#{$color-name}#{$opacity-name} {
+                .#{$prefix}-subtitle-region-container {
+                    background-color: transparentize($color-value, 1 - $opacity-value) #{!important};
+                }
+            }
         }
-      }
     }
-  }
 
   // Font size
   @each $name, $value in $font-sizes {


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Add "!important" tag to the "window" styling (subtitle overlay). 

The Window styling for FCC subtitles was getting overridden probably here : 
https://github.com/bitmovin/bitmovin-player-ui/blob/751da29a4e3d1882c87317abdd65ebbb93ec5f6e/src/scss/components/overlays/_subtitle-overlay.scss#L23

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [ ] `CHANGELOG` entry
