### PR TITLE
Add missing secret for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ on:
       RELEASE_DEPLOY_KEY:
         description: 'SSH deploy key with write access to the repository'
         required: true
+      GCS_BUCKET:
+        description: 'Google Cloud Storage bucket name for uploading docs'
+        required: true
 
 concurrency:
   group: release-${{ inputs.version_number }}-${{ inputs.release_type }}

--- a/.github/workflows/tag-release-version.yml
+++ b/.github/workflows/tag-release-version.yml
@@ -100,3 +100,4 @@ jobs:
       GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
+      GCS_BUCKET: ${{ secrets.GCS_BUCKET }}


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
The first automated release failed due to a missing secret. This PR fixes that by passing the secret properly.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **IMO Not needed for a tiny CI change**
