### PR TITLE
Update TimelineMarkers on Player size changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `AdStatusOverlay` blocking clicks on `HugePlaybackToggleButton` at small player sizes
+- Missing `TimelineMarker`s when the position calculation happens before the UI finished rendering
 
 ## [4.10.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `AdStatusOverlay` blocking clicks on `HugePlaybackToggleButton` at small player sizes
 - Missing `TimelineMarker`s when the position calculation happens before the UI finished rendering
+- Unexpected `TimelineMarker`s animation when the Player size changes
 
 ## [4.10.0] - 2026-03-16
 

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -103,9 +103,10 @@ export class TimelineMarkersHandler {
     });
     liveStreamDetector.detect(); // Initial detection
 
-    this.uimanager.getConfig().events.onUpdated.subscribe(() => this.updateMarkers(false));
+    const onUpdated = () => this.updateMarkers(false);
+    this.uimanager.getConfig().events.onUpdated.subscribe(onUpdated);
     this.uimanager.onRelease.subscribe(() => {
-      this.uimanager.getConfig().events.onUpdated.unsubscribe(() => this.updateMarkers(false));
+      this.uimanager.getConfig().events.onUpdated.unsubscribe(onUpdated);
       reset();
     });
 

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -111,7 +111,7 @@ export class TimelineMarkersHandler {
 
     // Refresh timeline markers when the player is resized or the UI is configured. Timeline markers
     // are positioned absolutely and must therefore be updated when the size of the seekbar changes.
-    this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkersDOM());
+    this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkers());
     // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
     // resulting in a wrong initial position of the marker. Refreshing it once the UI is configured solved this issue.
     this.uimanager.onConfigured.subscribe(() => {

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -84,7 +84,7 @@ export class TimelineMarkersHandler {
     this.player.on(this.player.exports.PlayerEvent.Destroy, reset);
 
     this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, () => this.clearMarkers());
-    this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers());
+    this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers(false));
 
     const liveStreamDetector = new PlayerUtils.LiveStreamDetector(this.player, this.uimanager);
     liveStreamDetector.onLiveChanged.subscribe((sender, args: PlayerUtils.LiveStreamDetectorEventArgs) => {
@@ -103,26 +103,26 @@ export class TimelineMarkersHandler {
     });
     liveStreamDetector.detect(); // Initial detection
 
-    this.uimanager.getConfig().events.onUpdated.subscribe(() => this.updateMarkers());
+    this.uimanager.getConfig().events.onUpdated.subscribe(() => this.updateMarkers(false));
     this.uimanager.onRelease.subscribe(() => {
-      this.uimanager.getConfig().events.onUpdated.unsubscribe(() => this.updateMarkers());
+      this.uimanager.getConfig().events.onUpdated.unsubscribe(() => this.updateMarkers(false));
       reset();
     });
 
     // Refresh timeline markers when the player is resized or the UI is configured. Timeline markers
     // are positioned absolutely and must therefore be updated when the size of the seekbar changes.
-    this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkers());
+    this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkers(false));
     // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
     // resulting in a wrong initial position of the marker. Refreshing it once the UI is configured solved this issue.
     this.uimanager.onConfigured.subscribe(() => {
-      this.updateMarkers();
+      this.updateMarkers(false);
     });
     this.player.on(this.player.exports.PlayerEvent.SourceLoaded, () => {
-      this.updateMarkers();
+      this.updateMarkers(false);
     });
 
     // Init markers at startup
-    this.updateMarkers();
+    this.updateMarkers(false);
   }
 
   public getMarkerAtPosition(percentage: number): SeekBarMarker | null {
@@ -175,7 +175,7 @@ export class TimelineMarkersHandler {
     }
   }
 
-  private updateMarkers(): void {
+  private updateMarkers(animated: boolean): void {
     const seekBarWidth = this.getSeekBarWidth();
     if (seekBarWidth === 0) {
       // Skip marker update when the seekBarWidth is not yet available.
@@ -206,12 +206,12 @@ export class TimelineMarkersHandler {
           matchingMarker.position = markerPosition;
           matchingMarker.duration = markerDuration;
 
-          this.updateMarkerDOM(matchingMarker);
+          this.updateMarkerDOM(matchingMarker, animated);
         } else {
           const newMarker: SeekBarMarker = { marker, position: markerPosition, duration: markerDuration };
           this.timelineMarkers.push(newMarker);
 
-          this.createMarkerDOM(newMarker);
+          this.createMarkerDOM(newMarker, animated);
         }
       }
     });
@@ -243,13 +243,14 @@ export class TimelineMarkersHandler {
     return cssProperties;
   }
 
-  private updateMarkerDOM(marker: SeekBarMarker): void {
-    // Removing the 'transition: none' value from the initial creation when updating the marker position.
+  private updateMarkerDOM(marker: SeekBarMarker, animated: boolean): void {
+    // Always remove the shorthand 'transition: none' set during creation,
+    // otherwise setting only 'transition-duration' won't re-enable transition-property.
     marker.element.removeCss('transition');
-    marker.element.css(this.getMarkerCssProperties(marker, true));
+    marker.element.css(this.getMarkerCssProperties(marker, animated));
   }
 
-  private createMarkerDOM(marker: SeekBarMarker): void {
+  private createMarkerDOM(marker: SeekBarMarker, animated: boolean): void {
     const markerClasses = ['seekbar-marker']
       .concat(marker.marker.cssClasses || [])
       .map(cssClass => prefixCss(cssClass));
@@ -269,7 +270,7 @@ export class TimelineMarkersHandler {
     })
       // We do not want to animate the initial creation of a marker to prevent a 'fly in' animation.
       // Only updating the marker position will be animated.
-      .css(this.getMarkerCssProperties(marker, false));
+      .css(this.getMarkerCssProperties(marker, animated));
 
     if (marker.marker.imageUrl) {
       const removeImage = () => {
@@ -294,16 +295,6 @@ export class TimelineMarkersHandler {
     this.markersContainer.append(markerElement);
   }
 
-  private updateMarkersDOM(): void {
-    this.timelineMarkers.forEach(marker => {
-      if (marker.element) {
-        this.updateMarkerDOM(marker);
-      } else {
-        this.createMarkerDOM(marker);
-      }
-    });
-  }
-
   private startLiveMarkerUpdater(): void {
     const updateIntervalMs = this.config.markerUpdateIntervalMs || defaultMarkerUpdateIntervalMs;
 
@@ -317,7 +308,7 @@ export class TimelineMarkersHandler {
           this.captureSeekableRangeSnapshot();
         }
 
-        this.updateMarkers();
+        this.updateMarkers(true);
       },
       true,
     );

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -212,7 +212,7 @@ export class TimelineMarkersHandler {
           const newMarker: SeekBarMarker = { marker, position: markerPosition, duration: markerDuration };
           this.timelineMarkers.push(newMarker);
 
-          this.createMarkerDOM(newMarker, animated);
+          this.createMarkerDOM(newMarker);
         }
       }
     });
@@ -251,7 +251,7 @@ export class TimelineMarkersHandler {
     marker.element.css(this.getMarkerCssProperties(marker, animated));
   }
 
-  private createMarkerDOM(marker: SeekBarMarker, animated: boolean): void {
+  private createMarkerDOM(marker: SeekBarMarker): void {
     const markerClasses = ['seekbar-marker']
       .concat(marker.marker.cssClasses || [])
       .map(cssClass => prefixCss(cssClass));
@@ -271,7 +271,7 @@ export class TimelineMarkersHandler {
     })
       // We do not want to animate the initial creation of a marker to prevent a 'fly in' animation.
       // Only updating the marker position will be animated.
-      .css(this.getMarkerCssProperties(marker, animated));
+      .css(this.getMarkerCssProperties(marker, false));
 
     if (marker.marker.imageUrl) {
       const removeImage = () => {

--- a/src/ts/utils/TimelineMarkersHandler.ts
+++ b/src/ts/utils/TimelineMarkersHandler.ts
@@ -56,6 +56,9 @@ export class TimelineMarkersHandler {
   }
 
   private configureMarkers(): void {
+    const refreshMarkers = () => this.updateMarkers(false);
+    const clearMarkers = () => this.clearMarkers();
+
     const onTimeShift = () => {
       this.isTimeShifting = true;
     };
@@ -70,9 +73,8 @@ export class TimelineMarkersHandler {
       }
     };
 
-    const reset = () => {
+    const resetLiveState = () => {
       this.stopLiveMarkerUpdater();
-      this.clearMarkers();
       this.isTimeShifting = false;
       this.seekableRangeSnapshot = null;
 
@@ -80,14 +82,20 @@ export class TimelineMarkersHandler {
       this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
       this.uimanager.onSeekPreview.unsubscribe(onSeekPreview);
     };
+
+    const reset = () => {
+      resetLiveState();
+      this.clearMarkers();
+    };
+
     this.player.on(this.player.exports.PlayerEvent.SourceUnloaded, reset);
     this.player.on(this.player.exports.PlayerEvent.Destroy, reset);
 
-    this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, () => this.clearMarkers());
-    this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, () => this.updateMarkers(false));
+    this.player.on(this.player.exports.PlayerEvent.AdBreakStarted, clearMarkers);
+    this.player.on(this.player.exports.PlayerEvent.AdBreakFinished, refreshMarkers);
 
     const liveStreamDetector = new PlayerUtils.LiveStreamDetector(this.player, this.uimanager);
-    liveStreamDetector.onLiveChanged.subscribe((sender, args: PlayerUtils.LiveStreamDetectorEventArgs) => {
+    const onLiveChanged = (_sender: PlayerAPI, args: PlayerUtils.LiveStreamDetectorEventArgs) => {
       if (args.live) {
         this.player.on(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
         this.player.on(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
@@ -95,31 +103,34 @@ export class TimelineMarkersHandler {
 
         this.startLiveMarkerUpdater();
       } else {
-        this.stopLiveMarkerUpdater();
-        this.uimanager.onSeekPreview.unsubscribe(onSeekPreview);
-        this.player.off(this.player.exports.PlayerEvent.TimeShift, onTimeShift);
-        this.player.off(this.player.exports.PlayerEvent.TimeShifted, onTimeShifted);
+        resetLiveState();
       }
-    });
+    };
+    liveStreamDetector.onLiveChanged.subscribe(onLiveChanged);
     liveStreamDetector.detect(); // Initial detection
 
-    const onUpdated = () => this.updateMarkers(false);
-    this.uimanager.getConfig().events.onUpdated.subscribe(onUpdated);
-    this.uimanager.onRelease.subscribe(() => {
-      this.uimanager.getConfig().events.onUpdated.unsubscribe(onUpdated);
-      reset();
-    });
+    this.uimanager.getConfig().events.onUpdated.subscribe(refreshMarkers);
 
     // Refresh timeline markers when the player is resized or the UI is configured. Timeline markers
     // are positioned absolutely and must therefore be updated when the size of the seekbar changes.
-    this.player.on(this.player.exports.PlayerEvent.PlayerResized, () => this.updateMarkers(false));
+    this.player.on(this.player.exports.PlayerEvent.PlayerResized, refreshMarkers);
     // Additionally, when this code is called, the seekbar is not part of the UI yet and therefore does not have a size,
     // resulting in a wrong initial position of the marker. Refreshing it once the UI is configured solved this issue.
-    this.uimanager.onConfigured.subscribe(() => {
-      this.updateMarkers(false);
-    });
-    this.player.on(this.player.exports.PlayerEvent.SourceLoaded, () => {
-      this.updateMarkers(false);
+    this.uimanager.onConfigured.subscribe(refreshMarkers);
+    this.player.on(this.player.exports.PlayerEvent.SourceLoaded, refreshMarkers);
+
+    this.uimanager.onRelease.subscribe(() => {
+      this.uimanager.getConfig().events.onUpdated.unsubscribe(refreshMarkers);
+      this.uimanager.onConfigured.unsubscribe(refreshMarkers);
+      liveStreamDetector.onLiveChanged.unsubscribe(onLiveChanged);
+      reset();
+
+      this.player.off(this.player.exports.PlayerEvent.SourceUnloaded, reset);
+      this.player.off(this.player.exports.PlayerEvent.Destroy, reset);
+      this.player.off(this.player.exports.PlayerEvent.AdBreakStarted, clearMarkers);
+      this.player.off(this.player.exports.PlayerEvent.AdBreakFinished, refreshMarkers);
+      this.player.off(this.player.exports.PlayerEvent.PlayerResized, refreshMarkers);
+      this.player.off(this.player.exports.PlayerEvent.SourceLoaded, refreshMarkers);
     });
 
     // Init markers at startup


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
When the `PlayerSize` changes, only the existing markers' DOM elements are updated. However, there is the use-case that the initial rendering wasn't completed in use-cases where the seekbar width wasn't known yet (due to an initial layouting race-condition).

### Changes
- Lazily create the TimelineMarkers also on `PlayerResize` events
- Skip animation when the player resizes and initial. Only animate position changes during live playback.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
