### PR TITLE
Respect safe-area for controlbar in UI variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- The control bar was not respecting the safe-area, e.g. on iOS, within the Ads UI variant.
+
 ## [4.10.0] - 2026-03-16
 
 ### Added

--- a/src/scss/_ads.scss
+++ b/src/scss/_ads.scss
@@ -37,14 +37,4 @@
       display: none;
     }
   }
-
-  &.#{$prefix}-ui-smallscreen {
-    .#{$prefix}-ui-ads-status {
-      bottom: 0;
-      left: 0;
-      padding: 1em 1.5em;
-      top: auto;
-      width: 100%;
-    }
-  }
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -83,6 +83,14 @@
   width: 100%;
 }
 
+@function safe-area-inset($edge) {
+  @return env(safe-area-inset-#{$edge}, 0);
+}
+
+@function safe-area-max($value, $edge) {
+  @return max($value, safe-area-inset($edge));
+}
+
 @mixin animate-slide-in-from-bottom($max-height, $duration: $animation-duration, $inner-selector: '') {
   // Animate show
   & #{$inner-selector} {

--- a/src/scss/_small-screen.scss
+++ b/src/scss/_small-screen.scss
@@ -39,8 +39,8 @@
   .#{$prefix}-ui-titlebar {
     // Adjust title bar padding for small screens to better align text with button elements
     $titlebar-padding: 1em;
-    padding: max($titlebar-padding, env(safe-area-inset-top, 0)) max($titlebar-padding, env(safe-area-inset-right, 0))
-      $titlebar-padding max($titlebar-padding, env(safe-area-inset-left, 0));
+    padding: safe-area-max($titlebar-padding, top) safe-area-max($titlebar-padding, right) $titlebar-padding
+      safe-area-max($titlebar-padding, left);
 
     .#{$prefix}-label-metadata {
       margin: 0 0.25em;

--- a/src/scss/components/_control-bar.scss
+++ b/src/scss/components/_control-bar.scss
@@ -11,8 +11,8 @@
   box-sizing: border-box;
 
   $controlbar-padding: 1em;
-  padding: $controlbar-padding max($controlbar-padding, env(safe-area-inset-right, 0))
-    max($controlbar-padding, env(safe-area-inset-bottom, 0)) max($controlbar-padding, env(safe-area-inset-left, 0));
+  padding: $controlbar-padding safe-area-max($controlbar-padding, right) safe-area-max($controlbar-padding, bottom)
+    safe-area-max($controlbar-padding, left);
 
   .#{$prefix}-container-wrapper {
     display: flex;

--- a/src/scss/components/_title-bar.scss
+++ b/src/scss/components/_title-bar.scss
@@ -11,8 +11,8 @@
   box-sizing: border-box;
 
   $titlebar-padding: 1.5em;
-  padding: max($titlebar-padding, env(safe-area-inset-top, 0)) max($titlebar-padding, env(safe-area-inset-right, 0))
-    $titlebar-padding max($titlebar-padding, env(safe-area-inset-left, 0));
+  padding: safe-area-max($titlebar-padding, top) safe-area-max($titlebar-padding, right) $titlebar-padding
+    safe-area-max($titlebar-padding, left);
 
   pointer-events: none;
 

--- a/src/scss/components/ads/_ad-control-bar.scss
+++ b/src/scss/components/ads/_ad-control-bar.scss
@@ -27,7 +27,9 @@
   @include background-gradient(to bottom);
 
   box-sizing: border-box;
-  padding: 1em;
+  $controlbar-padding: 1em;
+  padding: $controlbar-padding safe-area-max($controlbar-padding, right) safe-area-max($controlbar-padding, bottom)
+    safe-area-max($controlbar-padding, left);
 
   .#{$prefix}-container-wrapper {
     display: flex;

--- a/src/scss/components/ads/_ad-status-overlay.scss
+++ b/src/scss/components/ads/_ad-status-overlay.scss
@@ -5,9 +5,10 @@
   @extend %ui-container;
   @include layout-align-bottom;
 
+  $ad-status-overlay-bottom-offset: 5em;
   box-sizing: border-box;
-  padding: 1em 1em 0.5em;
-  bottom: 5em;
+  padding: 1em safe-area-max(1em, right) 0.5em safe-area-max(1em, left);
+  bottom: calc(#{$ad-status-overlay-bottom-offset} + #{safe-area-inset(bottom)});
 
   .#{$prefix}-bar {
     > .#{$prefix}-container-wrapper {

--- a/src/scss/components/ads/_ad-status-overlay.scss
+++ b/src/scss/components/ads/_ad-status-overlay.scss
@@ -8,7 +8,7 @@
   $ad-status-overlay-bottom-offset: 5em;
   box-sizing: border-box;
   padding: 1em safe-area-max(1em, right) 0.5em safe-area-max(1em, left);
-  bottom: calc(#{$ad-status-overlay-bottom-offset} + #{safe-area-inset(bottom)});
+  bottom: calc(#{$ad-status-overlay-bottom-offset} + (max(1em, #{safe-area-inset(bottom)}) - 1em));
   pointer-events: none;
 
   * {


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
The safe-area insets (e.g. on iOS) were not respected durnig Ad playback.

_hard to spot on a all black background but you can see the bottom padding to the virtual home indicator_
| before | now |
|---|---|
| <img width="590" height="1278" alt="IMG_0002" src="https://github.com/user-attachments/assets/558828ff-9bf5-45b1-b10e-c138b1eb6ce4" /> | <img width="590" height="1278" alt="IMG_0003" src="https://github.com/user-attachments/assets/5efe0383-c503-4c0c-80ff-3dbf5d8cc0fc" /> |


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
