### PR TITLE
Fix AdStatusOverlay blocking clicks on HugePlaybackToggleButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `AdStatusOverlay` blocking clicks on `HugePlaybackToggleButton` at small player sizes
+
 ## [4.10.0] - 2026-03-16
 
 ### Added

--- a/src/scss/components/ads/_ad-skip-button.scss
+++ b/src/scss/components/ads/_ad-skip-button.scss
@@ -3,6 +3,7 @@
 %ui-button-ad-skip {
   @extend %ui-button;
 
+  pointer-events: auto;
   background-color: transparentize($color-black, 0.25);
   border-radius: 20px;
   padding: 0.5em 1em;

--- a/src/scss/components/ads/_ad-skip-button.scss
+++ b/src/scss/components/ads/_ad-skip-button.scss
@@ -23,7 +23,7 @@
     }
   }
 
-  &:hover {
+  &:not(.#{$prefix}-disabled):hover {
     background-color: $color-black;
   }
 }

--- a/src/scss/components/ads/_ad-status-overlay.scss
+++ b/src/scss/components/ads/_ad-status-overlay.scss
@@ -8,10 +8,14 @@
   box-sizing: border-box;
   padding: 1em 1em 0.5em;
   bottom: 5em;
+  pointer-events: none;
+
+  * {
+    pointer-events: none;
+  }
 
   .#{$prefix}-bar {
     > .#{$prefix}-container-wrapper {
-      pointer-events: none;
       display: flex;
       margin: 0.5em 0;
     }

--- a/src/scss/components/ads/_ad-status-overlay.scss
+++ b/src/scss/components/ads/_ad-status-overlay.scss
@@ -14,6 +14,10 @@
     pointer-events: none;
   }
 
+  .#{$prefix}-ui-button-ad-skip {
+    pointer-events: auto;
+  }
+
   .#{$prefix}-bar {
     > .#{$prefix}-container-wrapper {
       display: flex;


### PR DESCRIPTION
## Summary

- Disable `pointer-events` on `AdStatusOverlay` and its descendants so clicks pass through to the `HugePlaybackToggleButton` underneath on small player sizes
- Re-enable `pointer-events` on `AdSkipButton` so it remains clickable

## Test plan

- [x] Load a small-sized player (e.g. 400x225) with an ad
- [x] Pause the ad and verify the `HugePlaybackToggleButton` is clickable
- [x] Verify the `AdSkipButton` still works when the ad becomes skippable