### PR TITLE
Fix unmute not restoring audible volume when stored volume is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `AdCounterLabel` now shows the ad position across multiple ad breaks scheduled at the same time (e.g. `Ad 2 of 3` instead of `Ad 1 of 1` for each)
 
+### Fixed
+
+- `VolumeController` can store a volume to restore of `0` in some cases, causing unmute to not restore an audible volume level
+
 ## [4.9.1] - 2026-02-24
 
 ### Fixed

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -145,6 +145,9 @@ export namespace MockHelper {
         isViewModeAvailable: jest.fn(),
         seek: jest.fn(),
         isMuted: jest.fn(),
+        mute: jest.fn(),
+        unmute: jest.fn(),
+        setVolume: jest.fn(),
         setAudio: jest.fn(),
 
         // Event faker

--- a/spec/utils/VolumeController.spec.ts
+++ b/spec/utils/VolumeController.spec.ts
@@ -27,10 +27,9 @@ describe('VolumeController', () => {
       expect(volumeController.storeVolume).toHaveBeenCalledTimes(1);
     });
 
-    it('should not update the stored volume when player is muted', () => {
+    it('should not update the stored volume when player is muted with zero volume', () => {
       (playerMock.isMuted as jest.Mock).mockReturnValue(true);
       (playerMock.getVolume as jest.Mock).mockReturnValue(0);
-      volumeController.storeVolume = jest.fn();
 
       playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
         type: PlayerEvent.VolumeChanged,
@@ -39,13 +38,13 @@ describe('VolumeController', () => {
         timestamp: Date.now(),
       });
 
-      expect(volumeController.storeVolume).not.toHaveBeenCalled();
+      // storeVolume should not persist zero — verify via the private field
+      expect((volumeController as any).storedVolume).not.toBe(0);
     });
 
     it('should not update the stored volume when volume is zero', () => {
       (playerMock.isMuted as jest.Mock).mockReturnValue(false);
       (playerMock.getVolume as jest.Mock).mockReturnValue(0);
-      volumeController.storeVolume = jest.fn();
 
       playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
         type: PlayerEvent.VolumeChanged,
@@ -54,7 +53,31 @@ describe('VolumeController', () => {
         timestamp: Date.now(),
       });
 
-      expect(volumeController.storeVolume).not.toHaveBeenCalled();
+      // storeVolume should not persist zero — verify via the private field
+      expect((volumeController as any).storedVolume).not.toBe(0);
+    });
+  });
+
+  describe('recallVolume', () => {
+    it('should default to volume 100 when stored volume is 0', () => {
+      // Constructor calls storeVolume() which gets 0 — should not persist it
+      (playerMock.getVolume as jest.Mock).mockReturnValue(0);
+      volumeController = new VolumeController(playerMock);
+
+      volumeController.recallVolume();
+
+      expect(playerMock.unmute).toHaveBeenCalled();
+      expect(playerMock.setVolume).toHaveBeenCalledWith(100, expect.any(String));
+    });
+
+    it('should restore previously stored non-zero volume', () => {
+      (playerMock.getVolume as jest.Mock).mockReturnValue(42);
+      volumeController = new VolumeController(playerMock);
+
+      volumeController.recallVolume();
+
+      expect(playerMock.unmute).toHaveBeenCalled();
+      expect(playerMock.setVolume).toHaveBeenCalledWith(42, expect.any(String));
     });
   });
 });

