### PR TITLE
Handle multiple ad breaks at the same position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- `AdCounterLabel` now correctly shows the ad position across multiple ad breaks scheduled at the same time (e.g. `Ad 2 of 3` instead of `Ad 1 of 1` for each)
+- `AdCounterLabel` now shows the ad position across multiple ad breaks scheduled at the same time (e.g. `Ad 2 of 3` instead of `Ad 1 of 1` for each)
 
 ## [4.9.1] - 2026-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `AdCounterLabel` now correctly shows the ad position across multiple ad breaks scheduled at the same time (e.g. `Ad 2 of 3` instead of `Ad 1 of 1` for each)
+
 ## [4.9.1] - 2026-02-24
 
 ### Fixed

--- a/spec/components/ads/AdCounterLabel.spec.ts
+++ b/spec/components/ads/AdCounterLabel.spec.ts
@@ -43,24 +43,8 @@ describe('AdCounterLabel', () => {
     expect(adCounterLabel.getText()).toBe('Ad 2 of 3');
   });
 
-  it('clears text on AdBreakStarted', () => {
-    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 2 });
-    expect(adCounterLabel.getText()).toBe('Ad 1 of 2');
-
-    playerMock.eventEmitter.fireAdBreakStartedEvent(5, []);
-    expect(adCounterLabel.getText()).toBe('');
-  });
-
-  it('clears text on AdBreakFinished', () => {
-    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 1 });
-    expect(adCounterLabel.getText()).toBe('Ad 1 of 1');
-
-    playerMock.eventEmitter.fireAdBreakFinishedEvent({ id: 'break-1', scheduleTime: 5, ads: [] } as any);
-    expect(adCounterLabel.getText()).toBe('');
-  });
-
-  it('shows 0 of 0 when tracker reports reset values', () => {
+  it('shows empty text when tracker reports reset values', () => {
     adCountChangedDispatcher.dispatch(null, { currentAdIndex: 0, totalNumberOfAds: 0 });
-    expect(adCounterLabel.getText()).toBe('Ad 0 of 0');
+    expect(adCounterLabel.getText()).toBe('');
   });
 });

--- a/spec/components/ads/AdCounterLabel.spec.ts
+++ b/spec/components/ads/AdCounterLabel.spec.ts
@@ -1,20 +1,20 @@
 import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
 import { UIInstanceManager } from '../../../src/ts/UIManager';
 import { AdCounterLabel } from '../../../src/ts/components/ads/AdCounterLabel';
-import { AdBreakTrackerChangedArgs } from '../../../src/ts/utils/AdBreakTracker';
+import { AdBreakTrackerAdCountChangedArgs } from '../../../src/ts/utils/AdBreakTracker';
 import { EventDispatcher } from '../../../src/ts/EventDispatcher';
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;
 let adCounterLabel: AdCounterLabel;
-let adCountChangedDispatcher: EventDispatcher<any, AdBreakTrackerChangedArgs>;
+let adCountChangedDispatcher: EventDispatcher<any, AdBreakTrackerAdCountChangedArgs>;
 
 describe('AdCounterLabel', () => {
   beforeEach(() => {
     playerMock = MockHelper.getPlayerMock();
     uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
 
-    adCountChangedDispatcher = new EventDispatcher<any, AdBreakTrackerChangedArgs>();
+    adCountChangedDispatcher = new EventDispatcher<any, AdBreakTrackerAdCountChangedArgs>();
 
     const adBreakTrackerMock = {
       onAdCountChanged: adCountChangedDispatcher.getEvent(),

--- a/spec/components/ads/AdCounterLabel.spec.ts
+++ b/spec/components/ads/AdCounterLabel.spec.ts
@@ -1,245 +1,66 @@
 import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
 import { UIInstanceManager } from '../../../src/ts/UIManager';
 import { AdCounterLabel } from '../../../src/ts/components/ads/AdCounterLabel';
-import { AdBreak } from 'bitmovin-player';
+import { AdBreakTrackerChangedArgs } from '../../../src/ts/utils/AdBreakTracker';
+import { EventDispatcher } from '../../../src/ts/EventDispatcher';
 
 let playerMock: TestingPlayerAPI;
 let uiInstanceManagerMock: UIInstanceManager;
 let adCounterLabel: AdCounterLabel;
-
-const makeBreak = (id: string, scheduleTime: number, ads: { id: string }[]) =>
-  ({ id, scheduleTime, ads }) as unknown as AdBreak;
-
-// Mutable ad state that the player mock delegates to.
-// `list` represents the breaks still upcoming (active and past breaks are excluded).
-let adsState: {
-  activeAdBreak: ReturnType<typeof makeBreak> | null;
-  activeAd: { id: string } | null;
-  list: ReturnType<typeof makeBreak>[];
-};
+let adCountChangedDispatcher: EventDispatcher<any, AdBreakTrackerChangedArgs>;
 
 describe('AdCounterLabel', () => {
   beforeEach(() => {
     playerMock = MockHelper.getPlayerMock();
     uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
 
-    adsState = { activeAdBreak: null, activeAd: null, list: [] };
+    adCountChangedDispatcher = new EventDispatcher<any, AdBreakTrackerChangedArgs>();
 
-    Object.defineProperty(playerMock, 'ads', {
-      get: () => ({
-        getActiveAdBreak: () => adsState.activeAdBreak,
-        getActiveAd: () => adsState.activeAd,
-        list: () => adsState.list,
-        isLinearAdActive: () => adsState.activeAd !== null,
-      }),
-      configurable: true,
-    });
+    const adBreakTrackerMock = {
+      onAdCountChanged: adCountChangedDispatcher.getEvent(),
+      currentAdIndex: 0,
+      totalNumberOfAds: 0,
+      release: jest.fn(),
+    };
+
+    const config = uiInstanceManagerMock.getConfig();
+    (config as any).adBreakTracker = adBreakTrackerMock;
 
     adCounterLabel = new AdCounterLabel({ adCountOutOfTotal: 'Ad {activeAdIndex} of {totalAdsCount}' });
     adCounterLabel.configure(playerMock, uiInstanceManagerMock);
   });
 
-  describe('single ad break', () => {
-    it('shows correct index and total for a single ad in a break', () => {
-      const ad = { id: 'a1' };
-      const adBreak = makeBreak('break-1', 5, [ad]);
-
-      adsState.activeAdBreak = adBreak;
-      adsState.list = [];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad as any]);
-
-      adsState.activeAd = ad;
-      playerMock.eventEmitter.fireAdStartedEvent();
-
-      expect(adCounterLabel.getText()).toBe('Ad 1 of 1');
-    });
-
-    it('shows correct index and total for multiple ads in a single break', () => {
-      const ads = [{ id: 'a1' }, { id: 'a2' }, { id: 'a3' }];
-      const adBreak = makeBreak('break-1', 5, ads);
-
-      adsState.activeAdBreak = adBreak;
-      adsState.list = [];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, ads as any);
-
-      adsState.activeAd = ads[1];
-      playerMock.eventEmitter.fireAdStartedEvent();
-
-      expect(adCounterLabel.getText()).toBe('Ad 2 of 3');
-    });
-
-    it('clears text on AdBreakFinished', () => {
-      const ad = { id: 'a1' };
-      const adBreak = makeBreak('break-1', 5, [ad]);
-
-      adsState.activeAdBreak = adBreak;
-      adsState.list = [];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad as any]);
-
-      adsState.activeAd = ad;
-      playerMock.eventEmitter.fireAdStartedEvent();
-
-      adsState.activeAd = null;
-      adsState.activeAdBreak = null;
-      playerMock.eventEmitter.fireAdBreakFinishedEvent(adBreak);
-
-      expect(adCounterLabel.getText()).toBe('');
-    });
+  it('shows the ad counter text when onAdCountChanged fires', () => {
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 3 });
+    expect(adCounterLabel.getText()).toBe('Ad 1 of 3');
   });
 
-  describe('co-scheduled ad breaks (same scheduleTime)', () => {
-    it('shows Ad 1 of 3 for the first of three co-scheduled single-ad breaks', () => {
-      const ad1 = { id: 'a1' };
-      const ad2 = { id: 'a2' };
-      const ad3 = { id: 'a3' };
-      const break1 = makeBreak('break-1', 5, [ad1]);
-      const break2 = makeBreak('break-2', 5, [ad2]);
-      const break3 = makeBreak('break-3', 5, [ad3]);
+  it('updates text when onAdCountChanged fires again with new values', () => {
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 3 });
+    expect(adCounterLabel.getText()).toBe('Ad 1 of 3');
 
-      // break-1 is active; break-2 and break-3 are still in list()
-      adsState.activeAdBreak = break1;
-      adsState.list = [break2, break3];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad1 as any]);
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 2, totalNumberOfAds: 3 });
+    expect(adCounterLabel.getText()).toBe('Ad 2 of 3');
+  });
 
-      adsState.activeAd = ad1;
-      playerMock.eventEmitter.fireAdStartedEvent();
+  it('clears text on AdBreakStarted', () => {
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 2 });
+    expect(adCounterLabel.getText()).toBe('Ad 1 of 2');
 
-      expect(adCounterLabel.getText()).toBe('Ad 1 of 3');
-    });
+    playerMock.eventEmitter.fireAdBreakStartedEvent(5, []);
+    expect(adCounterLabel.getText()).toBe('');
+  });
 
-    it('shows Ad 2 of 3 for the second co-scheduled break after the first finishes', () => {
-      const ad1 = { id: 'a1' };
-      const ad2 = { id: 'a2' };
-      const ad3 = { id: 'a3' };
-      const break1 = makeBreak('break-1', 5, [ad1]);
-      const break2 = makeBreak('break-2', 5, [ad2]);
-      const break3 = makeBreak('break-3', 5, [ad3]);
+  it('clears text on AdBreakFinished', () => {
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 1 });
+    expect(adCounterLabel.getText()).toBe('Ad 1 of 1');
 
-      // Break 1
-      adsState.activeAdBreak = break1;
-      adsState.list = [break2, break3];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad1 as any]);
-      adsState.activeAd = ad1;
-      playerMock.eventEmitter.fireAdStartedEvent();
-      adsState.activeAd = null;
-      adsState.activeAdBreak = null;
-      playerMock.eventEmitter.fireAdBreakFinishedEvent(break1);
+    playerMock.eventEmitter.fireAdBreakFinishedEvent({ id: 'break-1', scheduleTime: 5, ads: [] } as any);
+    expect(adCounterLabel.getText()).toBe('');
+  });
 
