### PR TITLE
Fix back button not recorded on tizen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- In TV spatial navigation, the BACK button could be swallowed by the UI and not reach the player when the controls were already hidden
+- In TV spatial navigation, the BACK button could be swallowed by the UI and not reach the application when the controls were already hidden
 
 ## [4.10.2] - 2026-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- In TV spatial navigation, the BACK button could be swallowed by the UI and not reach the player when the controls were already hidden
+
 ## [4.10.1] - 2026-03-24
 
 ### Fixed

--- a/spec/spatialnavigation/NavigationGroup.spec.ts
+++ b/spec/spatialnavigation/NavigationGroup.spec.ts
@@ -108,7 +108,10 @@ describe('NavigationGroup', () => {
 
     describe('onNavigation', () => {
       it('should not call default navigation handler if propagation was stopped from the outside', () => {
-        rootNavigationGroup.onNavigation = (_direction, _element, preventDefault) => preventDefault();
+        rootNavigationGroup.onNavigation = (_direction, _element, preventDefault) => {
+          preventDefault();
+          return true;
+        };
 
         rootNavigationGroup.handleNavigation(Direction.DOWN);
 
@@ -148,7 +151,10 @@ describe('NavigationGroup', () => {
 
     describe('onAction', () => {
       it('should not call default action handler if propagation was stopped from the outside', () => {
-        rootNavigationGroup.onAction = (_action, _element, preventDefault) => preventDefault();
+        rootNavigationGroup.onAction = (_action, _element, preventDefault) => {
+          preventDefault();
+          return true;
+        };
         rootNavigationGroup.handleAction(Action.SELECT);
 
         expect(playButtonHTML.click).not.toHaveBeenCalled();

--- a/spec/spatialnavigation/NavigationGroup.spec.ts
+++ b/spec/spatialnavigation/NavigationGroup.spec.ts
@@ -123,6 +123,16 @@ describe('NavigationGroup', () => {
 
         expect(subtitleToggleButtonHTML.focus).not.toHaveBeenCalled();
       });
+
+      it('should return handled when the custom navigation handler consumes the event without preventing the default handler', () => {
+        const getComponentInDirectionMock = navigationAlgorithm.getComponentInDirection as jest.Mock;
+        getComponentInDirectionMock.mockReset();
+        getComponentInDirectionMock.mockReturnValue(undefined);
+        rootNavigationGroup['activeComponent'] = playbackToggleButtonMock;
+        rootNavigationGroup.onNavigation = () => true;
+
+        expect(rootNavigationGroup.handleNavigation(Direction.DOWN)).toBe(true);
+      });
     });
   });
 

--- a/spec/spatialnavigation/NavigationGroup.spec.ts
+++ b/spec/spatialnavigation/NavigationGroup.spec.ts
@@ -106,6 +106,12 @@ describe('NavigationGroup', () => {
       expect(subtitleToggleButtonHTML.focus).toHaveBeenCalled();
     });
 
+    it('should return false when there is no active or focusable component', () => {
+      const emptyNavigationGroup = new NavigationGroup(rootContainerMock);
+
+      expect(emptyNavigationGroup.handleNavigation(Direction.LEFT)).toBe(false);
+    });
+
     describe('onNavigation', () => {
       it('should not call default navigation handler if propagation was stopped from the outside', () => {
         rootNavigationGroup.onNavigation = (_direction, _element, preventDefault) => {

--- a/spec/spatialnavigation/RootNavigationGroup.spec.ts
+++ b/spec/spatialnavigation/RootNavigationGroup.spec.ts
@@ -13,6 +13,15 @@ describe('RootNavigationGroup', () => {
     containerUiMock = mockClass(UIContainer);
     containerUiMock.showUi = jest.fn();
     containerUiMock.hideUi = jest.fn();
+    containerUiMock.getDomElement = jest.fn().mockReturnValue({
+      get: jest.fn().mockReturnValue({
+        classList: {
+          [Symbol.iterator]: function* () {
+            yield 'bmpui-controls-hidden';
+          },
+        },
+      }),
+    } as any);
 
     rootNavigationGroup = new RootNavigationGroup(containerUiMock);
   });
@@ -25,15 +34,32 @@ describe('RootNavigationGroup', () => {
     });
 
     it('should call hideUi on UIContainer on Action.BACK', () => {
-      rootNavigationGroup['defaultActionHandler'](Action.BACK);
+      containerUiMock.getDomElement = jest.fn().mockReturnValue({
+        get: jest.fn().mockReturnValue({
+          classList: {
+            [Symbol.iterator]: function* () {
+              yield 'bmpui-controls-shown';
+            },
+          },
+        }),
+      } as any);
+      const handled = rootNavigationGroup['defaultActionHandler'](Action.BACK);
 
       expect(containerUiMock.hideUi).toHaveBeenCalled();
+      expect(handled).toBe(true);
     });
 
     it('should not call hideUi on UIContainer on Action.SELECT', () => {
       rootNavigationGroup['defaultActionHandler'](Action.SELECT);
 
       expect(containerUiMock.hideUi).not.toHaveBeenCalled();
+    });
+
+    it('should not handle Action.BACK when the UI is already hidden', () => {
+      const handled = rootNavigationGroup['defaultActionHandler'](Action.BACK);
+
+      expect(containerUiMock.hideUi).not.toHaveBeenCalled();
+      expect(handled).toBe(false);
     });
   });
 

--- a/spec/spatialnavigation/SeekBarHandler.spec.ts
+++ b/spec/spatialnavigation/SeekBarHandler.spec.ts
@@ -59,9 +59,10 @@ describe('SeekBarHandler', () => {
     `("should not prevent default if the event target isn't the seekbar with direction=$direction", ({ direction }) => {
       jest.spyOn(toHtmlElementModule, 'toHtmlElement').mockReturnValue(document.createElement('div'));
 
-      rootNavigationGroupMock.onNavigation!(direction, targetComponentMock, preventDefaultSpy);
+      const handled = rootNavigationGroupMock.onNavigation!(direction, targetComponentMock, preventDefaultSpy);
 
       expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(handled).toBe(false);
     });
 
     test.each`
@@ -69,11 +70,12 @@ describe('SeekBarHandler', () => {
       ${Direction.DOWN}
       ${Direction.UP}
     `('should stop scrubbing when onDirection is called with direction=$direction', ({ direction }) => {
-      rootNavigationGroupMock.onNavigation!(direction, targetComponentMock, preventDefaultSpy);
+      const handled = rootNavigationGroupMock.onNavigation!(direction, targetComponentMock, preventDefaultSpy);
 
       expect(preventDefaultSpy).not.toHaveBeenCalled();
       expect(seekBarMock.dispatchEvent).toHaveBeenCalledWith(new MouseEvent('mouseleave'));
       expect(eventSubscriberOnSpy).not.toHaveBeenCalled();
+      expect(handled).toBe(true);
     });
 
     it('should increase scrubSpeedPercentage', () => {
@@ -128,22 +130,24 @@ describe('SeekBarHandler', () => {
       ${Action.BACK}
     `('should not prevent default if the event target is not the seek bar with action=$action', ({ action }) => {
       jest.spyOn(toHtmlElementModule, 'toHtmlElement').mockReturnValue(document.createElement('div'));
-      rootNavigationGroupMock.onAction!(action, targetComponentMock, preventDefaultSpy);
+      const handled = rootNavigationGroupMock.onAction!(action, targetComponentMock, preventDefaultSpy);
 
       expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(handled).toBe(false);
     });
 
     it('should ignore SELECT actions when not actively scrubbing', () => {
-      rootNavigationGroupMock.onAction!(Action.SELECT, targetComponentMock, preventDefaultSpy);
+      const handled = rootNavigationGroupMock.onAction!(Action.SELECT, targetComponentMock, preventDefaultSpy);
 
       expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(handled).toBe(false);
     });
 
     it('should dispatch a mouse click event when the SELECT action is triggered while scrubbing', () => {
       eventSubscriberOnSpy.mockImplementation((_, __, handler: EventListener) => handler(null as any));
       rootNavigationGroupMock.onNavigation!(Direction.RIGHT, targetComponentMock, preventDefaultSpy);
       preventDefaultSpy.mockReset();
-      rootNavigationGroupMock.onAction!(Action.SELECT, targetComponentMock, preventDefaultSpy);
+      const handled = rootNavigationGroupMock.onAction!(Action.SELECT, targetComponentMock, preventDefaultSpy);
 
       expect(preventDefaultSpy).toHaveBeenCalled();
       expect(seekBarMock.dispatchEvent).toHaveBeenCalledWith(new MouseEvent('mousedown'));
@@ -153,14 +157,25 @@ describe('SeekBarHandler', () => {
       expect(documentDispatchEventSpy).toHaveBeenCalledWith(
         new MouseEvent('mouseup', expect.anything() as MouseEventInit),
       );
+      expect(handled).toBe(true);
     });
 
-    it('should stop seeking when the BACK action is triggered', () => {
-      rootNavigationGroupMock.onAction!(Action.BACK, targetComponentMock, preventDefaultSpy);
+    it('should stop seeking when the BACK action is triggered while scrubbing', () => {
+      rootNavigationGroupMock.onNavigation!(Direction.RIGHT, targetComponentMock, preventDefaultSpy);
+      preventDefaultSpy.mockReset();
+      const handled = rootNavigationGroupMock.onAction!(Action.BACK, targetComponentMock, preventDefaultSpy);
 
       expect(preventDefaultSpy).toHaveBeenCalled();
       expect(seekBarMock.dispatchEvent).toHaveBeenCalledWith(new MouseEvent('mouseleave'));
       expect(eventSubscriberOnSpy).not.toHaveBeenCalled();
+      expect(handled).toBe(true);
+    });
+
+    it('should ignore BACK actions when not actively scrubbing', () => {
+      const handled = rootNavigationGroupMock.onAction!(Action.BACK, targetComponentMock, preventDefaultSpy);
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(handled).toBe(false);
     });
   });
 

--- a/spec/spatialnavigation/SpatialNavigation.spec.ts
+++ b/spec/spatialnavigation/SpatialNavigation.spec.ts
@@ -68,7 +68,7 @@ describe('SpatialNavigation', () => {
   describe('handleKeyEvent', () => {
     it('should call handle navigation on active group on key event', () => {
       rootNavigationContainer.show();
-      const rootHandleNavigationSpy = jest.spyOn(rootNavigationGroup, 'handleNavigation');
+      const rootHandleNavigationSpy = jest.spyOn(rootNavigationGroup, 'handleNavigation').mockReturnValue(true);
       spatialNavigation['handleKeyEvent'](new KeyboardEvent('keydown', { key: 'Up', keyCode: 38 } as any));
 
       expect(rootHandleNavigationSpy).toHaveBeenCalledWith(Direction.UP);
@@ -76,10 +76,36 @@ describe('SpatialNavigation', () => {
 
     it('should call handle action on active group on key event', () => {
       rootNavigationContainer.show();
-      const rootHandleActionSpy = jest.spyOn(rootNavigationGroup, 'handleAction');
+      const rootHandleActionSpy = jest.spyOn(rootNavigationGroup, 'handleAction').mockReturnValue(true);
       spatialNavigation['handleKeyEvent'](new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27 } as any));
 
       expect(rootHandleActionSpy).toHaveBeenCalledWith(Action.BACK);
+    });
+
+    it('should prevent default when action is handled', () => {
+      rootNavigationContainer.show();
+      jest.spyOn(rootNavigationGroup, 'handleAction').mockReturnValue(true);
+      const event = new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27 } as any);
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+      const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+
+      spatialNavigation['handleKeyEvent'](event);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('should not prevent default when action is not handled', () => {
+      rootNavigationContainer.show();
+      jest.spyOn(rootNavigationGroup, 'handleAction').mockReturnValue(false);
+      const event = new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27 } as any);
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+      const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+
+      spatialNavigation['handleKeyEvent'](event);
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(stopPropagationSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/ts/spatialnavigation/NavigationGroup.ts
+++ b/src/ts/spatialnavigation/NavigationGroup.ts
@@ -204,7 +204,8 @@ export class NavigationGroup {
     }
 
     if (handleDefault) {
-      handled = defaultHandler.call(this, data) || handled;
+      const defaultHandled = defaultHandler.call(this, data);
+      handled = handled || defaultHandled;
     }
 
     return handled;

--- a/src/ts/spatialnavigation/NavigationGroup.ts
+++ b/src/ts/spatialnavigation/NavigationGroup.ts
@@ -94,6 +94,7 @@ export class NavigationGroup {
    * @param direction {Direction} The direction to move along
    * @param target {HTMLElement} The target element for the event
    * @param preventDefault {() => void} A function that, when called, will prevent the execution of the default handler
+   * @returns `true` if the event was handled, `false` or `undefined` otherwise
    */
   public onNavigation?: NavigationCallback;
 
@@ -104,6 +105,7 @@ export class NavigationGroup {
    * @param action {Action} The action that was called
    * @param target {HTMLElement} The target element that action was called on
    * @param preventDefault {() => void} A function that, when called, will prevent the execution of the default handler
+   * @returns `true` if the event was handled, `false` or `undefined` otherwise
    */
   public onAction?: ActionCallback;
 
@@ -192,7 +194,7 @@ export class NavigationGroup {
     let handled = false;
 
     if (userHandler && this.activeComponent) {
-      handled = userHandler(data, this.activeComponent, preventDefault);
+      handled = Boolean(userHandler(data, this.activeComponent, preventDefault));
     }
 
     if (handleDefault) {

--- a/src/ts/spatialnavigation/NavigationGroup.ts
+++ b/src/ts/spatialnavigation/NavigationGroup.ts
@@ -221,7 +221,7 @@ export class NavigationGroup {
       } else {
         this.focusFirstComponent();
       }
-      return true;
+      return Boolean(this.activeComponent);
     }
 
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/ts/spatialnavigation/NavigationGroup.ts
+++ b/src/ts/spatialnavigation/NavigationGroup.ts
@@ -186,6 +186,8 @@ export class NavigationGroup {
         this.container.hide();
         return true;
     }
+
+    return false;
   }
 
   private handleInput<T>(data: T, defaultHandler: (data: T) => boolean, userHandler?: Callback<T>): boolean {

--- a/src/ts/spatialnavigation/NavigationGroup.ts
+++ b/src/ts/spatialnavigation/NavigationGroup.ts
@@ -143,9 +143,9 @@ export class NavigationGroup {
     }
   }
 
-  protected defaultNavigationHandler(direction: Direction): void {
+  protected defaultNavigationHandler(direction: Direction): boolean {
     if (!this.activeComponent) {
-      return;
+      return false;
     }
 
     const containerContainingActiveComponent = this.getActiveFocusableContainer();
@@ -158,7 +158,7 @@ export class NavigationGroup {
 
       if (targetComponent) {
         this.focusComponent(targetComponent);
-        return;
+        return true;
       }
     }
 
@@ -167,31 +167,39 @@ export class NavigationGroup {
 
     if (targetComponent) {
       this.focusComponent(targetComponent);
+      return true;
     }
+
+    return false;
   }
 
-  protected defaultActionHandler(action: Action): void {
+  protected defaultActionHandler(action: Action): boolean {
     switch (action) {
       case Action.SELECT:
         if (this.activeComponent) {
           toHtmlElement(this.activeComponent).click();
         }
-        break;
+        return Boolean(this.activeComponent);
       case Action.BACK:
         this.container.hide();
-        break;
+        return true;
     }
   }
 
-  private handleInput<T>(data: T, defaultHandler: (data: T) => void, userHandler?: Callback<T>): void {
+  private handleInput<T>(data: T, defaultHandler: (data: T) => boolean, userHandler?: Callback<T>): boolean {
     let handleDefault = true;
     const preventDefault = () => (handleDefault = false);
+    let handled = false;
 
-    userHandler?.(data, this.activeComponent, preventDefault);
+    if (userHandler && this.activeComponent) {
+      handled = userHandler(data, this.activeComponent, preventDefault);
+    }
 
     if (handleDefault) {
-      defaultHandler.call(this, data);
+      handled = defaultHandler.call(this, data) || handled;
     }
+
+    return handled;
   }
 
   /**
@@ -200,7 +208,7 @@ export class NavigationGroup {
    * @param direction The direction of the navigation event
    * @returns true if navigation was successful, false otherwise
    */
-  public handleNavigation(direction: Direction): void {
+  public handleNavigation(direction: Direction): boolean {
     if (!this.activeComponent) {
       // If we do not have an active element, the active element has been disabled by a mouseleave
       // event. We should continue the navigation at the exact place where we left off.
@@ -209,11 +217,11 @@ export class NavigationGroup {
       } else {
         this.focusFirstComponent();
       }
-      return;
+      return true;
     }
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    this.handleInput(direction, this.defaultNavigationHandler, this.onNavigation);
+    return this.handleInput(direction, this.defaultNavigationHandler, this.onNavigation);
   }
 
   /**
@@ -221,9 +229,9 @@ export class NavigationGroup {
    *
    * @param action The action of the event
    */
-  public handleAction(action: Action): void {
+  public handleAction(action: Action): boolean {
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    this.handleInput(action, this.defaultActionHandler, this.onAction);
+    return this.handleInput(action, this.defaultActionHandler, this.onAction);
   }
 
   /**

--- a/src/ts/spatialnavigation/NavigationGroup.ts
+++ b/src/ts/spatialnavigation/NavigationGroup.ts
@@ -89,7 +89,9 @@ export class NavigationGroup {
 
   /**
    * If overwritten, allows to implement custom navigation behavior. Per default, the internal handler will still be
-   * executed. To prevent execution of the default navigation handler, call `preventDefault()`;
+   * executed. To prevent execution of the default navigation handler, call `preventDefault()`. Return `true` if your
+   * handler consumed the navigation event. Return `false` or `undefined` if it did not. Consumed events will not be
+   * handled any further by spatial navigation.
    *
    * @param direction {Direction} The direction to move along
    * @param target {HTMLElement} The target element for the event
@@ -100,7 +102,9 @@ export class NavigationGroup {
 
   /**
    * If overwritten, allows to implement custom action behavior. Per default, the internal handler will still be
-   * executed. To prevent execution of the default action handler, call `preventDefault()`;
+   * executed. To prevent execution of the default action handler, call `preventDefault()`. Return `true` if your
+   * handler consumed the action event. Return `false` or `undefined` if it did not. Consumed events will not be
+   * handled any further by spatial navigation.
    *
    * @param action {Action} The action that was called
    * @param target {HTMLElement} The target element that action was called on

--- a/src/ts/spatialnavigation/RootNavigationGroup.ts
+++ b/src/ts/spatialnavigation/RootNavigationGroup.ts
@@ -15,24 +15,42 @@ export class RootNavigationGroup extends NavigationGroup {
     super(container, ...elements);
   }
 
-  public handleAction(action: Action) {
-    this.container.showUi();
-
-    super.handleAction(action);
-  }
-
-  public handleNavigation(direction: Direction) {
-    this.container.showUi();
-
-    super.handleNavigation(direction);
-  }
-
-  protected defaultActionHandler(action: Action): void {
-    if (action === Action.BACK) {
-      this.container.hideUi();
-    } else {
-      super.defaultActionHandler(action);
+  public handleAction(action: Action): boolean {
+    if (action !== Action.BACK) {
+      this.container.showUi();
     }
+
+    return super.handleAction(action);
+  }
+
+  public handleNavigation(direction: Direction): boolean {
+    this.container.showUi();
+
+    return super.handleNavigation(direction);
+  }
+
+  protected defaultActionHandler(action: Action): boolean {
+    if (action !== Action.BACK) {
+      return super.defaultActionHandler(action);
+    }
+
+    if (!this.isUiShown()) {
+      return false;
+    }
+
+    this.container.hideUi();
+
+    return true;
+  }
+
+  private isUiShown(): boolean {
+    const classList = this.container.getDomElement().get(0)?.classList;
+
+    if (!classList) {
+      return false;
+    }
+
+    return Array.from(classList).some(className => /-controls-shown$/.test(className));
   }
 
   public release(): void {

--- a/src/ts/spatialnavigation/SeekBarHandler.ts
+++ b/src/ts/spatialnavigation/SeekBarHandler.ts
@@ -84,22 +84,24 @@ export class SeekBarHandler {
     seekBar.dispatchEvent(new MouseEvent('mousemove', this.getCursorPositionMouseEventInit()));
   }
 
-  private readonly onNavigation = (direction: Direction, target: AnyComponent, preventDefault: () => void): void => {
+  private readonly onNavigation = (direction: Direction, target: AnyComponent, preventDefault: () => void): boolean => {
     const element = toHtmlElement(target);
     if (!isSeekBarWrapper(element)) {
-      return;
+      return false;
     }
 
     if (direction === Direction.UP || direction === Direction.DOWN) {
       this.stopSeeking(getSeekBar(element));
 
-      return;
+      return true;
     }
 
     this.initializeOrUpdateCursorPosition(element, direction);
     this.dispatchMouseMoveEvent(getSeekBar(element));
 
     preventDefault();
+
+    return true;
   };
 
   private dispatchMouseClickEvent(seekBar: Element): void {
@@ -125,10 +127,10 @@ export class SeekBarHandler {
     seekBar.dispatchEvent(new MouseEvent('mouseleave'));
   }
 
-  private readonly onAction = (action: Action, target: AnyComponent, preventDefault: () => void): void => {
+  private readonly onAction = (action: Action, target: AnyComponent, preventDefault: () => void): boolean => {
     const element = toHtmlElement(target);
     if (!isSeekBarWrapper(element)) {
-      return;
+      return false;
     }
 
     const seekBar = getSeekBar(element);
@@ -136,10 +138,14 @@ export class SeekBarHandler {
     if (action === Action.SELECT && this.isScrubbing) {
       this.dispatchMouseClickEvent(seekBar);
       preventDefault();
-    } else if (action === Action.BACK) {
+      return true;
+    } else if (action === Action.BACK && this.isScrubbing) {
       this.stopSeeking(seekBar);
       preventDefault();
+      return true;
     }
+
+    return false;
   };
 
   /**

--- a/src/ts/spatialnavigation/SettingsPanelNavigationGroup.ts
+++ b/src/ts/spatialnavigation/SettingsPanelNavigationGroup.ts
@@ -69,10 +69,10 @@ export class SettingsPanelNavigationGroup extends NavigationGroup {
     return componentsToConsider;
   }
 
-  protected defaultActionHandler(action: Action) {
+  protected defaultActionHandler(action: Action): boolean {
     if (action === Action.BACK) {
       this.settingsPanel.popSettingsPanelPage();
-      return;
+      return true;
     }
 
     if (action === Action.SELECT) {
@@ -83,9 +83,9 @@ export class SettingsPanelNavigationGroup extends NavigationGroup {
         this.settingsPanel.hide();
         super.defaultActionHandler(Action.BACK);
       }
-      return;
+      return true;
     }
 
-    super.defaultActionHandler(action);
+    return super.defaultActionHandler(action);
   }
 }

--- a/src/ts/spatialnavigation/SpatialNavigation.ts
+++ b/src/ts/spatialnavigation/SpatialNavigation.ts
@@ -126,15 +126,10 @@ export class SpatialNavigation {
       return;
     }
 
-    if (isDirection(event)) {
-      active.handleNavigation(event);
-
+    if (isDirection(event) && active.handleNavigation(event)) {
       e.preventDefault();
       e.stopPropagation();
-    }
-    if (isAction(event)) {
-      active.handleAction(event);
-
+    } else if (isAction(event) && active.handleAction(event)) {
       e.preventDefault();
       e.stopPropagation();
     }

--- a/src/ts/spatialnavigation/types.ts
+++ b/src/ts/spatialnavigation/types.ts
@@ -4,7 +4,7 @@ import { FocusableContainer } from './FocusableContainer';
 
 export type AnyComponent = Component<ComponentConfig>;
 export type AnyContainer = Container<ContainerConfig>;
-export type Callback<T> = (data: T, target: AnyComponent, preventDefault: () => void) => boolean;
+export type Callback<T> = (data: T, target: AnyComponent, preventDefault: () => void) => boolean | void;
 export type NavigationCallback = Callback<Direction>;
 export type ActionCallback = Callback<Action>;
 export type KeyMap = {

--- a/src/ts/spatialnavigation/types.ts
+++ b/src/ts/spatialnavigation/types.ts
@@ -4,7 +4,7 @@ import { FocusableContainer } from './FocusableContainer';
 
 export type AnyComponent = Component<ComponentConfig>;
 export type AnyContainer = Container<ContainerConfig>;
-export type Callback<T> = (data: T, target: AnyComponent, preventDefault: () => void) => void;
+export type Callback<T> = (data: T, target: AnyComponent, preventDefault: () => void) => boolean;
 export type NavigationCallback = Callback<Direction>;
 export type ActionCallback = Callback<Action>;
 export type KeyMap = {


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

  This fixes a regression introduced during the UI v3 -> v4 migration in the handling of `Action.BACK` for spatial navigation.


In v3, commit 0f3b376 added special handling for BACK in the root navigation group:
- if the controls were visible, BACK hid the UI and returned `true`
- if the controls were already hidden, it returned `false`

`SpatialNavigation` then only called `preventDefault()` / `stopPropagation()` when the action was actually handled.

During the v4 migration, that contract was lost:
- `RootNavigationGroup` always consumed BACK by hiding the UI
- `NavigationGroup` no longer propagated handled vs not-handled state
- `SpatialNavigation` always prevented default for mapped actions

 As a result, when the controls were already hidden, the UI still swallowed the BACK key instead of letting the platform/player handle it. On TV platforms such as Tizen, this meant the expected back event was no longer emitted.

  This PR restores the old behavior:
  - `RootNavigationGroup` returns `false` for BACK when the UI is already hidden
  - `NavigationGroup` propagates whether an action/navigation event was actually handled
  - `SpatialNavigation` only prevents default when the active navigation group handled the key

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