--- a/spec/utils/VolumeController.spec.ts
+++ b/spec/utils/VolumeController.spec.ts
@@ -8,11 +8,11 @@ describe('VolumeController', () => {
 
   beforeEach(() => {
     playerMock = MockHelper.getPlayerMock();
-    volumeController = new VolumeController(playerMock);
   });
 
   describe('onChangedEvent', () => {
     it('should update the stored volume on VolumeChanged event', () => {
+      volumeController = new VolumeController(playerMock);
       volumeController.storeVolume = jest.fn();
 
       playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
@@ -66,6 +66,7 @@ describe('VolumeController', () => {
     it('should store volume when muted at non-zero volume', () => {
       (playerMock.isMuted as jest.Mock).mockReturnValue(true);
       (playerMock.getVolume as jest.Mock).mockReturnValue(50);
+      volumeController = new VolumeController(playerMock);
 
       playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
         type: PlayerEvent.VolumeChanged,

--- a/spec/utils/VolumeController.spec.ts
+++ b/spec/utils/VolumeController.spec.ts
@@ -79,6 +79,53 @@ describe('VolumeController', () => {
     });
   });
 
+  describe('volume transition (scrubbing)', () => {
+    it('should not store intermediate volume values during scrubbing', () => {
+      // Start with volume at 80
+      (playerMock.getVolume as jest.Mock).mockReturnValue(80);
+      volumeController = new VolumeController(playerMock);
+
+      // Start a transition (user starts scrubbing)
+      const transition = volumeController.startTransition();
+
+      // Simulate intermediate volume changes during scrubbing (e.g. slowly dragging to low values)
+      (playerMock.getVolume as jest.Mock).mockReturnValue(1);
+      playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
+        type: PlayerEvent.VolumeChanged,
+        sourceVolume: 80,
+        targetVolume: 1,
+        timestamp: Date.now(),
+      });
+
+      // Finish the transition at 0 (user dragged to mute)
+      transition.finish(0);
+
+      // Recalling should restore the original volume (80), not the intermediate value (1)
+      volumeController.recallVolume();
+      expect(playerMock.setVolume).toHaveBeenCalledWith(80, expect.any(String));
+    });
+
+    it('should resume storing volume after transition finishes', () => {
+      (playerMock.getVolume as jest.Mock).mockReturnValue(50);
+      volumeController = new VolumeController(playerMock);
+
+      const transition = volumeController.startTransition();
+      transition.finish(50);
+
+      // After transition ends, volume changes should be stored again
+      (playerMock.getVolume as jest.Mock).mockReturnValue(30);
+      playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
+        type: PlayerEvent.VolumeChanged,
+        sourceVolume: 50,
+        targetVolume: 30,
+        timestamp: Date.now(),
+      });
+
+      volumeController.recallVolume();
+      expect(playerMock.setVolume).toHaveBeenCalledWith(30, expect.any(String));
+    });
+  });
+
   describe('recallVolume', () => {
     it('should default to volume 100 when no volume was ever stored', () => {
       (playerMock.getVolume as jest.Mock).mockReturnValue(0);

--- a/spec/utils/VolumeController.spec.ts
+++ b/spec/utils/VolumeController.spec.ts
@@ -80,10 +80,19 @@ describe('VolumeController', () => {
   });
 
   describe('recallVolume', () => {
-    it('should default to volume 100 when stored volume is 0', () => {
-      // Constructor calls storeVolume() which gets 0 — should not persist it
+    it('should default to volume 100 when no volume was ever stored', () => {
       (playerMock.getVolume as jest.Mock).mockReturnValue(0);
       volumeController = new VolumeController(playerMock);
+
+      volumeController.recallVolume();
+
+      expect(playerMock.unmute).toHaveBeenCalled();
+      expect(playerMock.setVolume).toHaveBeenCalledWith(100, expect.any(String));
+    });
+
+    it('should default to volume 100 when stored volume is explicitly 0', () => {
+      volumeController = new VolumeController(playerMock);
+      (volumeController as any).storedVolume = 0;
 
       volumeController.recallVolume();
 

--- a/spec/utils/VolumeController.spec.ts
+++ b/spec/utils/VolumeController.spec.ts
@@ -13,6 +13,8 @@ describe('VolumeController', () => {
 
   describe('onChangedEvent', () => {
     it('should update the stored volume on VolumeChanged event', () => {
+      (playerMock.isMuted as jest.Mock).mockReturnValue(false);
+      (playerMock.getVolume as jest.Mock).mockReturnValue(70);
       volumeController.storeVolume = jest.fn();
 
       playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
@@ -23,6 +25,36 @@ describe('VolumeController', () => {
       });
 
       expect(volumeController.storeVolume).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not update the stored volume when player is muted', () => {
+      (playerMock.isMuted as jest.Mock).mockReturnValue(true);
+      (playerMock.getVolume as jest.Mock).mockReturnValue(0);
+      volumeController.storeVolume = jest.fn();
+
+      playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
+        type: PlayerEvent.VolumeChanged,
+        sourceVolume: 0.7,
+        targetVolume: 0,
+        timestamp: Date.now(),
+      });
+
+      expect(volumeController.storeVolume).not.toHaveBeenCalled();
+    });
+
+    it('should not update the stored volume when volume is zero', () => {
+      (playerMock.isMuted as jest.Mock).mockReturnValue(false);
+      (playerMock.getVolume as jest.Mock).mockReturnValue(0);
+      volumeController.storeVolume = jest.fn();
+
+      playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
+        type: PlayerEvent.VolumeChanged,
+        sourceVolume: 0.7,
+        targetVolume: 0,
+        timestamp: Date.now(),
+      });
+
+      expect(volumeController.storeVolume).not.toHaveBeenCalled();
     });
   });
 });

--- a/spec/utils/VolumeController.spec.ts
+++ b/spec/utils/VolumeController.spec.ts
@@ -13,14 +13,12 @@ describe('VolumeController', () => {
 
   describe('onChangedEvent', () => {
     it('should update the stored volume on VolumeChanged event', () => {
-      (playerMock.isMuted as jest.Mock).mockReturnValue(false);
-      (playerMock.getVolume as jest.Mock).mockReturnValue(70);
       volumeController.storeVolume = jest.fn();
 
       playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
         type: PlayerEvent.VolumeChanged,
-        sourceVolume: 0.2,
-        targetVolume: 0.7,
+        sourceVolume: 20,
+        targetVolume: 70,
         timestamp: Date.now(),
       });
 
@@ -28,33 +26,56 @@ describe('VolumeController', () => {
     });
 
     it('should not update the stored volume when player is muted with zero volume', () => {
+      (playerMock.getVolume as jest.Mock).mockReturnValue(50);
+      volumeController = new VolumeController(playerMock);
+
       (playerMock.isMuted as jest.Mock).mockReturnValue(true);
       (playerMock.getVolume as jest.Mock).mockReturnValue(0);
 
       playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
         type: PlayerEvent.VolumeChanged,
-        sourceVolume: 0.7,
+        sourceVolume: 50,
         targetVolume: 0,
         timestamp: Date.now(),
       });
 
-      // storeVolume should not persist zero — verify via the private field
-      expect((volumeController as any).storedVolume).not.toBe(0);
+      // Zero volume should not overwrite the previously stored volume
+      volumeController.recallVolume();
+      expect(playerMock.setVolume).toHaveBeenCalledWith(50, expect.any(String));
     });
 
     it('should not update the stored volume when volume is zero', () => {
+      (playerMock.getVolume as jest.Mock).mockReturnValue(50);
+      volumeController = new VolumeController(playerMock);
+
       (playerMock.isMuted as jest.Mock).mockReturnValue(false);
       (playerMock.getVolume as jest.Mock).mockReturnValue(0);
 
       playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
         type: PlayerEvent.VolumeChanged,
-        sourceVolume: 0.7,
+        sourceVolume: 50,
         targetVolume: 0,
         timestamp: Date.now(),
       });
 
-      // storeVolume should not persist zero — verify via the private field
-      expect((volumeController as any).storedVolume).not.toBe(0);
+      // Zero volume should not overwrite the previously stored volume
+      volumeController.recallVolume();
+      expect(playerMock.setVolume).toHaveBeenCalledWith(50, expect.any(String));
+    });
+
+    it('should store volume when muted at non-zero volume', () => {
+      (playerMock.isMuted as jest.Mock).mockReturnValue(true);
+      (playerMock.getVolume as jest.Mock).mockReturnValue(50);
+
+      playerMock.eventEmitter.fireEvent<VolumeChangedEvent>({
+        type: PlayerEvent.VolumeChanged,
+        sourceVolume: 70,
+        targetVolume: 50,
+        timestamp: Date.now(),
+      });
+
+      volumeController.recallVolume();
+      expect(playerMock.setVolume).toHaveBeenCalledWith(50, expect.any(String));
     });
   });
 

--- a/src/ts/utils/VolumeController.ts
+++ b/src/ts/utils/VolumeController.ts
@@ -89,7 +89,9 @@ export class VolumeController {
     const uiMuted = playerMuted || playerVolume === 0;
     const uiVolume = playerMuted ? 0 : playerVolume;
 
-    this.storeVolume();
+    if (!playerMuted && playerVolume > 0) {
+      this.storeVolume();
+    }
 
     this.events.onChanged.dispatch(this, { volume: uiVolume, muted: uiMuted });
   }

--- a/src/ts/utils/VolumeController.ts
+++ b/src/ts/utils/VolumeController.ts
@@ -132,8 +132,6 @@ export class VolumeTransition {
   }
 
   finish(volume: number): void {
-    this.controller.endTransition();
-
     if (volume === 0) {
       // When the volume is zero we essentially mute the volume so we recall the volume from the beginning of the
       // transition and mute the player instead. Recalling is necessary to return to the actual audio volume
@@ -147,5 +145,9 @@ export class VolumeTransition {
       this.controller.setVolume(volume);
       this.controller.storeVolume();
     }
+
+    // End the transition after all volume/mute operations are complete, so that events emitted
+    // during finish() don't trigger storeVolume() with intermediate values.
+    this.controller.endTransition();
   }
 }

--- a/src/ts/utils/VolumeController.ts
+++ b/src/ts/utils/VolumeController.ts
@@ -11,6 +11,7 @@ export interface VolumeSettingChangedArgs {
  */
 export class VolumeController {
   private static readonly issuerName = 'ui-volumecontroller';
+  private static readonly defaultVolume = 100;
 
   private readonly events = {
     onChanged: new EventDispatcher<VolumeController, VolumeSettingChangedArgs>(),
@@ -72,8 +73,9 @@ export class VolumeController {
    * Recalls (sets) the volume previously stored with {@link storeVolume}.
    */
   recallVolume(): void {
-    this.setMuted(this.storedVolume === 0);
-    this.setVolume(this.storedVolume);
+    const volume = this.storedVolume > 0 ? this.storedVolume : VolumeController.defaultVolume;
+    this.setMuted(false);
+    this.setVolume(volume);
   }
 
   startTransition(): VolumeTransition {

--- a/src/ts/utils/VolumeController.ts
+++ b/src/ts/utils/VolumeController.ts
@@ -66,7 +66,10 @@ export class VolumeController {
    * Stores (saves) the current volume so it can later be restored with {@link recallVolume}.
    */
   storeVolume(): void {
-    this.storedVolume = this.getVolume();
+    const volume = this.getVolume();
+    if (volume > 0) {
+      this.storedVolume = volume;
+    }
   }
 
   /**
@@ -89,9 +92,7 @@ export class VolumeController {
     const uiMuted = playerMuted || playerVolume === 0;
     const uiVolume = playerMuted ? 0 : playerVolume;
 
-    if (!playerMuted && playerVolume > 0) {
-      this.storeVolume();
-    }
+    this.storeVolume();
 
     this.events.onChanged.dispatch(this, { volume: uiVolume, muted: uiMuted });
   }

--- a/src/ts/utils/VolumeController.ts
+++ b/src/ts/utils/VolumeController.ts
@@ -18,8 +18,12 @@ export class VolumeController {
   };
 
   private storedVolume: number;
+  private transitionActive = false;
 
   constructor(private readonly player: PlayerAPI) {
+    // If player's volume is `0`, `storeVolume` will not store that, therefore assigning the `defaultVolume` to ensure
+    // `storedVolume` is properly initialized.
+    this.storedVolume = VolumeController.defaultVolume;
     this.storeVolume();
 
     const handler = () => {
@@ -82,7 +86,12 @@ export class VolumeController {
   }
 
   startTransition(): VolumeTransition {
+    this.transitionActive = true;
     return new VolumeTransition(this);
+  }
+
+  endTransition(): void {
+    this.transitionActive = false;
   }
 
   onChangedEvent() {
@@ -92,7 +101,11 @@ export class VolumeController {
     const uiMuted = playerMuted || playerVolume === 0;
     const uiVolume = playerMuted ? 0 : playerVolume;
 
-    this.storeVolume();
+    // Don't store intermediate volume values while the user is scrubbing the volume slider.
+    // The VolumeTransition will store the final value when scrubbing finishes.
+    if (!this.transitionActive) {
+      this.storeVolume();
+    }
 
     this.events.onChanged.dispatch(this, { volume: uiVolume, muted: uiMuted });
   }
@@ -119,6 +132,8 @@ export class VolumeTransition {
   }
 
   finish(volume: number): void {
+    this.controller.endTransition();
+
     if (volume === 0) {
       // When the volume is zero we essentially mute the volume so we recall the volume from the beginning of the
       // transition and mute the player instead. Recalling is necessary to return to the actual audio volume


### PR DESCRIPTION
## Description
In some cases the player could not be unmuted anymore via the unmute button, only with the volume slider. This is bad UX, but even worse, on mobile devices, we don't show the slider, which means the user can never unmute in that scenario.

- Prevent `VolumeController` from storing a volume to restore of `0`, so that unmuting always restores an audible level
- When recalling volume, always unmute and default to `100` if the stored volume is `0`
- Add tests covering the muted and zero-volume edge cases

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry