### PR TITLE
Do not switch ad-ui to main-content-ui during active ad playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Ad-UI switches to main content UI when a `SourceLoaded` event is received during active ad playback
+
 ## [4.10.1] - 2026-03-24
 
 ### Fixed

--- a/spec/UIManager.spec.ts
+++ b/spec/UIManager.spec.ts
@@ -1,4 +1,11 @@
-import { InternalUIConfig, PlayerWrapper, UIInstanceManager, UIManager, UIVariant } from '../src/ts/UIManager';
+import {
+  InternalUIConfig,
+  PlayerWrapper,
+  UIConditionContext,
+  UIInstanceManager,
+  UIManager,
+  UIVariant,
+} from '../src/ts/UIManager';
 import { PlayerAPI } from 'bitmovin-player';
 import { MockHelper, TestingPlayerAPI } from './helper/MockHelper';
 import { MobileV3PlayerEvent } from '../src/ts/utils/MobileV3PlayerAPI';
@@ -141,6 +148,35 @@ describe('UIManager', () => {
       uiManager.switchToUiVariant(secondUI);
 
       expect(onUiChanged).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ui variant resolution', () => {
+    it('keeps the ad UI active when SourceLoaded fires during an active ad', () => {
+      const playerMock = MockHelper.getPlayerMock();
+      const adUi = {
+        ui: new UIContainer({ components: [new Container({})] }),
+        condition: (context: UIConditionContext) => context.isAd,
+      };
+      const contentUi = {
+        ui: new UIContainer({ components: [new Container({})] }),
+        condition: (context: UIConditionContext) => context.isSourceLoaded,
+      };
+      const defaultUi = { ui: new UIContainer({ components: [new Container({})] }) };
+
+      new UIManager(playerMock, [adUi, contentUi, defaultUi]);
+
+      playerMock.eventEmitter.fireAdStartedEvent();
+      expect(adUi.ui.isHidden()).toBeFalsy();
+      expect(contentUi.ui.isHidden()).toBeTruthy();
+
+      playerMock.eventEmitter.fireSourceLoadedEvent();
+      expect(adUi.ui.isHidden()).toBeFalsy();
+      expect(contentUi.ui.isHidden()).toBeTruthy();
+
+      playerMock.eventEmitter.fireAdBreakFinishedEvent();
+      expect(adUi.ui.isHidden()).toBeTruthy();
+      expect(contentUi.ui.isHidden()).toBeFalsy();
     });
   });
 

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -367,7 +367,7 @@ export class UIManager {
             this.config.events.onUpdated.dispatch(this);
             break;
           case player.exports.PlayerEvent.SourceLoaded:
-            // No need to take care of SourceLoaded. As when the source changes, SourceUnload gets called.
+            // No need to take care of SourceLoaded. As when the source changes, a SourceUnloaded event is received.
             // When the source gets loaded during ad playback, we don't want to change the UI.
             break;
           case player.exports.PlayerEvent.SourceUnloaded:

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -366,9 +366,13 @@ export class UIManager {
             // TODO introduce an event that is fired when the playback content is updated, a switch to/from ads
             this.config.events.onUpdated.dispatch(this);
             break;
-          // When a new source is loaded during ad playback, there will be no Ad(Break)Finished event
           case player.exports.PlayerEvent.SourceLoaded:
+            // No need to take care of SourceLoaded. As when the source changes, SourceUnload gets called.
+            // When the source gets loaded during ad playback, we don't want to change the UI.
+            break;
           case player.exports.PlayerEvent.SourceUnloaded:
+            // When the source gets unloaded during ad playback, there will be no Ad(Break)Finished event.
+            // This also covers changing a source
             adStartedEvent = null;
             break;
         }


### PR DESCRIPTION
## Description
When a pre-load ad is actively playing before the main content is loaded, the `SourceLoaded` event will switch the UI from ad to main content.
Currently this UI bug happens on the Android Player when a pre-load ad is scheduled,`autoPlay = true` and the main content takes a little longer to load.

## Checklist (for PR submitter and reviewers)
- [x] `CHANGELOG` entry