-      // Break 2 — break-3 is still in list()
-      adsState.activeAdBreak = break2;
-      adsState.list = [break3];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad2 as any]);
-      adsState.activeAd = ad2;
-      playerMock.eventEmitter.fireAdStartedEvent();
-
-      expect(adCounterLabel.getText()).toBe('Ad 2 of 3');
-    });
-
-    it('shows Ad 3 of 3 for the third co-scheduled break', () => {
-      const ad1 = { id: 'a1' };
-      const ad2 = { id: 'a2' };
-      const ad3 = { id: 'a3' };
-      const break1 = makeBreak('break-1', 5, [ad1]);
-      const break2 = makeBreak('break-2', 5, [ad2]);
-      const break3 = makeBreak('break-3', 5, [ad3]);
-
-      // Break 1
-      adsState.activeAdBreak = break1;
-      adsState.list = [break2, break3];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad1 as any]);
-      adsState.activeAd = ad1;
-      playerMock.eventEmitter.fireAdStartedEvent();
-      adsState.activeAd = null;
-      adsState.activeAdBreak = null;
-      playerMock.eventEmitter.fireAdBreakFinishedEvent(break1);
-
-      // Break 2
-      adsState.activeAdBreak = break2;
-      adsState.list = [break3];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad2 as any]);
-      adsState.activeAd = ad2;
-      playerMock.eventEmitter.fireAdStartedEvent();
-      adsState.activeAd = null;
-      adsState.activeAdBreak = null;
-      playerMock.eventEmitter.fireAdBreakFinishedEvent(break2);
-
-      // Break 3 — no siblings left in list()
-      adsState.activeAdBreak = break3;
-      adsState.list = [];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad3 as any]);
-      adsState.activeAd = ad3;
-      playerMock.eventEmitter.fireAdStartedEvent();
-
-      expect(adCounterLabel.getText()).toBe('Ad 3 of 3');
-    });
-
-    it('resets state after the last co-scheduled break finishes', () => {
-      const ad1 = { id: 'a1' };
-      const ad2 = { id: 'a2' };
-      const break1 = makeBreak('break-1', 5, [ad1]);
-      const break2 = makeBreak('break-2', 5, [ad2]);
-
-      // Break 1
-      adsState.activeAdBreak = break1;
-      adsState.list = [break2];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad1 as any]);
-      adsState.activeAd = ad1;
-      playerMock.eventEmitter.fireAdStartedEvent();
-      adsState.activeAd = null;
-      adsState.activeAdBreak = null;
-      playerMock.eventEmitter.fireAdBreakFinishedEvent(break1);
-
-      // Break 2 — last in group
-      adsState.activeAdBreak = break2;
-      adsState.list = [];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad2 as any]);
-      adsState.activeAd = ad2;
-      playerMock.eventEmitter.fireAdStartedEvent();
-      adsState.activeAd = null;
-      adsState.activeAdBreak = null;
-      playerMock.eventEmitter.fireAdBreakFinishedEvent(break2);
-
-      // Subsequent unrelated break at a different time should show 1 of 1
-      const adNext = { id: 'a-next' };
-      const breakNext = makeBreak('break-next', 10, [adNext]);
-      adsState.activeAdBreak = breakNext;
-      adsState.list = [];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(10, [adNext as any]);
-      adsState.activeAd = adNext;
-      playerMock.eventEmitter.fireAdStartedEvent();
-
-      expect(adCounterLabel.getText()).toBe('Ad 1 of 1');
-    });
-
-    it('handles co-scheduled breaks where each break contains multiple ads', () => {
-      const ads1 = [{ id: 'a1' }, { id: 'a2' }];
-      const ads2 = [{ id: 'a3' }, { id: 'a4' }];
-      const break1 = makeBreak('break-1', 5, ads1);
-      const break2 = makeBreak('break-2', 5, ads2);
-
-      // Break 1, second ad playing. Sibling break-2 is in list() with its ads already populated,
-      // so total = 2 (current break) + 2 (sibling break) = 4.
-      adsState.activeAdBreak = break1;
-      adsState.list = [break2];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, ads1 as any);
-      adsState.activeAd = ads1[1];
-      playerMock.eventEmitter.fireAdStartedEvent();
-
-      expect(adCounterLabel.getText()).toBe('Ad 2 of 4');
-
-      // Break 1 finishes
-      adsState.activeAd = null;
-      adsState.activeAdBreak = null;
-      playerMock.eventEmitter.fireAdBreakFinishedEvent(break1);
-
-      // Break 2 starts — now its real ad count (2) is known via getActiveAdBreak(), so total updates to 2 + 2 = 4.
-      adsState.activeAdBreak = break2;
-      adsState.list = [];
-      playerMock.eventEmitter.fireAdBreakStartedEvent(5, ads2 as any);
-      adsState.activeAd = ads2[0];
-      playerMock.eventEmitter.fireAdStartedEvent();
-
-      expect(adCounterLabel.getText()).toBe('Ad 3 of 4');
-    });
+  it('shows 0 of 0 when tracker reports reset values', () => {
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 0, totalNumberOfAds: 0 });
+    expect(adCounterLabel.getText()).toBe('Ad 0 of 0');
   });
 });

--- a/spec/components/ads/AdCounterLabel.spec.ts
+++ b/spec/components/ads/AdCounterLabel.spec.ts
@@ -1,0 +1,245 @@
+import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
+import { UIInstanceManager } from '../../../src/ts/UIManager';
+import { AdCounterLabel } from '../../../src/ts/components/ads/AdCounterLabel';
+import { AdBreak } from 'bitmovin-player';
+
+let playerMock: TestingPlayerAPI;
+let uiInstanceManagerMock: UIInstanceManager;
+let adCounterLabel: AdCounterLabel;
+
+const makeBreak = (id: string, scheduleTime: number, ads: { id: string }[]) =>
+  ({ id, scheduleTime, ads }) as unknown as AdBreak;
+
+// Mutable ad state that the player mock delegates to.
+// `list` represents the breaks still upcoming (active and past breaks are excluded).
+let adsState: {
+  activeAdBreak: ReturnType<typeof makeBreak> | null;
+  activeAd: { id: string } | null;
+  list: ReturnType<typeof makeBreak>[];
+};
+
+describe('AdCounterLabel', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+
+    adsState = { activeAdBreak: null, activeAd: null, list: [] };
+
+    Object.defineProperty(playerMock, 'ads', {
+      get: () => ({
+        getActiveAdBreak: () => adsState.activeAdBreak,
+        getActiveAd: () => adsState.activeAd,
+        list: () => adsState.list,
+        isLinearAdActive: () => adsState.activeAd !== null,
+      }),
+      configurable: true,
+    });
+
+    adCounterLabel = new AdCounterLabel({ adCountOutOfTotal: 'Ad {activeAdIndex} of {totalAdsCount}' });
+    adCounterLabel.configure(playerMock, uiInstanceManagerMock);
+  });
+
+  describe('single ad break', () => {
+    it('shows correct index and total for a single ad in a break', () => {
+      const ad = { id: 'a1' };
+      const adBreak = makeBreak('break-1', 5, [ad]);
+
+      adsState.activeAdBreak = adBreak;
+      adsState.list = [];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad as any]);
+
+      adsState.activeAd = ad;
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      expect(adCounterLabel.getText()).toBe('Ad 1 of 1');
+    });
+
+    it('shows correct index and total for multiple ads in a single break', () => {
+      const ads = [{ id: 'a1' }, { id: 'a2' }, { id: 'a3' }];
+      const adBreak = makeBreak('break-1', 5, ads);
+
+      adsState.activeAdBreak = adBreak;
+      adsState.list = [];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, ads as any);
+
+      adsState.activeAd = ads[1];
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      expect(adCounterLabel.getText()).toBe('Ad 2 of 3');
+    });
+
+    it('clears text on AdBreakFinished', () => {
+      const ad = { id: 'a1' };
+      const adBreak = makeBreak('break-1', 5, [ad]);
+
+      adsState.activeAdBreak = adBreak;
+      adsState.list = [];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad as any]);
+
+      adsState.activeAd = ad;
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      playerMock.eventEmitter.fireAdBreakFinishedEvent(adBreak);
+
+      expect(adCounterLabel.getText()).toBe('');
+    });
+  });
+
+  describe('co-scheduled ad breaks (same scheduleTime)', () => {
+    it('shows Ad 1 of 3 for the first of three co-scheduled single-ad breaks', () => {
+      const ad1 = { id: 'a1' };
+      const ad2 = { id: 'a2' };
+      const ad3 = { id: 'a3' };
+      const break1 = makeBreak('break-1', 5, [ad1]);
+      const break2 = makeBreak('break-2', 5, [ad2]);
+      const break3 = makeBreak('break-3', 5, [ad3]);
+
+      // break-1 is active; break-2 and break-3 are still in list()
+      adsState.activeAdBreak = break1;
+      adsState.list = [break2, break3];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad1 as any]);
+
+      adsState.activeAd = ad1;
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      expect(adCounterLabel.getText()).toBe('Ad 1 of 3');
+    });
+
+    it('shows Ad 2 of 3 for the second co-scheduled break after the first finishes', () => {
+      const ad1 = { id: 'a1' };
+      const ad2 = { id: 'a2' };
+      const ad3 = { id: 'a3' };
+      const break1 = makeBreak('break-1', 5, [ad1]);
+      const break2 = makeBreak('break-2', 5, [ad2]);
+      const break3 = makeBreak('break-3', 5, [ad3]);
+
+      // Break 1
+      adsState.activeAdBreak = break1;
+      adsState.list = [break2, break3];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad1 as any]);
+      adsState.activeAd = ad1;
+      playerMock.eventEmitter.fireAdStartedEvent();
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      playerMock.eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // Break 2 — break-3 is still in list()
+      adsState.activeAdBreak = break2;
+      adsState.list = [break3];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad2 as any]);
+      adsState.activeAd = ad2;
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      expect(adCounterLabel.getText()).toBe('Ad 2 of 3');
+    });
+
+    it('shows Ad 3 of 3 for the third co-scheduled break', () => {
+      const ad1 = { id: 'a1' };
+      const ad2 = { id: 'a2' };
+      const ad3 = { id: 'a3' };
+      const break1 = makeBreak('break-1', 5, [ad1]);
+      const break2 = makeBreak('break-2', 5, [ad2]);
+      const break3 = makeBreak('break-3', 5, [ad3]);
+
+      // Break 1
+      adsState.activeAdBreak = break1;
+      adsState.list = [break2, break3];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad1 as any]);
+      adsState.activeAd = ad1;
+      playerMock.eventEmitter.fireAdStartedEvent();
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      playerMock.eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // Break 2
+      adsState.activeAdBreak = break2;
+      adsState.list = [break3];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad2 as any]);
+      adsState.activeAd = ad2;
+      playerMock.eventEmitter.fireAdStartedEvent();
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      playerMock.eventEmitter.fireAdBreakFinishedEvent(break2);
+
+      // Break 3 — no siblings left in list()
+      adsState.activeAdBreak = break3;
+      adsState.list = [];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad3 as any]);
+      adsState.activeAd = ad3;
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      expect(adCounterLabel.getText()).toBe('Ad 3 of 3');
+    });
+
+    it('resets state after the last co-scheduled break finishes', () => {
+      const ad1 = { id: 'a1' };
+      const ad2 = { id: 'a2' };
+      const break1 = makeBreak('break-1', 5, [ad1]);
+      const break2 = makeBreak('break-2', 5, [ad2]);
+
+      // Break 1
+      adsState.activeAdBreak = break1;
+      adsState.list = [break2];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad1 as any]);
+      adsState.activeAd = ad1;
+      playerMock.eventEmitter.fireAdStartedEvent();
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      playerMock.eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // Break 2 — last in group
+      adsState.activeAdBreak = break2;
+      adsState.list = [];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, [ad2 as any]);
+      adsState.activeAd = ad2;
+      playerMock.eventEmitter.fireAdStartedEvent();
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      playerMock.eventEmitter.fireAdBreakFinishedEvent(break2);
+
+      // Subsequent unrelated break at a different time should show 1 of 1
+      const adNext = { id: 'a-next' };
+      const breakNext = makeBreak('break-next', 10, [adNext]);
+      adsState.activeAdBreak = breakNext;
+      adsState.list = [];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(10, [adNext as any]);
+      adsState.activeAd = adNext;
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      expect(adCounterLabel.getText()).toBe('Ad 1 of 1');
+    });
+
+    it('handles co-scheduled breaks where each break contains multiple ads', () => {
+      const ads1 = [{ id: 'a1' }, { id: 'a2' }];
+      const ads2 = [{ id: 'a3' }, { id: 'a4' }];
+      const break1 = makeBreak('break-1', 5, ads1);
+      const break2 = makeBreak('break-2', 5, ads2);
+
+      // Break 1, second ad playing. Sibling break-2 is in list() with its ads already populated,
+      // so total = 2 (current break) + 2 (sibling break) = 4.
+      adsState.activeAdBreak = break1;
+      adsState.list = [break2];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, ads1 as any);
+      adsState.activeAd = ads1[1];
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      expect(adCounterLabel.getText()).toBe('Ad 2 of 4');
+
+      // Break 1 finishes
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      playerMock.eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // Break 2 starts — now its real ad count (2) is known via getActiveAdBreak(), so total updates to 2 + 2 = 4.
+      adsState.activeAdBreak = break2;
+      adsState.list = [];
+      playerMock.eventEmitter.fireAdBreakStartedEvent(5, ads2 as any);
+      adsState.activeAd = ads2[0];
+      playerMock.eventEmitter.fireAdStartedEvent();
+
+      expect(adCounterLabel.getText()).toBe('Ad 3 of 4');
+    });
+  });
+});

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -1,4 +1,5 @@
 import {
+  AdBreak,
   AdBreakEvent,
   AdEvent,
   AirplayChangedEvent,
@@ -31,6 +32,10 @@ export interface ViewModeAvailabilityChangedEvent extends PlayerEventBase {
 
 export class PlayerEventEmitter {
   private eventHandlers: { [eventType: string]: PlayerEventCallback<PlayerEvent>[] } = {};
+  private readonly defaultAdBreak: AdBreak = {
+    id: 'Break-ID',
+    scheduleTime: -1,
+  };
 
   public on<T extends PlayerEvent>(eventType: T, callback: PlayerEventCallback<T>) {
     if (!this.eventHandlers[eventType]) {
@@ -80,14 +85,11 @@ export class PlayerEventEmitter {
     });
   }
 
-  fireAdBreakFinishedEvent(): void {
+  fireAdBreakFinishedEvent(adBreak: AdBreak = this.defaultAdBreak): void {
     this.fireEvent<AdBreakEvent>({
       timestamp: Date.now(),
       type: PlayerEvent.AdBreakFinished,
-      adBreak: {
-        id: 'Break-ID',
-        scheduleTime: -1,
-      },
+      adBreak,
     });
   }
 

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -110,8 +110,9 @@ describe('AdBreakTracker', () => {
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(break1);
 
-      // Between breaks: currentAdIndex is unchanged (still 1), totalNumberOfAds carries last known value
-      expect(tracker.currentAdIndex).toBe(1);
+      // Between breaks no ad is active, so currentAdIndex is 0.
+      // totalNumberOfAds is still derived from the retained group breaks + list.
+      expect(tracker.currentAdIndex).toBe(0);
       expect(tracker.totalNumberOfAds).toBe(2);
     });
 
@@ -179,8 +180,9 @@ describe('AdBreakTracker', () => {
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(break1);
 
-      // currentAdIndex unchanged between breaks; totalNumberOfAds carries group total
-      expect(tracker.currentAdIndex).toBe(1);
+      // Between breaks no ad is active, so currentAdIndex is 0.
+      // Group is not reset: totalNumberOfAds still includes all breaks.
+      expect(tracker.currentAdIndex).toBe(0);
       expect(tracker.totalNumberOfAds).toBe(3);
     });
 
@@ -284,15 +286,12 @@ describe('AdBreakTracker', () => {
       expect(tracker.currentAdIndex).toBe(1);
       expect(tracker.totalNumberOfAds).toBe(2);
 
-      // Break 2 becomes active before break 1's AdBreakFinished fires
+      // Break 2 becomes active before break 1's AdBreakFinished fires.
+      // No dispatch happens between breaks (the next AdStarted will update the UI).
       adsState.activeAdBreak = break2;
       adsState.activeAd = { id: 'a2' };
       adsState.list = [];
       eventEmitter.fireAdBreakFinishedEvent(break1);
-
-      // Offset should be preserved, not reset
-      expect(tracker.currentAdIndex).toBe(1);
-      expect(tracker.totalNumberOfAds).toBe(2);
 
       // Break 2's AdStarted fires
       eventEmitter.fireAdStartedEvent();
@@ -345,7 +344,7 @@ describe('AdBreakTracker', () => {
       expect(onChange).toHaveBeenCalledWith(tracker, { currentAdIndex: 1, totalNumberOfAds: 2 });
     });
 
-    it('dispatches onAdCountChanged with currentAdIndex and totalNumberOfAds after AdBreakFinished', () => {
+    it('does not dispatch onAdCountChanged on AdBreakFinished when more breaks remain in the group', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
       const onChange = jest.fn();
@@ -360,8 +359,8 @@ describe('AdBreakTracker', () => {
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(break1);
 
-      // currentAdIndex retains the last playing ad's index between breaks; only the offset has changed
-      expect(onChange).toHaveBeenCalledWith(tracker, { currentAdIndex: 1, totalNumberOfAds: 2 });
+      // No dispatch between breaks — the next AdStarted will provide up-to-date values
+      expect(onChange).not.toHaveBeenCalled();
     });
   });
 });

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -1,0 +1,307 @@
+import { AdBreak, PlayerEvent } from 'bitmovin-player';
+import { PlayerEventEmitter } from '../helper/PlayerEventEmitter';
+import { AdBreakTracker } from '../../src/ts/utils/AdBreakTracker';
+
+const makeBreak = (id: string, scheduleTime: number, ads: { id: string }[] = []): AdBreak =>
+  ({ id, scheduleTime, ads }) as unknown as AdBreak;
+
+// Mutable ad state the player mock delegates to.
+// `list` represents upcoming breaks (the active break is excluded).
+let adsState: {
+  activeAdBreak: ReturnType<typeof makeBreak> | null;
+  activeAd: { id: string } | null;
+  list: ReturnType<typeof makeBreak>[];
+};
+
+let eventEmitter: PlayerEventEmitter;
+let player: any;
+let tracker: AdBreakTracker;
+
+describe('AdBreakTracker', () => {
+  beforeEach(() => {
+    adsState = { activeAdBreak: null, activeAd: null, list: [] };
+    eventEmitter = new PlayerEventEmitter();
+
+    player = {
+      exports: { PlayerEvent },
+      on: eventEmitter.on.bind(eventEmitter),
+      off: jest.fn(),
+      ads: {
+        getActiveAdBreak: () => adsState.activeAdBreak,
+        getActiveAd: () => adsState.activeAd,
+        list: () => adsState.list,
+      },
+    };
+
+    tracker = new AdBreakTracker(player);
+  });
+
+  afterEach(() => {
+    tracker.release();
+  });
+
+  describe('single ad break (no siblings)', () => {
+    it('returns currentAdIndex=1 and totalNumberOfAds=1 for a single-ad break', () => {
+      const ad = { id: 'a1' };
+      const adBreak = makeBreak('break-1', 5, [ad]);
+      adsState.activeAdBreak = adBreak;
+      adsState.activeAd = ad;
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(1);
+    });
+
+    it('returns correct index for a later ad within the same break', () => {
+      const ads = [{ id: 'a1' }, { id: 'a2' }, { id: 'a3' }];
+      const adBreak = makeBreak('break-1', 5, ads);
+      adsState.activeAdBreak = adBreak;
+      adsState.activeAd = ads[1];
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(2);
+      expect(tracker.totalNumberOfAds).toBe(3);
+    });
+
+    it('does not change currentAdIndex or totalNumberOfAds when a lone break finishes', () => {
+      const ad = { id: 'a1' };
+      const adBreak = makeBreak('break-1', 5, [ad]);
+      adsState.activeAdBreak = adBreak;
+      adsState.activeAd = ad;
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(adBreak);
+
+      // groupScheduleTime is undefined for a lone break, so AdBreakFinished is a no-op
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(1);
+    });
+  });
+
+  describe('co-scheduled ad breaks (same scheduleTime)', () => {
+    it('shows currentAdIndex=1 and totalNumberOfAds=3 for the first of three co-scheduled single-ad breaks', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+      const break3 = makeBreak('break-3', 5, [{ id: 'a3' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2, break3];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(3); // 1 current + 2 siblings
+    });
+
+    it('carries offset after the first break finishes', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // Between breaks: currentAdIndex is unchanged (still 1), totalNumberOfAds carries last known value
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(2);
+    });
+
+    it('shows currentAdIndex=2 and corrected total when the second break starts with its real ad count', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }, { id: 'a3' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // break-2 starts — now its real ad count (2) is known via getActiveAdBreak()
+      adsState.activeAdBreak = break2;
+      adsState.activeAd = { id: 'a2' };
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(2); // 1 offset + position 1 in break2
+      expect(tracker.totalNumberOfAds).toBe(3); // 1 offset + 2 from break-2
+    });
+
+    it('retains last state after the last sibling break finishes (no full reset until next AdStarted)', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      adsState.activeAdBreak = break2;
+      adsState.activeAd = { id: 'a2' };
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break2);
+
+      // AdBreakFinished accumulates offset; currentAdIndex holds its last value until the next AdStarted
+      expect(tracker.currentAdIndex).toBe(2);
+      expect(tracker.totalNumberOfAds).toBe(2);
+    });
+
+    it('does not reset between breaks while siblings remain', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+      const break3 = makeBreak('break-3', 5, [{ id: 'a3' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2, break3];
+      eventEmitter.fireAdStartedEvent();
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // currentAdIndex unchanged between breaks; totalNumberOfAds carries group total
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(3);
+    });
+
+    it('ignores AdBreakFinished for a different scheduleTime', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+      const unrelated = makeBreak('break-x', 10, [{ id: 'ax' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      eventEmitter.fireAdBreakFinishedEvent(unrelated); // should be a no-op
+
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(2);
+    });
+
+    it('handles three single-ad breaks producing correct indices throughout', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+      const break3 = makeBreak('break-3', 5, [{ id: 'a3' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2, break3];
+      eventEmitter.fireAdStartedEvent();
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(3);
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+      adsState.activeAdBreak = break2;
+      adsState.activeAd = { id: 'a2' };
+      adsState.list = [break3];
+      eventEmitter.fireAdStartedEvent();
+      expect(tracker.currentAdIndex).toBe(2);
+      expect(tracker.totalNumberOfAds).toBe(3);
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break2);
+      adsState.activeAdBreak = break3;
+      adsState.activeAd = { id: 'a3' };
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+      expect(tracker.currentAdIndex).toBe(3);
+      expect(tracker.totalNumberOfAds).toBe(3);
+
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break3);
+      // After all breaks done, currentAdIndex holds last value until next AdStarted
+      expect(tracker.currentAdIndex).toBe(3);
+      expect(tracker.totalNumberOfAds).toBe(3);
+    });
+
+    it('resets correctly so a subsequent unrelated break shows 1 of 1', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      adsState.activeAdBreak = break2;
+      adsState.activeAd = { id: 'a2' };
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break2);
+
+      const breakNext = makeBreak('break-next', 10, [{ id: 'ax' }]);
+      adsState.activeAdBreak = breakNext;
+      adsState.activeAd = { id: 'ax' };
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(1);
+    });
+
+    it('dispatches onChanged with currentAdIndex and totalNumberOfAds after AdStarted', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+      const onChange = jest.fn();
+      tracker.onChanged.subscribe(onChange);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(onChange).toHaveBeenCalledWith(tracker, { currentAdIndex: 1, totalNumberOfAds: 2 });
+    });
+
+    it('dispatches onChanged with currentAdIndex and totalNumberOfAds after AdBreakFinished', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+      const onChange = jest.fn();
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      tracker.onChanged.subscribe(onChange);
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // currentAdIndex retains the last playing ad's index between breaks; only the offset has changed
+      expect(onChange).toHaveBeenCalledWith(tracker, { currentAdIndex: 1, totalNumberOfAds: 2 });
+    });
+  });
+});

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -270,6 +270,36 @@ describe('AdBreakTracker', () => {
       expect(tracker.totalNumberOfAds).toBe(1);
     });
 
+    it('handles co-scheduled breaks where each break contains multiple ads', () => {
+      const ads1 = [{ id: 'a1' }, { id: 'a2' }];
+      const ads2 = [{ id: 'a3' }, { id: 'a4' }];
+      const break1 = makeBreak('break-1', 5, ads1);
+      const break2 = makeBreak('break-2', 5, ads2);
+
+      // Break 1, second ad playing
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = ads1[1];
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(2);
+      expect(tracker.totalNumberOfAds).toBe(4); // 2 from break1 + 2 from break2
+
+      // Break 1 finishes
+      adsState.activeAd = null;
+      adsState.activeAdBreak = null;
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // Break 2 starts, first ad
+      adsState.activeAdBreak = break2;
+      adsState.activeAd = ads2[0];
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(3); // 2 offset + position 1 in break2
+      expect(tracker.totalNumberOfAds).toBe(4); // 2 offset + 2 from break2
+    });
+
     it('dispatches onAdCountChanged with currentAdIndex and totalNumberOfAds after AdStarted', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -40,7 +40,7 @@ describe('AdBreakTracker', () => {
     tracker.release();
   });
 
-  describe('single ad break (no siblings)', () => {
+  describe('single ad break (no subsequent ad breaks)', () => {
     it('returns currentAdIndex=1 and totalNumberOfAds=1 for a single-ad break', () => {
       const ad = { id: 'a1' };
       const adBreak = makeBreak('break-1', 5, [ad]);
@@ -82,8 +82,8 @@ describe('AdBreakTracker', () => {
     });
   });
 
-  describe('co-scheduled ad breaks (same scheduleTime)', () => {
-    it('shows currentAdIndex=1 and totalNumberOfAds=3 for the first of three co-scheduled single-ad breaks', () => {
+  describe('subsequent ad breaks (same scheduleTime)', () => {
+    it('shows currentAdIndex=1 and totalNumberOfAds=3 for the first of three subsequent single-ad breaks', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
       const break3 = makeBreak('break-3', 5, [{ id: 'a3' }]);
@@ -94,7 +94,7 @@ describe('AdBreakTracker', () => {
       eventEmitter.fireAdStartedEvent();
 
       expect(tracker.currentAdIndex).toBe(1);
-      expect(tracker.totalNumberOfAds).toBe(3); // 1 current + 2 siblings
+      expect(tracker.totalNumberOfAds).toBe(3);
     });
 
     it('carries offset after the first break finishes', () => {
@@ -138,7 +138,7 @@ describe('AdBreakTracker', () => {
       expect(tracker.totalNumberOfAds).toBe(3); // 1 offset + 2 from break-2
     });
 
-    it('resets to 0 after the last sibling break finishes', () => {
+    it('resets to 0 after the last subsequent ad break finishes', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
 
@@ -160,12 +160,12 @@ describe('AdBreakTracker', () => {
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(break2);
 
-      // No siblings remain: tracker resets so currentAdIndex=0 (no ad is active)
+      // No subsequent ad breaks remain: tracker resets so currentAdIndex=0 (no ad is active)
       expect(tracker.currentAdIndex).toBe(0);
       expect(tracker.totalNumberOfAds).toBe(0);
     });
 
-    it('does not reset between breaks while siblings remain', () => {
+    it('does not reset between breaks while subsequent ad breaks remain', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
       const break3 = makeBreak('break-3', 5, [{ id: 'a3' }]);
@@ -235,7 +235,8 @@ describe('AdBreakTracker', () => {
       adsState.activeAd = null;
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(break3);
-      // No siblings remain after the last break finishes: tracker resets
+
+      // No subsequent ad breaks remain after the last break finishes: tracker resets
       expect(tracker.currentAdIndex).toBe(0);
       expect(tracker.totalNumberOfAds).toBe(0);
     });
@@ -270,7 +271,7 @@ describe('AdBreakTracker', () => {
       expect(tracker.totalNumberOfAds).toBe(1);
     });
 
-    it('handles co-scheduled breaks where each break contains multiple ads', () => {
+    it('handles subsequent ad breaks where each break contains multiple ads', () => {
       const ads1 = [{ id: 'a1' }, { id: 'a2' }];
       const ads2 = [{ id: 'a3' }, { id: 'a4' }];
       const break1 = makeBreak('break-1', 5, ads1);
@@ -296,8 +297,8 @@ describe('AdBreakTracker', () => {
       adsState.list = [];
       eventEmitter.fireAdStartedEvent();
 
-      expect(tracker.currentAdIndex).toBe(3); // 2 offset + position 1 in break2
-      expect(tracker.totalNumberOfAds).toBe(4); // 2 offset + 2 from break2
+      expect(tracker.currentAdIndex).toBe(3);
+      expect(tracker.totalNumberOfAds).toBe(4);
     });
 
     it('dispatches onAdCountChanged with currentAdIndex and totalNumberOfAds after AdStarted', () => {

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -270,11 +270,11 @@ describe('AdBreakTracker', () => {
       expect(tracker.totalNumberOfAds).toBe(1);
     });
 
-    it('dispatches onChanged with currentAdIndex and totalNumberOfAds after AdStarted', () => {
+    it('dispatches onAdCountChanged with currentAdIndex and totalNumberOfAds after AdStarted', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
       const onChange = jest.fn();
-      tracker.onChanged.subscribe(onChange);
+      tracker.onAdCountChanged.subscribe(onChange);
 
       adsState.activeAdBreak = break1;
       adsState.activeAd = { id: 'a1' };
@@ -284,7 +284,7 @@ describe('AdBreakTracker', () => {
       expect(onChange).toHaveBeenCalledWith(tracker, { currentAdIndex: 1, totalNumberOfAds: 2 });
     });
 
-    it('dispatches onChanged with currentAdIndex and totalNumberOfAds after AdBreakFinished', () => {
+    it('dispatches onAdCountChanged with currentAdIndex and totalNumberOfAds after AdBreakFinished', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
       const onChange = jest.fn();
@@ -294,7 +294,7 @@ describe('AdBreakTracker', () => {
       adsState.list = [break2];
       eventEmitter.fireAdStartedEvent();
 
-      tracker.onChanged.subscribe(onChange);
+      tracker.onAdCountChanged.subscribe(onChange);
       adsState.activeAd = null;
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(break1);

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -139,7 +139,7 @@ describe('AdBreakTracker', () => {
       expect(tracker.totalNumberOfAds).toBe(3); // 1 offset + 2 from break-2
     });
 
-    it('retains last state after the last sibling break finishes (no full reset until next AdStarted)', () => {
+    it('resets to 0 after the last sibling break finishes', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
 
@@ -161,9 +161,9 @@ describe('AdBreakTracker', () => {
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(break2);
 
-      // AdBreakFinished accumulates offset; currentAdIndex holds its last value until the next AdStarted
-      expect(tracker.currentAdIndex).toBe(2);
-      expect(tracker.totalNumberOfAds).toBe(2);
+      // No siblings remain: tracker resets so currentAdIndex=0 (no ad is active)
+      expect(tracker.currentAdIndex).toBe(0);
+      expect(tracker.totalNumberOfAds).toBe(0);
     });
 
     it('does not reset between breaks while siblings remain', () => {
@@ -236,9 +236,9 @@ describe('AdBreakTracker', () => {
       adsState.activeAd = null;
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(break3);
-      // After all breaks done, currentAdIndex holds last value until next AdStarted
-      expect(tracker.currentAdIndex).toBe(3);
-      expect(tracker.totalNumberOfAds).toBe(3);
+      // No siblings remain after the last break finishes: tracker resets
+      expect(tracker.currentAdIndex).toBe(0);
+      expect(tracker.totalNumberOfAds).toBe(0);
     });
 
     it('resets correctly so a subsequent unrelated break shows 1 of 1', () => {

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -271,6 +271,36 @@ describe('AdBreakTracker', () => {
       expect(tracker.totalNumberOfAds).toBe(1);
     });
 
+    it('carries offset when the next break is already active before AdBreakFinished fires', () => {
+      const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
+      const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);
+
+      // Break 1 starts
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(2);
+
+      // Break 2 becomes active before break 1's AdBreakFinished fires
+      adsState.activeAdBreak = break2;
+      adsState.activeAd = { id: 'a2' };
+      adsState.list = [];
+      eventEmitter.fireAdBreakFinishedEvent(break1);
+
+      // Offset should be preserved, not reset
+      expect(tracker.currentAdIndex).toBe(1);
+      expect(tracker.totalNumberOfAds).toBe(2);
+
+      // Break 2's AdStarted fires
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(2);
+      expect(tracker.totalNumberOfAds).toBe(2);
+    });
+
     it('handles subsequent ad breaks where each break contains multiple ads', () => {
       const ads1 = [{ id: 'a1' }, { id: 'a2' }];
       const ads2 = [{ id: 'a3' }, { id: 'a4' }];

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -65,7 +65,7 @@ describe('AdBreakTracker', () => {
       expect(tracker.totalNumberOfAds).toBe(3);
     });
 
-    it('does not change currentAdIndex or totalNumberOfAds when a lone break finishes', () => {
+    it('resets currentAdIndex and totalNumberOfAds to 0 when a lone break finishes', () => {
       const ad = { id: 'a1' };
       const adBreak = makeBreak('break-1', 5, [ad]);
       adsState.activeAdBreak = adBreak;
@@ -77,9 +77,8 @@ describe('AdBreakTracker', () => {
       adsState.activeAdBreak = null;
       eventEmitter.fireAdBreakFinishedEvent(adBreak);
 
-      // groupScheduleTime is undefined for a lone break, so AdBreakFinished is a no-op
-      expect(tracker.currentAdIndex).toBe(1);
-      expect(tracker.totalNumberOfAds).toBe(1);
+      expect(tracker.currentAdIndex).toBe(0);
+      expect(tracker.totalNumberOfAds).toBe(0);
     });
   });
 

--- a/spec/utils/StringUtils.spec.ts
+++ b/spec/utils/StringUtils.spec.ts
@@ -138,6 +138,67 @@ describe('StringUtils.replaceAdMessagePlaceholders', () => {
     expect(result).toBe('Ad 0 of 0');
   });
 
+  it('uses provided activeAdIndex directly without calling player API', () => {
+    const getActiveAdBreak = jest.fn();
+    const getActiveAd = jest.fn();
+    const playerMock = createPlayer({ ads: { getActiveAdBreak, getActiveAd } });
+
+    const result = StringUtils.replaceAdMessagePlaceholders('Ad {activeAdIndex}', playerMock as any, undefined, 3);
+
+    expect(result).toBe('Ad 3');
+    expect(getActiveAdBreak).not.toHaveBeenCalled();
+    expect(getActiveAd).not.toHaveBeenCalled();
+  });
+
+  it('uses provided totalNumberOfAds directly without calling player API', () => {
+    const getActiveAdBreak = jest.fn();
+    const playerMock = createPlayer({ ads: { getActiveAdBreak, getActiveAd: jest.fn() } });
+
+    const result = StringUtils.replaceAdMessagePlaceholders(
+      'of {totalAdsCount}',
+      playerMock as any,
+      undefined,
+      undefined,
+      5,
+    );
+
+    expect(result).toBe('of 5');
+    expect(getActiveAdBreak).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ads.length for totalAdsCount when not provided but ad break is available', () => {
+    const ads = [{ id: 'a1' }, { id: 'a2' }];
+    const playerMock = createPlayer({
+      ads: {
+        getActiveAdBreak: jest.fn().mockReturnValue({ ads }),
+        getActiveAd: jest.fn().mockReturnValue(null),
+      },
+    });
+
+    const result = StringUtils.replaceAdMessagePlaceholders('of {totalAdsCount}', playerMock as any);
+
+    expect(result).toBe('of 2');
+  });
+
+  it('uses provided activeAdIndex even when player has no active ad context', () => {
+    const playerMock = createPlayer({
+      ads: {
+        getActiveAdBreak: jest.fn().mockReturnValue(null),
+        getActiveAd: jest.fn().mockReturnValue(null),
+      },
+    });
+
+    const result = StringUtils.replaceAdMessagePlaceholders(
+      'Ad {activeAdIndex} of {totalAdsCount}',
+      playerMock as any,
+      undefined,
+      2,
+      4,
+    );
+
+    expect(result).toBe('Ad 2 of 4');
+  });
+
   it('supports mm:ss formatting for time placeholders', () => {
     const playerMock = createPlayer({
       getCurrentTime: jest.fn().mockReturnValue(0),

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -18,6 +18,7 @@ import { SubtitleSettingsManager } from './utils/SubtitleSettingsManager';
 import { StorageUtils } from './utils/StorageUtils';
 import { BufferingOverlay } from './components/overlays/BufferingOverlay';
 import { ShadowDomManager } from './utils/ShadowDomManager';
+import { AdBreakTracker } from './utils/AdBreakTracker';
 
 /**
  * @category Configs
@@ -61,6 +62,7 @@ export interface InternalUIConfig extends UIConfig {
     onUpdated: EventDispatcher<UIManager, void>;
   };
   volumeController: VolumeController;
+  adBreakTracker: AdBreakTracker;
 }
 
 /**
@@ -206,6 +208,7 @@ export class UIManager {
         onUpdated: new EventDispatcher<UIManager, void>(),
       },
       volumeController: new VolumeController(this.managerPlayerWrapper.getPlayer()),
+      adBreakTracker: new AdBreakTracker(this.managerPlayerWrapper.getPlayer()),
     };
 
     /**
@@ -610,6 +613,8 @@ export class UIManager {
   }
 
   release(): void {
+    this.config.adBreakTracker.release();
+
     for (const uiInstanceManager of this.uiInstanceManagers) {
       this.releaseUi(uiInstanceManager);
     }

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -41,10 +41,7 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
     this.player = player;
 
     this.adBreakTracker = uimanager.getConfig().adBreakTracker;
-
-    this.adBreakTracker.onAdCountChanged.subscribe((_, adBreakTrackerEvent: AdBreakTrackerAdCountChangedArgs) => {
-      this.setAdCounterFromAdBreakTracker(adBreakTrackerEvent.currentAdIndex, adBreakTrackerEvent.totalNumberOfAds);
-    });
+    this.adBreakTracker.onAdCountChanged.subscribe(this.adBreakTrackerAdCountChangedHandler);
 
     // An ad break may already be ongoing when configure is called, in this case the onAdCountChanged event was missed
     // and the label is set here
@@ -54,6 +51,8 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
   }
 
   release(): void {
+    this.adBreakTracker?.onAdCountChanged.unsubscribe(this.adBreakTrackerAdCountChangedHandler);
+
     this.adBreakTracker = undefined;
     this.player = undefined;
 
@@ -65,6 +64,13 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
       this.setAdCounterFromAdBreakTracker(this.adBreakTracker?.currentAdIndex, this.adBreakTracker?.totalNumberOfAds);
     }
   }
+
+  private readonly adBreakTrackerAdCountChangedHandler = (
+    _: AdBreakTracker,
+    adBreakTrackerEvent: AdBreakTrackerAdCountChangedArgs,
+  ) => {
+    this.setAdCounterFromAdBreakTracker(adBreakTrackerEvent.currentAdIndex, adBreakTrackerEvent.totalNumberOfAds);
+  };
 
   private setAdCounterFromAdBreakTracker(currentAdIndex?: number, totalNumberOfAds?: number) {
     if (currentAdIndex === 0 && totalNumberOfAds === 0) {

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -3,7 +3,7 @@ import { UIInstanceManager } from '../../UIManager';
 import { LabelConfig, Label } from '../labels/Label';
 import { PlayerAPI } from 'bitmovin-player';
 import { StringUtils } from '../../utils/StringUtils';
-import { AdBreakTracker, AdBreakTrackerChangedArgs } from '../../utils/AdBreakTracker';
+import { AdBreakTracker, AdBreakTrackerAdCountChangedArgs } from '../../utils/AdBreakTracker';
 
 export interface AdCounterLabelConfig extends LabelConfig {
   /**
@@ -42,7 +42,7 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
 
     this.adBreakTracker = uimanager.getConfig().adBreakTracker;
 
-    this.adBreakTracker.onAdCountChanged.subscribe((_, adBreakTrackerEvent: AdBreakTrackerChangedArgs) => {
+    this.adBreakTracker.onAdCountChanged.subscribe((_, adBreakTrackerEvent: AdBreakTrackerAdCountChangedArgs) => {
       this.setText(
         StringUtils.replaceAdMessagePlaceholders(
           i18n.performLocalization(this.config.adCountOutOfTotal),

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -7,7 +7,8 @@ import { AdBreakTracker, AdBreakTrackerChangedArgs } from '../../utils/AdBreakTr
 
 export interface AdCounterLabelConfig extends LabelConfig {
   /**
-   * Message displayed during the ad indicating which ad out of how many in the current ad break is currently playing.
+   * Message displayed during the ad indicating which ad out of how many is currently playing. It takes all ad breaks
+   * with the same schedule time into account.
    * Supported placeholders: look at {@link StringUtils.replaceAdMessagePlaceholders}
    */
   adCountOutOfTotal?: LocalizableText;

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -54,34 +54,37 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
       );
     });
 
-    player.on(player.exports.PlayerEvent.AdBreakStarted, () => {
-      this.setText('');
-    });
-
-    player.on(player.exports.PlayerEvent.AdBreakFinished, () => {
-      this.setText('');
-    });
+    player.on(player.exports.PlayerEvent.AdBreakStarted, this.clearText);
+    player.on(player.exports.PlayerEvent.AdBreakFinished, this.clearText);
   }
 
+  clearText = () => {
+    super.clearText();
+  };
+
   release(): void {
+    this.player?.on(this.player.exports.PlayerEvent.AdBreakStarted, this.clearText);
+    this.player?.on(this.player.exports.PlayerEvent.AdBreakFinished, this.clearText);
+
     this.adBreakTracker?.release();
+
     this.adBreakTracker = undefined;
+    this.player = undefined;
+
     super.release();
   }
 
   protected onLanguageChanged(): void {
-    if (this.player?.ads?.isLinearAdActive?.()) {
-      if (this.adBreakTracker) {
-        this.setText(
-          StringUtils.replaceAdMessagePlaceholders(
-            i18n.performLocalization(this.config.adCountOutOfTotal),
-            this.player,
-            undefined,
-            this.adBreakTracker.currentAdIndex,
-            this.adBreakTracker.totalNumberOfAds,
-          ),
-        );
-      }
+    if (this.adBreakTracker?.currentAdIndex > 0 || this.player?.ads?.isLinearAdActive?.()) {
+      this.setText(
+        StringUtils.replaceAdMessagePlaceholders(
+          i18n.performLocalization(this.config.adCountOutOfTotal),
+          this.player,
+          undefined,
+          this.adBreakTracker?.currentAdIndex,
+          this.adBreakTracker?.totalNumberOfAds,
+        ),
+      );
     }
   }
 }

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -43,16 +43,14 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
     this.adBreakTracker = uimanager.getConfig().adBreakTracker;
 
     this.adBreakTracker.onAdCountChanged.subscribe((_, adBreakTrackerEvent: AdBreakTrackerAdCountChangedArgs) => {
-      this.setText(
-        StringUtils.replaceAdMessagePlaceholders(
-          i18n.performLocalization(this.config.adCountOutOfTotal),
-          player,
-          undefined,
-          adBreakTrackerEvent.currentAdIndex,
-          adBreakTrackerEvent.totalNumberOfAds,
-        ),
-      );
+      this.setAdCounterFromAdBreakTracker(adBreakTrackerEvent.currentAdIndex, adBreakTrackerEvent.totalNumberOfAds);
     });
+
+    // An ad break may already be ongoing when configure is called, in this case the onAdCountChanged event was missed
+    // and the label is set here
+    if (this.adBreakTracker.currentAdIndex > 0 && this.adBreakTracker.totalNumberOfAds > 0) {
+      this.setAdCounterFromAdBreakTracker(this.adBreakTracker.currentAdIndex, this.adBreakTracker.totalNumberOfAds);
+    }
 
     player.on(player.exports.PlayerEvent.AdBreakStarted, this.clearText);
     player.on(player.exports.PlayerEvent.AdBreakFinished, this.clearText);
@@ -76,15 +74,19 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
 
   protected onLanguageChanged(): void {
     if (this.adBreakTracker?.currentAdIndex > 0 || this.player?.ads?.isLinearAdActive?.()) {
-      this.setText(
-        StringUtils.replaceAdMessagePlaceholders(
-          i18n.performLocalization(this.config.adCountOutOfTotal),
-          this.player,
-          undefined,
-          this.adBreakTracker?.currentAdIndex,
-          this.adBreakTracker?.totalNumberOfAds,
-        ),
-      );
+      this.setAdCounterFromAdBreakTracker(this.adBreakTracker?.currentAdIndex, this.adBreakTracker?.totalNumberOfAds);
     }
+  }
+
+  private setAdCounterFromAdBreakTracker(currentAdIndex: number, totalNumberOfAds: number) {
+    this.setText(
+      StringUtils.replaceAdMessagePlaceholders(
+        i18n.performLocalization(this.config.adCountOutOfTotal),
+        this.player,
+        undefined,
+        currentAdIndex,
+        totalNumberOfAds,
+      ),
+    );
   }
 }

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -51,19 +51,9 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
     if (this.adBreakTracker.currentAdIndex > 0 && this.adBreakTracker.totalNumberOfAds > 0) {
       this.setAdCounterFromAdBreakTracker(this.adBreakTracker.currentAdIndex, this.adBreakTracker.totalNumberOfAds);
     }
-
-    player.on(player.exports.PlayerEvent.AdBreakStarted, this.clearText);
-    player.on(player.exports.PlayerEvent.AdBreakFinished, this.clearText);
   }
 
-  clearText = () => {
-    super.clearText();
-  };
-
   release(): void {
-    this.player?.off(this.player.exports.PlayerEvent.AdBreakStarted, this.clearText);
-    this.player?.off(this.player.exports.PlayerEvent.AdBreakFinished, this.clearText);
-
     this.adBreakTracker?.release();
 
     this.adBreakTracker = undefined;
@@ -78,7 +68,13 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
     }
   }
 
-  private setAdCounterFromAdBreakTracker(currentAdIndex: number, totalNumberOfAds: number) {
+  private setAdCounterFromAdBreakTracker(currentAdIndex?: number, totalNumberOfAds?: number) {
+    if (currentAdIndex === 0 && totalNumberOfAds === 0) {
+      // No ad break active and no subsequent ad breaks
+      this.setText('');
+      return;
+    }
+
     this.setText(
       StringUtils.replaceAdMessagePlaceholders(
         i18n.performLocalization(this.config.adCountOutOfTotal),

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -42,7 +42,7 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
 
     this.adBreakTracker = new AdBreakTracker(player);
 
-    this.adBreakTracker.onChanged.subscribe((_, adBreakTrackerEvent: AdBreakTrackerChangedArgs) => {
+    this.adBreakTracker.onAdCountChanged.subscribe((_, adBreakTrackerEvent: AdBreakTrackerChangedArgs) => {
       this.setText(
         StringUtils.replaceAdMessagePlaceholders(
           i18n.performLocalization(this.config.adCountOutOfTotal),

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -61,8 +61,8 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
   };
 
   release(): void {
-    this.player?.on(this.player.exports.PlayerEvent.AdBreakStarted, this.clearText);
-    this.player?.on(this.player.exports.PlayerEvent.AdBreakFinished, this.clearText);
+    this.player?.off(this.player.exports.PlayerEvent.AdBreakStarted, this.clearText);
+    this.player?.off(this.player.exports.PlayerEvent.AdBreakFinished, this.clearText);
 
     this.adBreakTracker?.release();
 

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -3,6 +3,7 @@ import { UIInstanceManager } from '../../UIManager';
 import { LabelConfig, Label } from '../labels/Label';
 import { PlayerAPI } from 'bitmovin-player';
 import { StringUtils } from '../../utils/StringUtils';
+import { AdBreakTracker, AdBreakTrackerChangedArgs } from '../../utils/AdBreakTracker';
 
 export interface AdCounterLabelConfig extends LabelConfig {
   /**
@@ -19,15 +20,7 @@ export interface AdCounterLabelConfig extends LabelConfig {
  */
 export class AdCounterLabel extends Label<AdCounterLabelConfig> {
   private player?: PlayerAPI;
-  private updateLabelText = () => {
-    if (!this.player) {
-      return;
-    }
-
-    this.setText(
-      StringUtils.replaceAdMessagePlaceholders(i18n.performLocalization(this.config.adCountOutOfTotal), this.player),
-    );
-  };
+  private adBreakTracker?: AdBreakTracker;
 
   constructor(config: AdCounterLabelConfig = {}) {
     super(config);
@@ -46,20 +39,48 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
     super.configure(player, uimanager);
     this.player = player;
 
-    const clearText = () => {
-      this.setText('');
-    };
+    this.adBreakTracker = new AdBreakTracker(player);
 
-    player.on(player.exports.PlayerEvent.AdStarted, () => {
-      this.updateLabelText();
+    this.adBreakTracker.onChanged.subscribe((_, adBreakTrackerEvent: AdBreakTrackerChangedArgs) => {
+      this.setText(
+        StringUtils.replaceAdMessagePlaceholders(
+          i18n.performLocalization(this.config.adCountOutOfTotal),
+          player,
+          undefined,
+          adBreakTrackerEvent.currentAdIndex,
+          adBreakTrackerEvent.totalNumberOfAds,
+        ),
+      );
     });
-    player.on(player.exports.PlayerEvent.AdBreakStarted, clearText);
-    player.on(player.exports.PlayerEvent.AdBreakFinished, clearText);
+
+    player.on(player.exports.PlayerEvent.AdBreakStarted, () => {
+      this.setText('');
+    });
+
+    player.on(player.exports.PlayerEvent.AdBreakFinished, () => {
+      this.setText('');
+    });
+  }
+
+  release(): void {
+    this.adBreakTracker?.release();
+    this.adBreakTracker = undefined;
+    super.release();
   }
 
   protected onLanguageChanged(): void {
     if (this.player?.ads?.isLinearAdActive?.()) {
-      this.updateLabelText();
+      if (this.adBreakTracker) {
+        this.setText(
+          StringUtils.replaceAdMessagePlaceholders(
+            i18n.performLocalization(this.config.adCountOutOfTotal),
+            this.player,
+            undefined,
+            this.adBreakTracker.currentAdIndex,
+            this.adBreakTracker.totalNumberOfAds,
+          ),
+        );
+      }
     }
   }
 }

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -54,8 +54,6 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
   }
 
   release(): void {
-    this.adBreakTracker?.release();
-
     this.adBreakTracker = undefined;
     this.player = undefined;
 

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -40,7 +40,7 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
     super.configure(player, uimanager);
     this.player = player;
 
-    this.adBreakTracker = new AdBreakTracker(player);
+    this.adBreakTracker = uimanager.getConfig().adBreakTracker;
 
     this.adBreakTracker.onAdCountChanged.subscribe((_, adBreakTrackerEvent: AdBreakTrackerChangedArgs) => {
       this.setText(

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -128,7 +128,13 @@ export class AdBreakTracker {
       b => b.scheduleTime === this.groupScheduleTime,
     );
 
-    if (remainingSubsequentAdBreaks.length === 0) {
+    // The next break in the group may already be active (and thus removed from `list()`),
+    // so also check whether the currently active break shares the same scheduleTime.
+    const activeBreak = this.player.ads?.getActiveAdBreak?.();
+    const activeBreakInGroup =
+      activeBreak?.scheduleTime === this.groupScheduleTime && this.groupScheduleTime !== undefined;
+
+    if (remainingSubsequentAdBreaks.length === 0 && !activeBreakInGroup) {
       this.reset();
     } else {
       this.adIndexOffsetOfPreviousBreaks += this.numberOfAdsInCurrentAdBreak;

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -12,7 +12,7 @@ export interface AdBreakTrackerChangedArgs {
  *
  * When multiple ad breaks are scheduled at the same position, the player fires separate
  * `AdBreakStarted`/`AdBreakFinished` events for each. This tracker accumulates state across those
- * events and dispatches {@link onChanged} after each update so callers can derive a group-wide
+ * events and dispatches {@link onAdCountChanged} after each update so callers can derive a group-wide
  * `currentAdIndex` and `totalNumberOfAds` to pass to
  * {@link StringUtils.replaceAdMessagePlaceholders}.
  *
@@ -31,7 +31,7 @@ export class AdBreakTracker {
   private numberOfAdsInCurrentAdBreak: number = 0;
 
   private readonly events = {
-    onChanged: new EventDispatcher<AdBreakTracker, AdBreakTrackerChangedArgs>(),
+    onAdCountChanged: new EventDispatcher<AdBreakTracker, AdBreakTrackerChangedArgs>(),
   };
 
   constructor(private readonly player: PlayerAPI) {
@@ -41,8 +41,8 @@ export class AdBreakTracker {
     player.on(player.exports.PlayerEvent.AdBreakFinished, this.handleAdBreakFinished);
   }
 
-  get onChanged(): Event<AdBreakTracker, AdBreakTrackerChangedArgs> {
-    return this.events.onChanged.getEvent();
+  get onAdCountChanged(): Event<AdBreakTracker, AdBreakTrackerChangedArgs> {
+    return this.events.onAdCountChanged.getEvent();
   }
 
   /**
@@ -63,7 +63,7 @@ export class AdBreakTracker {
     this.player.off(this.player.exports.PlayerEvent.AdStarted, this.handleAdStarted);
     this.player.off(this.player.exports.PlayerEvent.AdBreakFinished, this.handleAdBreakFinished);
     this.reset();
-    this.events.onChanged.unsubscribeAll();
+    this.events.onAdCountChanged.unsubscribeAll();
   }
 
   private readonly handleAdStarted = (): void => {
@@ -135,7 +135,7 @@ export class AdBreakTracker {
   };
 
   private dispatchChanged(): void {
-    this.events.onChanged.dispatch(this, {
+    this.events.onAdCountChanged.dispatch(this, {
       currentAdIndex: this.currentAdIndex,
       totalNumberOfAds: this.totalNumberOfAdsAcrossBreaks,
     });

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -92,9 +92,8 @@ export class AdBreakTracker {
     ) {
       this.groupScheduleTime = activeBreak.scheduleTime;
       this.currentAdIndexAcrossBreaks = withinBreakIndex + 1 + this.adIndexOffsetOfPreviousBreaks;
-      // Sibling ads arrays may not be populated yet (VAST manifests load lazily), so count
-      // sibling breaks and assume 1 ad each. totalAdsOverride self-corrects on each subsequent
-      // AdStarted as real ad counts become known.
+      // Sibling ads arrays may not be populated yet (VAST manifests load lazily), so we use the ads count if available,
+      // or assume 1 ad per break if not available. It will update and self-correct with each AdStarted event.
       const remainingSiblingAdCount = siblings.reduce(
         (sum, adBreak) => sum + (adBreak.ads?.length > 0 ? adBreak.ads.length : 1),
         0,

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -115,6 +115,10 @@ export class AdBreakTracker {
     const adBreak = adBreakFinishedEvent.adBreak;
 
     if (adBreak.scheduleTime !== this.groupScheduleTime) {
+      if (this.groupScheduleTime === undefined) {
+        this.reset();
+        this.dispatchChanged();
+      }
       return;
     }
 

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -115,6 +115,11 @@ export class AdBreakTracker {
     const isPartOfExistingGroup = this.groupBreaks.length > 0 && activeBreak.scheduleTime === this.groupScheduleTime;
 
     if (isPartOfExistingGroup || hasSubsequentBreaks) {
+      if (!isPartOfExistingGroup && this.groupBreaks.length > 0) {
+        // New group at a different scheduleTime — clear stale state from a previous group
+        this.groupBreaks = [];
+      }
+
       this.groupScheduleTime = activeBreak.scheduleTime;
 
       // Add the active break if it's not already retained (new break in the group)

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -117,8 +117,14 @@ export class AdBreakTracker {
       return;
     }
 
-    this.adIndexOffsetOfPreviousBreaks += this.numberOfAdsInCurrentAdBreak;
-    this.numberOfAdsInCurrentAdBreak = 0;
+    const remainingSiblings = (this.player.ads?.list?.() ?? []).filter(b => b.scheduleTime === this.groupScheduleTime);
+
+    if (remainingSiblings.length === 0) {
+      this.reset();
+    } else {
+      this.adIndexOffsetOfPreviousBreaks += this.numberOfAdsInCurrentAdBreak;
+      this.numberOfAdsInCurrentAdBreak = 0;
+    }
 
     this.dispatchChanged();
   };

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -77,10 +77,11 @@ export class AdBreakTracker {
     // Note: `player.ads.list()` provides all ad breaks except past ad breaks or the currently active ad break
     const siblings = (this.player.ads?.list?.() ?? []).filter(b => b.scheduleTime === activeBreak.scheduleTime);
 
-    this.numberOfAdsInCurrentAdBreak = activeBreak.ads?.length ?? 0;
-
     const activeAd = this.player.ads?.getActiveAd?.();
     const ads = activeBreak.ads;
+
+    // If ads are not yet loaded, assume 1 ad in the current break.
+    this.numberOfAdsInCurrentAdBreak = Array.isArray(ads) && ads.length > 0 ? ads.length : 1;
     const withinBreakIndex =
       Array.isArray(ads) && activeAd
         ? ads.findIndex(ad => (activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd))

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -53,7 +53,6 @@ export class AdBreakTracker {
     let offset = 0;
     for (const adBreak of this.groupBreaks) {
       const ads = adBreak.ads ?? [];
-      const adCount = ads.length > 0 ? ads.length : 1;
 
       if (ads.length > 0) {
         // ad.id/activeAd.id may be null/undefined, in which case we fall back to object reference comparison
@@ -64,9 +63,17 @@ export class AdBreakTracker {
         if (activeAdIndex >= 0) {
           return offset + activeAdIndex + 1;
         }
-      }
 
-      offset += adCount;
+        offset += ads.length;
+      } else {
+        // ads not yet populated — if this is the active break, the active ad is its first ad
+        const activeBreak = this.player.ads?.getActiveAdBreak?.();
+        if (activeBreak === adBreak || (activeBreak?.id != null && activeBreak.id === adBreak.id)) {
+          return offset + 1;
+        }
+
+        offset += 1;
+      }
     }
 
     // Active ad not found in any retained break — fall back to offset + 1

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -1,0 +1,137 @@
+import { AdBreakEvent, PlayerAPI } from 'bitmovin-player';
+import { Event, EventDispatcher } from '../EventDispatcher';
+
+export interface AdBreakTrackerChangedArgs {
+  currentAdIndex: number;
+  totalNumberOfAds: number;
+}
+
+/**
+ * Tracks a group of ad breaks that share the same `scheduleTime`, enabling a unified ad counter
+ * across what the player models as separate ad breaks.
+ *
+ * When multiple ad breaks are scheduled at the same position, the player fires separate
+ * `AdBreakStarted`/`AdBreakFinished` events for each. This tracker accumulates state across those
+ * events and dispatches {@link onChanged} after each update so callers can derive a group-wide
+ * `currentAdIndex` and `totalNumberOfAds` to pass to
+ * {@link StringUtils.replaceAdMessagePlaceholders}.
+ *
+ * @category Utils
+ */
+export class AdBreakTracker {
+  // Number of ads from co-scheduled ad breaks that have already finished.
+  private adIndexOffsetOfPreviousBreaks: number = 0;
+  // Index of the currently playing ad across all co-scheduled ad breaks (1-based)
+  private currentAdIndexAcrossBreaks: number = 0;
+  // Total ad count across the group of co-scheduled ad breaks
+  private totalNumberOfAdsAcrossBreaks: number = 0;
+  // scheduleTime shared by the current group of co-scheduled ad breaks, or undefined when not in a group.
+  private groupScheduleTime: number | undefined = undefined;
+  // Ad count of the currently active break
+  private numberOfAdsInCurrentAdBreak: number = 0;
+
+  private readonly events = {
+    onChanged: new EventDispatcher<AdBreakTracker, AdBreakTrackerChangedArgs>(),
+  };
+
+  constructor(private readonly player: PlayerAPI) {
+    // Sibling ad break detection is done in `AdStarted` because the ad UI variant is not yet configured when
+    // the `AdBreakStarted` event fires
+    player.on(player.exports.PlayerEvent.AdStarted, this.handleAdStarted);
+    player.on(player.exports.PlayerEvent.AdBreakFinished, this.handleAdBreakFinished);
+  }
+
+  get onChanged(): Event<AdBreakTracker, AdBreakTrackerChangedArgs> {
+    return this.events.onChanged.getEvent();
+  }
+
+  /**
+   * Index of the currently playing ad across all co-scheduled breaks (1-based), or 0 when no ad
+   * is active.
+   */
+  get currentAdIndex(): number {
+    return this.currentAdIndexAcrossBreaks;
+  }
+
+  /** Total ad count across all co-scheduled breaks in the current group. */
+  get totalNumberOfAds(): number {
+    return this.totalNumberOfAdsAcrossBreaks;
+  }
+
+  /** Unsubscribes all player events and resets state. Call when the tracker is no longer needed. */
+  release(): void {
+    this.player.off(this.player.exports.PlayerEvent.AdStarted, this.handleAdStarted);
+    this.player.off(this.player.exports.PlayerEvent.AdBreakFinished, this.handleAdBreakFinished);
+    this.reset();
+    this.events.onChanged.unsubscribeAll();
+  }
+
+  private readonly handleAdStarted = (): void => {
+    const activeBreak = this.player.ads?.getActiveAdBreak?.();
+    if (!activeBreak) {
+      this.reset();
+      this.dispatchChanged();
+      return;
+    }
+
+    // Note: `player.ads.list()` provides all ad breaks except past ad breaks or the currently active ad break
+    const siblings = (this.player.ads?.list?.() ?? []).filter(b => b.scheduleTime === activeBreak.scheduleTime);
+
+    this.numberOfAdsInCurrentAdBreak = activeBreak.ads?.length ?? 0;
+
+    const activeAd = this.player.ads?.getActiveAd?.();
+    const ads = activeBreak.ads;
+    const withinBreakIndex =
+      Array.isArray(ads) && activeAd
+        ? ads.findIndex(ad => (activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd))
+        : -1;
+    this.currentAdIndexAcrossBreaks = withinBreakIndex + 1 + this.adIndexOffsetOfPreviousBreaks;
+
+    if (this.adIndexOffsetOfPreviousBreaks > 0 || siblings.length > 0) {
+      this.groupScheduleTime = activeBreak.scheduleTime;
+      // Sibling ads arrays may not be populated yet (VAST manifests load lazily), so count
+      // sibling breaks and assume 1 ad each. totalAdsOverride self-corrects on each subsequent
+      // AdStarted as real ad counts become known.
+      const remainingSiblingAdCount = siblings.reduce(
+        (sum, adBreak) => sum + (adBreak.ads?.length > 0 ? adBreak.ads.length : 1),
+        0,
+      );
+      this.totalNumberOfAdsAcrossBreaks =
+        this.adIndexOffsetOfPreviousBreaks + this.numberOfAdsInCurrentAdBreak + remainingSiblingAdCount;
+    } else {
+      this.adIndexOffsetOfPreviousBreaks = 0;
+      this.totalNumberOfAdsAcrossBreaks = this.numberOfAdsInCurrentAdBreak;
+      this.groupScheduleTime = undefined;
+    }
+
+    this.dispatchChanged();
+  };
+
+  private readonly handleAdBreakFinished = (adBreakFinishedEvent: AdBreakEvent): void => {
+    const adBreak = adBreakFinishedEvent.adBreak;
+
+    if (adBreak.scheduleTime !== this.groupScheduleTime) {
+      return;
+    }
+
+    this.adIndexOffsetOfPreviousBreaks += this.numberOfAdsInCurrentAdBreak;
+    this.numberOfAdsInCurrentAdBreak = 0;
+
+    this.dispatchChanged();
+  };
+
+  private dispatchChanged(): void {
+    this.events.onChanged.dispatch(this, {
+      currentAdIndex: this.currentAdIndex,
+      totalNumberOfAds: this.totalNumberOfAdsAcrossBreaks,
+    });
+  }
+
+  private reset(): void {
+    this.adIndexOffsetOfPreviousBreaks = 0;
+    this.currentAdIndexAcrossBreaks = 0;
+    this.totalNumberOfAdsAcrossBreaks = 0;
+    this.groupScheduleTime = undefined;
+    this.numberOfAdsInCurrentAdBreak = 0;
+  }
+}

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -7,25 +7,25 @@ export interface AdBreakTrackerChangedArgs {
 }
 
 /**
- * Tracks a group of ad breaks that share the same `scheduleTime`, enabling a unified ad counter
+ * Tracks subsequent ad breaks that share the same `scheduleTime`, enabling a unified ad counter
  * across what the player models as separate ad breaks.
  *
  * When multiple ad breaks are scheduled at the same position, the player fires separate
  * `AdBreakStarted`/`AdBreakFinished` events for each. This tracker accumulates state across those
- * events and dispatches {@link onAdCountChanged} after each update so callers can derive a group-wide
+ * events and dispatches {@link onAdCountChanged} after each update so callers can derive a combined
  * `currentAdIndex` and `totalNumberOfAds` to pass to
  * {@link StringUtils.replaceAdMessagePlaceholders}.
  *
  * @category Utils
  */
 export class AdBreakTracker {
-  // Number of ads from co-scheduled ad breaks that have already finished.
+  // Number of ads from subsequent ad breaks that have already finished.
   private adIndexOffsetOfPreviousBreaks: number = 0;
-  // Index of the currently playing ad across all co-scheduled ad breaks (1-based)
+  // Index of the currently playing ad across all subsequent ad breaks (1-based)
   private currentAdIndexAcrossBreaks: number = 0;
-  // Total ad count across the group of co-scheduled ad breaks
+  // Total ad count across all subsequent ad breaks
   private totalNumberOfAdsAcrossBreaks: number = 0;
-  // scheduleTime shared by the current group of co-scheduled ad breaks, or undefined when not in a group.
+  // scheduleTime shared by the current subsequent ad breaks, or undefined when not in a group.
   private groupScheduleTime: number | undefined = undefined;
   // Ad count of the currently active break
   private numberOfAdsInCurrentAdBreak: number = 0;
@@ -35,7 +35,7 @@ export class AdBreakTracker {
   };
 
   constructor(private readonly player: PlayerAPI) {
-    // Sibling ad break detection is done in `AdStarted` because the ad UI variant is not yet configured when
+    // Subsequent ad break detection is done in `AdStarted` because the ad UI variant is not yet configured when
     // the `AdBreakStarted` event fires
     player.on(player.exports.PlayerEvent.AdStarted, this.handleAdStarted);
     player.on(player.exports.PlayerEvent.AdBreakFinished, this.handleAdBreakFinished);
@@ -46,14 +46,14 @@ export class AdBreakTracker {
   }
 
   /**
-   * Index of the currently playing ad across all co-scheduled breaks (1-based), or 0 when no ad
+   * Index of the currently playing ad across all subsequent ad breaks (1-based), or 0 when no ad
    * is active.
    */
   get currentAdIndex(): number {
     return this.currentAdIndexAcrossBreaks;
   }
 
-  /** Total ad count across all co-scheduled breaks in the current group. */
+  /** Total ad count across all subsequent ad breaks. */
   get totalNumberOfAds(): number {
     return this.totalNumberOfAdsAcrossBreaks;
   }
@@ -75,7 +75,9 @@ export class AdBreakTracker {
     }
 
     // Note: `player.ads.list()` provides all ad breaks except past ad breaks or the currently active ad break
-    const siblings = (this.player.ads?.list?.() ?? []).filter(b => b.scheduleTime === activeBreak.scheduleTime);
+    const subsequentAdBreaks = (this.player.ads?.list?.() ?? []).filter(
+      b => b.scheduleTime === activeBreak.scheduleTime,
+    );
 
     const activeAd = this.player.ads?.getActiveAd?.();
     const ads = activeBreak.ads;
@@ -89,18 +91,18 @@ export class AdBreakTracker {
 
     if (
       (this.adIndexOffsetOfPreviousBreaks > 0 && activeBreak.scheduleTime === this.groupScheduleTime) ||
-      siblings.length > 0
+      subsequentAdBreaks.length > 0
     ) {
       this.groupScheduleTime = activeBreak.scheduleTime;
       this.currentAdIndexAcrossBreaks = withinBreakIndex + 1 + this.adIndexOffsetOfPreviousBreaks;
-      // Sibling ads arrays may not be populated yet (VAST manifests load lazily), so we use the ads count if available,
-      // or assume 1 ad per break if not available. It will update and self-correct with each AdStarted event.
-      const remainingSiblingAdCount = siblings.reduce(
+      // Subsequent ad break ads arrays may not be populated yet (VAST manifests load lazily), so we use the ads count
+      // if available, or assume 1 ad per break if not available. It will update and self-correct with each AdStarted event.
+      const remainingSubsequentAdCount = subsequentAdBreaks.reduce(
         (sum, adBreak) => sum + (adBreak.ads?.length > 0 ? adBreak.ads.length : 1),
         0,
       );
       this.totalNumberOfAdsAcrossBreaks =
-        this.adIndexOffsetOfPreviousBreaks + this.numberOfAdsInCurrentAdBreak + remainingSiblingAdCount;
+        this.adIndexOffsetOfPreviousBreaks + this.numberOfAdsInCurrentAdBreak + remainingSubsequentAdCount;
     } else {
       this.adIndexOffsetOfPreviousBreaks = 0;
       this.currentAdIndexAcrossBreaks = withinBreakIndex + 1;
@@ -122,9 +124,11 @@ export class AdBreakTracker {
       return;
     }
 
-    const remainingSiblings = (this.player.ads?.list?.() ?? []).filter(b => b.scheduleTime === this.groupScheduleTime);
+    const remainingSubsequentAdBreaks = (this.player.ads?.list?.() ?? []).filter(
+      b => b.scheduleTime === this.groupScheduleTime,
+    );
 
-    if (remainingSiblings.length === 0) {
+    if (remainingSubsequentAdBreaks.length === 0) {
       this.reset();
     } else {
       this.adIndexOffsetOfPreviousBreaks += this.numberOfAdsInCurrentAdBreak;

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -1,4 +1,4 @@
-import { AdBreakEvent, PlayerAPI } from 'bitmovin-player';
+import { AdBreak, AdBreakEvent, PlayerAPI } from 'bitmovin-player';
 import { Event, EventDispatcher } from '../EventDispatcher';
 
 export interface AdBreakTrackerAdCountChangedArgs {
@@ -11,24 +11,19 @@ export interface AdBreakTrackerAdCountChangedArgs {
  * across what the player models as separate ad breaks.
  *
  * When multiple ad breaks are scheduled at the same position, the player fires separate
- * `AdBreakStarted`/`AdBreakFinished` events for each. This tracker accumulates state across those
- * events and dispatches {@link onAdCountChanged} after each update so callers can derive a combined
- * `currentAdIndex` and `totalNumberOfAds` to pass to
- * {@link StringUtils.replaceAdMessagePlaceholders}.
+ * `AdBreakStarted`/`AdBreakFinished` events for each. This tracker retains the ad break objects
+ * that the player removes from `player.ads.list()` after they finish, so that
+ * {@link currentAdIndex} and {@link totalNumberOfAds} can be derived lazily from the retained
+ * breaks plus the player's current state.
  *
  * @category Utils
  */
 export class AdBreakTracker {
-  // Number of ads from subsequent ad breaks that have already finished.
-  private adIndexOffsetOfPreviousBreaks: number = 0;
-  // Index of the currently playing ad across all subsequent ad breaks (1-based)
-  private currentAdIndexAcrossBreaks: number = 0;
-  // Total ad count across all subsequent ad breaks
-  private totalNumberOfAdsAcrossBreaks: number = 0;
-  // scheduleTime shared by the current subsequent ad breaks, or undefined when not in a group.
+  // Ad breaks belonging to the current group, captured as each break starts.
+  // The player removes finished breaks from `list()`, so we retain them here.
+  private groupBreaks: AdBreak[] = [];
+  // scheduleTime shared by the current group, or undefined when not in a group.
   private groupScheduleTime: number | undefined = undefined;
-  // Ad count of the currently active break
-  private numberOfAdsInCurrentAdBreak: number = 0;
 
   private readonly events = {
     onAdCountChanged: new EventDispatcher<AdBreakTracker, AdBreakTrackerAdCountChangedArgs>(),
@@ -50,12 +45,52 @@ export class AdBreakTracker {
    * is active.
    */
   get currentAdIndex(): number {
-    return this.currentAdIndexAcrossBreaks;
+    const activeAd = this.player.ads?.getActiveAd?.();
+    if (!activeAd || this.groupBreaks.length === 0) {
+      return 0;
+    }
+
+    let offset = 0;
+    for (const adBreak of this.groupBreaks) {
+      const ads = adBreak.ads ?? [];
+      const adCount = ads.length > 0 ? ads.length : 1;
+
+      if (ads.length > 0) {
+        // ad.id/activeAd.id may be null/undefined, in which case we fall back to object reference comparison
+        const activeAdIndex = ads.findIndex(ad =>
+          activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd,
+        );
+
+        if (activeAdIndex >= 0) {
+          return offset + activeAdIndex + 1;
+        }
+      }
+
+      offset += adCount;
+    }
+
+    // Active ad not found in any retained break — fall back to offset + 1
+    return offset + 1;
   }
 
   /** Total ad count across all subsequent ad breaks. */
   get totalNumberOfAds(): number {
-    return this.totalNumberOfAdsAcrossBreaks;
+    if (this.groupBreaks.length === 0) {
+      return 0;
+    }
+
+    // Subsequent ad break ads arrays may not be populated yet (VAST manifests may load lazily), so we use the ads count
+    // if available, or assume 1 ad per break if not available. It will update and self-correct with each AdStarted event.
+    const retainedCount = this.groupBreaks.reduce(
+      (sum, adBreak) => sum + (adBreak.ads?.length > 0 ? adBreak.ads.length : 1),
+      0,
+    );
+
+    const remainingScheduledCount = (this.player.ads?.list?.() ?? [])
+      .filter(b => b.scheduleTime === this.groupScheduleTime)
+      .reduce((sum, adBreak) => sum + (adBreak.ads?.length > 0 ? adBreak.ads.length : 1), 0);
+
+    return retainedCount + remainingScheduledCount;
   }
 
   /** Unsubscribes all player events and resets state. Call when the tracker is no longer needed. */
@@ -74,39 +109,21 @@ export class AdBreakTracker {
       return;
     }
 
-    // Note: `player.ads.list()` provides all ad breaks except past ad breaks or the currently active ad break
-    const subsequentAdBreaks = (this.player.ads?.list?.() ?? []).filter(
+    const hasSubsequentBreaks = (this.player.ads?.list?.() ?? []).some(
       b => b.scheduleTime === activeBreak.scheduleTime,
     );
+    const isPartOfExistingGroup = this.groupBreaks.length > 0 && activeBreak.scheduleTime === this.groupScheduleTime;
 
-    const activeAd = this.player.ads?.getActiveAd?.();
-    const ads = activeBreak.ads;
-
-    // If ads are not yet loaded, assume 1 ad in the current break.
-    this.numberOfAdsInCurrentAdBreak = Array.isArray(ads) && ads.length > 0 ? ads.length : 1;
-    const withinBreakIndex =
-      Array.isArray(ads) && activeAd
-        ? ads.findIndex(ad => (activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd))
-        : -1;
-
-    if (
-      (this.adIndexOffsetOfPreviousBreaks > 0 && activeBreak.scheduleTime === this.groupScheduleTime) ||
-      subsequentAdBreaks.length > 0
-    ) {
+    if (isPartOfExistingGroup || hasSubsequentBreaks) {
       this.groupScheduleTime = activeBreak.scheduleTime;
-      this.currentAdIndexAcrossBreaks = withinBreakIndex + 1 + this.adIndexOffsetOfPreviousBreaks;
-      // Subsequent ad break ads arrays may not be populated yet (VAST manifests load lazily), so we use the ads count
-      // if available, or assume 1 ad per break if not available. It will update and self-correct with each AdStarted event.
-      const remainingSubsequentAdCount = subsequentAdBreaks.reduce(
-        (sum, adBreak) => sum + (adBreak.ads?.length > 0 ? adBreak.ads.length : 1),
-        0,
-      );
-      this.totalNumberOfAdsAcrossBreaks =
-        this.adIndexOffsetOfPreviousBreaks + this.numberOfAdsInCurrentAdBreak + remainingSubsequentAdCount;
+
+      // Add the active break if it's not already retained (new break in the group)
+      if (!this.groupBreaks.includes(activeBreak)) {
+        this.groupBreaks.push(activeBreak);
+      }
     } else {
-      this.adIndexOffsetOfPreviousBreaks = 0;
-      this.currentAdIndexAcrossBreaks = withinBreakIndex + 1;
-      this.totalNumberOfAdsAcrossBreaks = this.numberOfAdsInCurrentAdBreak;
+      // Single ad break, not part of a group
+      this.groupBreaks = [activeBreak];
       this.groupScheduleTime = undefined;
     }
 
@@ -124,9 +141,7 @@ export class AdBreakTracker {
       return;
     }
 
-    const remainingSubsequentAdBreaks = (this.player.ads?.list?.() ?? []).filter(
-      b => b.scheduleTime === this.groupScheduleTime,
-    );
+    const subsequentAdBreaks = (this.player.ads?.list?.() ?? []).filter(b => b.scheduleTime === this.groupScheduleTime);
 
     // The next break in the group may already be active (and thus removed from `list()`),
     // so also check whether the currently active break shares the same scheduleTime.
@@ -134,28 +149,24 @@ export class AdBreakTracker {
     const activeBreakInGroup =
       activeBreak?.scheduleTime === this.groupScheduleTime && this.groupScheduleTime !== undefined;
 
-    if (remainingSubsequentAdBreaks.length === 0 && !activeBreakInGroup) {
+    if (subsequentAdBreaks.length === 0 && !activeBreakInGroup) {
       this.reset();
-    } else {
-      this.adIndexOffsetOfPreviousBreaks += this.numberOfAdsInCurrentAdBreak;
-      this.numberOfAdsInCurrentAdBreak = 0;
+      this.dispatchChanged();
     }
-
-    this.dispatchChanged();
+    // When more breaks remain in the group, skip dispatching — the next AdStarted will
+    // dispatch up-to-date values. Between breaks there is no active ad, so the lazy
+    // getters cannot produce meaningful values.
   };
 
   private dispatchChanged(): void {
     this.events.onAdCountChanged.dispatch(this, {
       currentAdIndex: this.currentAdIndex,
-      totalNumberOfAds: this.totalNumberOfAdsAcrossBreaks,
+      totalNumberOfAds: this.totalNumberOfAds,
     });
   }
 
   private reset(): void {
-    this.adIndexOffsetOfPreviousBreaks = 0;
-    this.currentAdIndexAcrossBreaks = 0;
-    this.totalNumberOfAdsAcrossBreaks = 0;
+    this.groupBreaks = [];
     this.groupScheduleTime = undefined;
-    this.numberOfAdsInCurrentAdBreak = 0;
   }
 }

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -1,7 +1,7 @@
 import { AdBreakEvent, PlayerAPI } from 'bitmovin-player';
 import { Event, EventDispatcher } from '../EventDispatcher';
 
-export interface AdBreakTrackerChangedArgs {
+export interface AdBreakTrackerAdCountChangedArgs {
   currentAdIndex: number;
   totalNumberOfAds: number;
 }
@@ -31,7 +31,7 @@ export class AdBreakTracker {
   private numberOfAdsInCurrentAdBreak: number = 0;
 
   private readonly events = {
-    onAdCountChanged: new EventDispatcher<AdBreakTracker, AdBreakTrackerChangedArgs>(),
+    onAdCountChanged: new EventDispatcher<AdBreakTracker, AdBreakTrackerAdCountChangedArgs>(),
   };
 
   constructor(private readonly player: PlayerAPI) {
@@ -41,7 +41,7 @@ export class AdBreakTracker {
     player.on(player.exports.PlayerEvent.AdBreakFinished, this.handleAdBreakFinished);
   }
 
-  get onAdCountChanged(): Event<AdBreakTracker, AdBreakTrackerChangedArgs> {
+  get onAdCountChanged(): Event<AdBreakTracker, AdBreakTrackerAdCountChangedArgs> {
     return this.events.onAdCountChanged.getEvent();
   }
 

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -85,10 +85,13 @@ export class AdBreakTracker {
       Array.isArray(ads) && activeAd
         ? ads.findIndex(ad => (activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd))
         : -1;
-    this.currentAdIndexAcrossBreaks = withinBreakIndex + 1 + this.adIndexOffsetOfPreviousBreaks;
 
-    if (this.adIndexOffsetOfPreviousBreaks > 0 || siblings.length > 0) {
+    if (
+      (this.adIndexOffsetOfPreviousBreaks > 0 && activeBreak.scheduleTime === this.groupScheduleTime) ||
+      siblings.length > 0
+    ) {
       this.groupScheduleTime = activeBreak.scheduleTime;
+      this.currentAdIndexAcrossBreaks = withinBreakIndex + 1 + this.adIndexOffsetOfPreviousBreaks;
       // Sibling ads arrays may not be populated yet (VAST manifests load lazily), so count
       // sibling breaks and assume 1 ad each. totalAdsOverride self-corrects on each subsequent
       // AdStarted as real ad counts become known.
@@ -100,6 +103,7 @@ export class AdBreakTracker {
         this.adIndexOffsetOfPreviousBreaks + this.numberOfAdsInCurrentAdBreak + remainingSiblingAdCount;
     } else {
       this.adIndexOffsetOfPreviousBreaks = 0;
+      this.currentAdIndexAcrossBreaks = withinBreakIndex + 1;
       this.totalNumberOfAdsAcrossBreaks = this.numberOfAdsInCurrentAdBreak;
       this.groupScheduleTime = undefined;
     }

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -82,8 +82,8 @@ export namespace StringUtils {
    *   - '{playedTime[formatString]}': the current time
    *   - '{adDuration[formatString]}': the ad duration
    *   - '{adBreakRemainingTime[formatString]}': the total remaining time of all ads in the ad break
-   *   - '{activeAdIndex[formatString]}': the number of the currently played ad within the current ad break
-   *   - '{totalAdsCount[formatString]}': the total number of ads in the current ad break
+   *   - '{activeAdIndex[formatString]}': the number of the currently played ad within the current group of ad breaks with the same schedule time
+   *   - '{totalAdsCount[formatString]}': the total number of ads in the current group of ad breaks with the same schedule time
    *
    * The format string is optional. If not specified, the placeholder is replaced by the time
    * in seconds. If specified, it must be of the following format:

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -156,22 +156,33 @@ export namespace StringUtils {
           time = duration - player.getCurrentTime();
         }
       } else if (formatString.indexOf('activeAdIndex') > -1 || formatString.indexOf('totalAdsCount') > -1) {
+        if (formatString.includes('activeAdIndex')) {
+          if (activeAdIndex != null) {
+            return formatNumber(activeAdIndex, formatString);
+          }
+
+          const activeAdBreak = player.ads?.getActiveAdBreak?.();
+          const activeAd = player.ads?.getActiveAd?.();
+          const ads = activeAdBreak?.ads;
+
+          if (!activeAdBreak || !activeAd || !Array.isArray(ads) || ads.length === 0) {
+            return formatNumber(0, formatString);
+          }
+
+          return formatNumber(
+            ads.findIndex(ad => (activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd)) + 1,
+            formatString,
+          );
+        }
+
+        if (totalNumberOfAds != null) {
+          return formatNumber(totalNumberOfAds, formatString);
+        }
+
         const activeAdBreak = player.ads?.getActiveAdBreak?.();
-        const activeAd = player.ads?.getActiveAd?.();
         const ads = activeAdBreak?.ads;
 
-        if (!activeAdBreak || !activeAd || !Array.isArray(ads) || ads.length === 0) {
-          return formatNumber(0, formatString);
-        }
-
-        if (formatString.includes('activeAdIndex')) {
-          const adIndex =
-            activeAdIndex ??
-            ads.findIndex(ad => (activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd)) + 1;
-          return formatNumber(adIndex, formatString);
-        }
-
-        return formatNumber(totalNumberOfAds ?? ads.length, formatString);
+        return formatNumber(Array.isArray(ads) ? ads.length : 0, formatString);
       }
 
       return formatNumber(Math.round(time), formatString);

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -110,7 +110,7 @@ export namespace StringUtils {
    * @param activeAdIndex if specified, {activeAdIndex} will be set to this value. Can be used to calculate the ad index
    *   across multiple ad breaks which are scheduled for the same time. If not provided, the value will be calculated
    *   for the current ad break only from the player API.
-   * @param totalNumberOfAds if specified, {totalAdsCount} wil be set to this value. Can be used to calculate the total
+   * @param totalNumberOfAds if specified, {totalAdsCount} will be set to this value. Can be used to calculate the total
    *   number of ads across multiple ad breaks which are scheduled for the same time. If not provided, the value will
    *   be calculated for the current ad break only from the player API.
    * @returns {string} the ad message with filled placeholders

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -107,9 +107,21 @@ export namespace StringUtils {
    * @param adMessage an ad message with optional placeholders to fill
    * @param player the player to get the time data from
    * @param skipOffset if specified, {remainingTime} will be filled with the remaining time until the ad can be skipped
+   * @param activeAdIndex if specified, {activeAdIndex} will be set to this value. Can be used to calculate the ad index
+   *   across multiple ad breaks which are scheduled for the same time. If not provided, the value will be calculated
+   *   for the current ad break only from the player API.
+   * @param totalNumberOfAds if specified, {totalAdsCount} wil be set to this value. Can be used to calculate the total
+   *   number of ads across multiple ad breaks which are scheduled for the same time. If not provided, the value will
+   *   be calculated for the current ad break only from the player API.
    * @returns {string} the ad message with filled placeholders
    */
-  export function replaceAdMessagePlaceholders(adMessage: string, player: PlayerAPI, skipOffset?: number) {
+  export function replaceAdMessagePlaceholders(
+    adMessage: string,
+    player: PlayerAPI,
+    skipOffset?: number,
+    activeAdIndex?: number,
+    totalNumberOfAds?: number,
+  ) {
     const adMessagePlaceholderRegex = new RegExp(
       '\\{(remainingTime|playedTime|adDuration|adBreakRemainingTime|activeAdIndex|totalAdsCount)(}|%((0[1-9]\\d*(\\.\\d+(d|f)|d|f)|\\.\\d+f|d|f)|hh:mm:ss|mm:ss)})',
       'g',
@@ -152,14 +164,14 @@ export namespace StringUtils {
           return formatNumber(0, formatString);
         }
 
-        const activeAdIndex =
-          ads.findIndex(ad => (activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd)) + 1;
-
-        if (formatString.indexOf('activeAdIndex') > -1) {
-          return formatNumber(activeAdIndex, formatString);
+        if (formatString.includes('activeAdIndex')) {
+          const adIndex =
+            activeAdIndex ??
+            ads.findIndex(ad => (activeAd.id != null && ad.id != null ? ad.id === activeAd.id : ad === activeAd)) + 1;
+          return formatNumber(adIndex, formatString);
         }
 
-        return formatNumber(ads.length, formatString);
+        return formatNumber(totalNumberOfAds ?? ads.length, formatString);
       }
 
       return formatNumber(Math.round(time), formatString);

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -82,8 +82,8 @@ export namespace StringUtils {
    *   - '{playedTime[formatString]}': the current time
    *   - '{adDuration[formatString]}': the ad duration
    *   - '{adBreakRemainingTime[formatString]}': the total remaining time of all ads in the ad break
-   *   - '{activeAdIndex[formatString]}': the number of the currently played ad within the current ad break by default, or within the current group of ad breaks with the same schedule time when an `activeAdIndex` override is provided
-   *   - '{totalAdsCount[formatString]}': the total number of ads in the current ad break by default, or across the current group of ad breaks with the same schedule time when a `totalNumberOfAds` override is provided
+   *   - '{activeAdIndex[formatString]}': the number of the currently played ad within the current ad break by default, or `activeAdIndex` if provided. `activeAdIndex` can be used to show the index of the current ad across multiple ad breaks with the same schedule time.
+   *   - '{totalAdsCount[formatString]}': the total number of ads in the current ad break by default, or `totalNumberOfAds` if provided. `totalNumberOfAds` can be used to show the number of ads across multiple ad breaks with the same schedule time.
    *
    * The format string is optional. If not specified, the placeholder is replaced by the time
    * in seconds. If specified, it must be of the following format:

--- a/src/ts/utils/StringUtils.ts
+++ b/src/ts/utils/StringUtils.ts
@@ -82,8 +82,8 @@ export namespace StringUtils {
    *   - '{playedTime[formatString]}': the current time
    *   - '{adDuration[formatString]}': the ad duration
    *   - '{adBreakRemainingTime[formatString]}': the total remaining time of all ads in the ad break
-   *   - '{activeAdIndex[formatString]}': the number of the currently played ad within the current group of ad breaks with the same schedule time
-   *   - '{totalAdsCount[formatString]}': the total number of ads in the current group of ad breaks with the same schedule time
+   *   - '{activeAdIndex[formatString]}': the number of the currently played ad within the current ad break by default, or within the current group of ad breaks with the same schedule time when an `activeAdIndex` override is provided
+   *   - '{totalAdsCount[formatString]}': the total number of ads in the current ad break by default, or across the current group of ad breaks with the same schedule time when a `totalNumberOfAds` override is provided
    *
    * The format string is optional. If not specified, the placeholder is replaced by the time
    * in seconds. If specified, it must be of the following format:


### PR DESCRIPTION
## Summary
- Adds `AdBreakTracker` utility to count current and total ads across ad breaks that share the same schedule time
- Updates `AdCounterLabel` to use `AdBreakTracker` so the ad counter reflects the total ad count when multiple breaks play at the same position
- Resets the tracker index when the last break in a group finishes

## Test plan
- [x] Ad counter label shows correct total ad count when multiple ad breaks are scheduled at the same time
- [x] Ad counter resets after the last break in a group finishes
- [x] Unit tests pass for `AdBreakTracker` and `AdCounterLabel`

## NOTE
This will only properly work with the Bitmovin Player Web 8.249.0+.