### PR TITLE
Export UI layout factory methods for easier customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Export of UI Layout functions to make it easier to customize only some UI variants or change the conditions when which UI variant should be displayed
+- Export default layout functions in `UIFactory.defaultLayouts` for easier customization of individual UI variants and their display conditions
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Export of UI Layout functions to make it easier to customize only some UI variants or change the conditions when which UI variant should be displayed
+
 ### Fixed
 
 - In TV spatial navigation, the BACK button could be swallowed by the UI and not reach the application when the controls were already hidden

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -214,11 +214,11 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildSubtitleUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, subtitleUi(), config);
+    return new UIManager(player, subtitleUiLayout(), config);
   }
 }
 
-function subtitleUi(): UIContainer {
+function subtitleUiLayout(): UIContainer {
   const subtitleOverlay = new SubtitleOverlay();
 
   // Subtitle styling only works if a `SubtitleSettingsPanelPage` (with the corresponding Subtitle Settings elements)

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -81,43 +81,43 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: UIFactory.defaultLayouts.emptyStateUi(),
+          ui: UIFactory.defaultLayouts.emptyState(),
           condition: context => {
             return !context.isSourceLoaded;
           },
         },
         {
-          ui: UIFactory.defaultLayouts.smallScreenAdsUi(),
+          ui: UIFactory.defaultLayouts.smallScreenAds(),
           condition: (context: UIConditionContext) => {
             return context.documentWidth < smallScreenSwitchWidth && context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: UIFactory.defaultLayouts.smallScreenUi(),
+          ui: UIFactory.defaultLayouts.smallScreen(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi && context.documentWidth < smallScreenSwitchWidth;
           },
         },
         {
-          ...UIFactory.defaultLayouts.tvAdsUi(),
+          ...UIFactory.defaultLayouts.tvAds(),
           condition: (context: UIConditionContext) => {
             return context.isTv && context.isAd && context.adRequiresUi;
           },
         },
         {
-          ...UIFactory.defaultLayouts.tvUi(),
+          ...UIFactory.defaultLayouts.tv(),
           condition: (context: UIConditionContext) => {
             return context.isTv && !context.isAd && !context.adRequiresUi;
           },
         },
         {
-          ui: UIFactory.defaultLayouts.adsUi(),
+          ui: UIFactory.defaultLayouts.ads(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: UIFactory.defaultLayouts.ui(config),
+          ui: UIFactory.defaultLayouts.main(config),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -143,13 +143,13 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: UIFactory.defaultLayouts.smallScreenAdsUi(),
+          ui: UIFactory.defaultLayouts.smallScreenAds(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: UIFactory.defaultLayouts.smallScreenUi(),
+          ui: UIFactory.defaultLayouts.smallScreen(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -169,7 +169,7 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildCastReceiverUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, UIFactory.defaultLayouts.castReceiverUi(config), config);
+    return new UIManager(player, UIFactory.defaultLayouts.castReceiver(config), config);
   }
 
   /**
@@ -186,13 +186,13 @@ export namespace UIFactory {
       player,
       [
         {
-          ...UIFactory.defaultLayouts.tvAdsUi(),
+          ...UIFactory.defaultLayouts.tvAds(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ...UIFactory.defaultLayouts.tvUi(),
+          ...UIFactory.defaultLayouts.tv(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -213,7 +213,7 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildSubtitleUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, UIFactory.defaultLayouts.subtitleUi(), config);
+    return new UIManager(player, UIFactory.defaultLayouts.subtitle(), config);
   }
 
   /**
@@ -223,7 +223,7 @@ export namespace UIFactory {
    * They can be used to recreate the default UI while changing the conditions based on which variant switching happens.
    */
   export namespace defaultLayouts {
-    export function subtitleUi(): UIContainer {
+    export function subtitle(): UIContainer {
       const subtitleOverlay = new SubtitleOverlay();
 
       // Subtitle styling only works if a `SubtitleSettingsPanelPage` (with the corresponding Subtitle Settings elements)
@@ -244,7 +244,7 @@ export namespace UIFactory {
       });
     }
 
-    export function ui(config: UIConfig = {}): UIContainer {
+    export function main(config: UIConfig = {}): UIContainer {
       const subtitleOverlay = new SubtitleOverlay();
 
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode === true);
@@ -306,7 +306,7 @@ export namespace UIFactory {
       });
     }
 
-    export function adsUi(): UIContainer {
+    export function ads(): UIContainer {
       const controlBar = new AdControlBar({
         components: [
           new Container({
@@ -359,7 +359,7 @@ export namespace UIFactory {
       });
     }
 
-    export function smallScreenUi(): UIContainer {
+    export function smallScreen(): UIContainer {
       const subtitleOverlay = new SubtitleOverlay();
 
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
@@ -431,7 +431,7 @@ export namespace UIFactory {
       });
     }
 
-    export function smallScreenAdsUi(): UIContainer {
+    export function smallScreenAds(): UIContainer {
       const controlBar = new AdControlBar({
         components: [
           new Container({
@@ -484,7 +484,7 @@ export namespace UIFactory {
       });
     }
 
-    export function castReceiverUi(config: UIConfig = {}): UIContainer {
+    export function castReceiver(config: UIConfig = {}): UIContainer {
       const controlBar = new ControlBar({
         components: [
           new Container({
@@ -525,7 +525,7 @@ export namespace UIFactory {
       });
     }
 
-    export function tvUi(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
+    export function tv(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
       const seekBar = new SeekBar({ label: new SeekBarLabel() });
       const subtitleOverlay = new SubtitleOverlay();
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, 5000);
@@ -632,7 +632,7 @@ export namespace UIFactory {
       };
     }
 
-    export function tvAdsUi(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
+    export function tvAds(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
       const playbackToggleOverlay = new PlaybackToggleOverlay();
       const adStatusOverlay = new AdStatusOverlay();
       const uiContainer = new UIContainer({
@@ -688,7 +688,7 @@ export namespace UIFactory {
     /**
      * Used for the initial startup phase of the UI. Only contains basic components.
      */
-    export function emptyStateUi(): UIContainer {
+    export function emptyState(): UIContainer {
       return new UIContainer({
         components: [new BufferingOverlay(), new PlaybackToggleOverlay(), new ErrorMessageOverlay()],
         cssClasses: ['ui', 'ui-empty-state'],

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -240,7 +240,7 @@ export namespace UILayoutFactory {
     });
   }
 
-  export function uiLayout(config: UIConfig): UIContainer {
+  export function uiLayout(config: UIConfig = {}): UIContainer {
     const subtitleOverlay = new SubtitleOverlay();
 
     const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode != undefined);
@@ -480,7 +480,7 @@ export namespace UILayoutFactory {
     });
   }
 
-  export function castReceiverUILayout(config: UIConfig): UIContainer {
+  export function castReceiverUILayout(config: UIConfig = {}): UIContainer {
     const controlBar = new ControlBar({
       components: [
         new Container({

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -70,7 +70,6 @@ export namespace UIFactory {
    * - Small Screens (e.g. mobile devices)
    * - Small Screen Ads
    * - TVs
-   * - Cast Receivers
    *
    * @param player The player instance used to build the UI
    * @param config The UIConfig object

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -82,43 +82,43 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: emptyStateUILayout(),
+          ui: UILayoutFactory.emptyStateUILayout(),
           condition: context => {
             return !context.isSourceLoaded;
           },
         },
         {
-          ui: smallScreenAdsUILayout(),
+          ui: UILayoutFactory.smallScreenAdsUILayout(),
           condition: (context: UIConditionContext) => {
             return context.documentWidth < smallScreenSwitchWidth && context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: smallScreenUILayout(),
+          ui: UILayoutFactory.smallScreenUILayout(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi && context.documentWidth < smallScreenSwitchWidth;
           },
         },
         {
-          ...tvAdsUILayout(),
+          ...UILayoutFactory.tvAdsUILayout(),
           condition: (context: UIConditionContext) => {
             return context.isTv && context.isAd && context.adRequiresUi;
           },
         },
         {
-          ...tvUILayout(),
+          ...UILayoutFactory.tvUILayout(),
           condition: (context: UIConditionContext) => {
             return context.isTv && !context.isAd && !context.adRequiresUi;
           },
         },
         {
-          ui: adsUILayout(),
+          ui: UILayoutFactory.adsUILayout(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: uiLayout(config),
+          ui: UILayoutFactory.uiLayout(config),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -144,13 +144,13 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: smallScreenAdsUILayout(),
+          ui: UILayoutFactory.smallScreenAdsUILayout(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: smallScreenUILayout(),
+          ui: UILayoutFactory.smallScreenUILayout(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -170,7 +170,7 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildCastReceiverUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, castReceiverUILayout(config), config);
+    return new UIManager(player, UILayoutFactory.castReceiverUILayout(config), config);
   }
 
   /**
@@ -187,13 +187,13 @@ export namespace UIFactory {
       player,
       [
         {
-          ...tvAdsUILayout(),
+          ...UILayoutFactory.tvAdsUILayout(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ...tvUILayout(),
+          ...UILayoutFactory.tvUILayout(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -214,470 +214,482 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildSubtitleUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, subtitleUiLayout(), config);
+    return new UIManager(player, UILayoutFactory.subtitleUiLayout(), config);
   }
 }
 
-function subtitleUiLayout(): UIContainer {
-  const subtitleOverlay = new SubtitleOverlay();
+export namespace UILayoutFactory {
+  export function subtitleUiLayout(): UIContainer {
+    const subtitleOverlay = new SubtitleOverlay();
 
-  // Subtitle styling only works if a `SubtitleSettingsPanelPage` (with the corresponding Subtitle Settings elements)
-  // are in the UI tree.
-  const settingsPanel = new SettingsPanel({
-    components: [],
-    hidden: true,
-  });
-  const subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({
-    settingsPanel: settingsPanel,
-    overlay: subtitleOverlay,
-  });
-  settingsPanel.addComponent(subtitleSettingsPanelPage);
+    // Subtitle styling only works if a `SubtitleSettingsPanelPage` (with the corresponding Subtitle Settings elements)
+    // are in the UI tree.
+    const settingsPanel = new SettingsPanel({
+      components: [],
+      hidden: true,
+    });
+    const subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({
+      settingsPanel: settingsPanel,
+      overlay: subtitleOverlay,
+    });
+    settingsPanel.addComponent(subtitleSettingsPanelPage);
 
-  // Create a custom UI structure with only the SubtitleOverlay (and the hidden SettingsPanel to enable UI customizations)
-  return new UIContainer({
-    components: [subtitleOverlay, settingsPanel],
-  });
-}
+    // Create a custom UI structure with only the SubtitleOverlay (and the hidden SettingsPanel to enable UI customizations)
+    return new UIContainer({
+      components: [subtitleOverlay, settingsPanel],
+    });
+  }
 
-function uiLayout(config: UIConfig) {
-  const subtitleOverlay = new SubtitleOverlay();
+  export function uiLayout(config: UIConfig) {
+    const subtitleOverlay = new SubtitleOverlay();
 
-  const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode != undefined);
-  const controlBar = new ControlBar({
-    components: [
-      new Container({
-        components: [
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
-            hideInLivePlayback: true,
-          }),
-          new SeekBar({ label: new SeekBarLabel() }),
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-            cssClasses: ['text-right'],
-          }),
-        ],
-        cssClasses: ['controlbar-top'],
-      }),
-      new Container({
-        components: [
-          new PlaybackToggleButton(),
-          new VolumeToggleButton(),
-          new VolumeSlider(),
-          new Spacer(),
-          new PictureInPictureToggleButton(),
-          new AirPlayToggleButton(),
-          new CastToggleButton(),
-          new VRToggleButton(),
-          new SettingsToggleButton({ settingsPanel: settingsPanel }),
-          new FullscreenToggleButton(),
-        ],
-        cssClasses: ['controlbar-bottom'],
-      }),
-    ],
-  });
+    const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode != undefined);
+    const controlBar = new ControlBar({
+      components: [
+        new Container({
+          components: [
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+              hideInLivePlayback: true,
+            }),
+            new SeekBar({ label: new SeekBarLabel() }),
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+              cssClasses: ['text-right'],
+            }),
+          ],
+          cssClasses: ['controlbar-top'],
+        }),
+        new Container({
+          components: [
+            new PlaybackToggleButton(),
+            new VolumeToggleButton(),
+            new VolumeSlider(),
+            new Spacer(),
+            new PictureInPictureToggleButton(),
+            new AirPlayToggleButton(),
+            new CastToggleButton(),
+            new VRToggleButton(),
+            new SettingsToggleButton({ settingsPanel: settingsPanel }),
+            new FullscreenToggleButton(),
+          ],
+          cssClasses: ['controlbar-bottom'],
+        }),
+      ],
+    });
 
-  const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
+    const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
 
-  return new UIContainer({
-    components: [
-      subtitleOverlay,
-      new BufferingOverlay(),
-      new PlaybackToggleOverlay(),
-      new CastStatusOverlay(),
-      controlBar,
-      new TitleBar(),
-      new RecommendationOverlay(),
-      ...conditionalComponents,
-      new DismissClickOverlay({ target: settingsPanel }),
-      settingsPanel,
-      new ErrorMessageOverlay(),
-    ],
-    hidePlayerStateExceptions: [
-      PlayerUtils.PlayerState.Prepared,
-      PlayerUtils.PlayerState.Paused,
-      PlayerUtils.PlayerState.Finished,
-    ],
-  });
-}
+    return new UIContainer({
+      components: [
+        subtitleOverlay,
+        new BufferingOverlay(),
+        new PlaybackToggleOverlay(),
+        new CastStatusOverlay(),
+        controlBar,
+        new TitleBar(),
+        new RecommendationOverlay(),
+        ...conditionalComponents,
+        new DismissClickOverlay({ target: settingsPanel }),
+        settingsPanel,
+        new ErrorMessageOverlay(),
+      ],
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
+    });
+  }
 
-function adsUILayout() {
-  const controlBar = new AdControlBar({
-    components: [
-      new Container({
-        components: [
-          new AdCounterLabel(),
-          new SeekBar({ label: new SeekBarLabel() }),
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
-            cssClasses: ['text-right'],
-          }),
-        ],
-        cssClasses: ['ad-controlbar-top'],
-      }),
-      new Container({
-        components: [new PlaybackToggleButton(), new VolumeToggleButton(), new Spacer(), new FullscreenToggleButton()],
-        cssClasses: ['ad-controlbar-bottom'],
-      }),
-    ],
-  });
+  export function adsUILayout() {
+    const controlBar = new AdControlBar({
+      components: [
+        new Container({
+          components: [
+            new AdCounterLabel(),
+            new SeekBar({ label: new SeekBarLabel() }),
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
+              cssClasses: ['text-right'],
+            }),
+          ],
+          cssClasses: ['ad-controlbar-top'],
+        }),
+        new Container({
+          components: [
+            new PlaybackToggleButton(),
+            new VolumeToggleButton(),
+            new Spacer(),
+            new FullscreenToggleButton(),
+          ],
+          cssClasses: ['ad-controlbar-bottom'],
+        }),
+      ],
+    });
 
-  return new UIContainer({
-    components: [
-      new BufferingOverlay(),
-      new AdClickOverlay(),
-      new PlaybackToggleOverlay(),
-      new AdStatusOverlay(),
-      controlBar,
-      new TitleBar({
-        components: [
-          new Container({
-            components: [new AdMessageLabel()],
-            cssClasses: ['ui-titlebar-top'],
-          }),
-        ],
-        keepHiddenWithoutMetadata: true,
-      }),
-      new ErrorMessageOverlay(),
-    ],
-    hidePlayerStateExceptions: [
-      PlayerUtils.PlayerState.Prepared,
-      PlayerUtils.PlayerState.Paused,
-      PlayerUtils.PlayerState.Finished,
-    ],
-    cssClasses: ['ui-ads'],
-  });
-}
+    return new UIContainer({
+      components: [
+        new BufferingOverlay(),
+        new AdClickOverlay(),
+        new PlaybackToggleOverlay(),
+        new AdStatusOverlay(),
+        controlBar,
+        new TitleBar({
+          components: [
+            new Container({
+              components: [new AdMessageLabel()],
+              cssClasses: ['ui-titlebar-top'],
+            }),
+          ],
+          keepHiddenWithoutMetadata: true,
+        }),
+        new ErrorMessageOverlay(),
+      ],
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
+      cssClasses: ['ui-ads'],
+    });
+  }
 
-function smallScreenUILayout() {
-  const subtitleOverlay = new SubtitleOverlay();
+  export function smallScreenUILayout() {
+    const subtitleOverlay = new SubtitleOverlay();
 
-  const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
+    const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
 
-  const controlBar = new ControlBar({
-    components: [
-      new Container({
-        components: [
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
-            hideInLivePlayback: true,
-          }),
-          new SeekBar({ label: new SeekBarLabel() }),
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-            cssClasses: ['text-right'],
-          }),
-        ],
-        cssClasses: ['controlbar-top'],
-      }),
-      new Container({
-        components: [
-          new PlaybackToggleButton(),
-          new VolumeToggleButton(),
-          new VolumeSlider(),
-          new Spacer(),
-          new PictureInPictureToggleButton(),
-          new SettingsToggleButton({ settingsPanel: settingsPanel }),
-          new FullscreenToggleButton(),
-        ],
-        cssClasses: ['controlbar-bottom'],
-      }),
-    ],
-  });
+    const controlBar = new ControlBar({
+      components: [
+        new Container({
+          components: [
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+              hideInLivePlayback: true,
+            }),
+            new SeekBar({ label: new SeekBarLabel() }),
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+              cssClasses: ['text-right'],
+            }),
+          ],
+          cssClasses: ['controlbar-top'],
+        }),
+        new Container({
+          components: [
+            new PlaybackToggleButton(),
+            new VolumeToggleButton(),
+            new VolumeSlider(),
+            new Spacer(),
+            new PictureInPictureToggleButton(),
+            new SettingsToggleButton({ settingsPanel: settingsPanel }),
+            new FullscreenToggleButton(),
+          ],
+          cssClasses: ['controlbar-bottom'],
+        }),
+      ],
+    });
 
-  return new UIContainer({
-    components: [
-      subtitleOverlay,
-      new BufferingOverlay(),
-      new CastStatusOverlay(),
-      // Use the touch overlay on mobile devices and the regular playback toggle overlay on desktop browsers
-      BrowserUtils.isMobile ? new TouchControlOverlay() : new PlaybackToggleOverlay(),
-      new RecommendationOverlay(),
-      controlBar,
-      new TitleBar({
-        components: [
-          new Container({
-            components: [
-              new MetadataLabel({ content: MetadataLabelContent.Title }),
-              new Spacer(),
-              new CastToggleButton(),
-              new AirPlayToggleButton(),
-              new VRToggleButton(),
-            ],
-            cssClasses: ['titlebar-row'],
-          }),
-        ],
-      }),
-      new DismissClickOverlay({ target: settingsPanel }),
-      settingsPanel,
-      new ErrorMessageOverlay(),
-    ],
-    cssClasses: ['ui-smallscreen'],
-    hidePlayerStateExceptions: [
-      PlayerUtils.PlayerState.Prepared,
-      PlayerUtils.PlayerState.Paused,
-      PlayerUtils.PlayerState.Finished,
-    ],
-  });
-}
+    return new UIContainer({
+      components: [
+        subtitleOverlay,
+        new BufferingOverlay(),
+        new CastStatusOverlay(),
+        // Use the touch overlay on mobile devices and the regular playback toggle overlay on desktop browsers
+        BrowserUtils.isMobile ? new TouchControlOverlay() : new PlaybackToggleOverlay(),
+        new RecommendationOverlay(),
+        controlBar,
+        new TitleBar({
+          components: [
+            new Container({
+              components: [
+                new MetadataLabel({ content: MetadataLabelContent.Title }),
+                new Spacer(),
+                new CastToggleButton(),
+                new AirPlayToggleButton(),
+                new VRToggleButton(),
+              ],
+              cssClasses: ['titlebar-row'],
+            }),
+          ],
+        }),
+        new DismissClickOverlay({ target: settingsPanel }),
+        settingsPanel,
+        new ErrorMessageOverlay(),
+      ],
+      cssClasses: ['ui-smallscreen'],
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
+    });
+  }
 
-function smallScreenAdsUILayout() {
-  const controlBar = new AdControlBar({
-    components: [
-      new Container({
-        components: [
-          new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.CurrentTime }),
-          new SeekBar({ label: new SeekBarLabel() }),
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-            cssClasses: ['text-right'],
-          }),
-        ],
-        cssClasses: ['ad-controlbar-top'],
-      }),
-      new Container({
-        components: [new PlaybackToggleButton(), new VolumeToggleButton(), new Spacer(), new FullscreenToggleButton()],
-        cssClasses: ['ad-controlbar-bottom'],
-      }),
-    ],
-  });
+  export function smallScreenAdsUILayout() {
+    const controlBar = new AdControlBar({
+      components: [
+        new Container({
+          components: [
+            new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.CurrentTime }),
+            new SeekBar({ label: new SeekBarLabel() }),
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+              cssClasses: ['text-right'],
+            }),
+          ],
+          cssClasses: ['ad-controlbar-top'],
+        }),
+        new Container({
+          components: [
+            new PlaybackToggleButton(),
+            new VolumeToggleButton(),
+            new Spacer(),
+            new FullscreenToggleButton(),
+          ],
+          cssClasses: ['ad-controlbar-bottom'],
+        }),
+      ],
+    });
 
-  return new UIContainer({
-    components: [
-      new BufferingOverlay(),
-      new AdClickOverlay(),
-      new PlaybackToggleOverlay(),
-      controlBar,
-      new TitleBar({
-        components: [
-          new Container({
-            components: [new AdMessageLabel()],
-            cssClasses: ['ui-titlebar-top'],
-          }),
-        ],
-        keepHiddenWithoutMetadata: true,
-      }),
-      new AdStatusOverlay(),
-      new ErrorMessageOverlay(),
-    ],
-    hidePlayerStateExceptions: [
-      PlayerUtils.PlayerState.Prepared,
-      PlayerUtils.PlayerState.Paused,
-      PlayerUtils.PlayerState.Finished,
-    ],
-    cssClasses: ['ui-smallscreen', 'ui-ads'],
-  });
-}
+    return new UIContainer({
+      components: [
+        new BufferingOverlay(),
+        new AdClickOverlay(),
+        new PlaybackToggleOverlay(),
+        controlBar,
+        new TitleBar({
+          components: [
+            new Container({
+              components: [new AdMessageLabel()],
+              cssClasses: ['ui-titlebar-top'],
+            }),
+          ],
+          keepHiddenWithoutMetadata: true,
+        }),
+        new AdStatusOverlay(),
+        new ErrorMessageOverlay(),
+      ],
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
+      cssClasses: ['ui-smallscreen', 'ui-ads'],
+    });
+  }
 
-function castReceiverUILayout(config: UIConfig) {
-  const controlBar = new ControlBar({
-    components: [
-      new Container({
-        components: [
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
-            hideInLivePlayback: true,
-          }),
-          new SeekBar({ smoothPlaybackPositionUpdateIntervalMs: -1 }),
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-            cssClasses: ['text-right'],
-          }),
-        ],
-        cssClasses: ['controlbar-top'],
-      }),
-    ],
-  });
+  export function castReceiverUILayout(config: UIConfig) {
+    const controlBar = new ControlBar({
+      components: [
+        new Container({
+          components: [
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+              hideInLivePlayback: true,
+            }),
+            new SeekBar({ smoothPlaybackPositionUpdateIntervalMs: -1 }),
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+              cssClasses: ['text-right'],
+            }),
+          ],
+          cssClasses: ['controlbar-top'],
+        }),
+      ],
+    });
 
-  const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
+    const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
 
-  return new CastUIContainer({
-    components: [
-      new SubtitleOverlay(),
-      new BufferingOverlay(),
-      new PlaybackToggleOverlay(),
-      controlBar,
-      new TitleBar({ keepHiddenWithoutMetadata: true }),
-      ...conditionalComponents,
-      new ErrorMessageOverlay(),
-    ],
-    cssClasses: ['ui-cast-receiver'],
-    hidePlayerStateExceptions: [
-      PlayerUtils.PlayerState.Prepared,
-      PlayerUtils.PlayerState.Paused,
-      PlayerUtils.PlayerState.Finished,
-    ],
-  });
-}
+    return new CastUIContainer({
+      components: [
+        new SubtitleOverlay(),
+        new BufferingOverlay(),
+        new PlaybackToggleOverlay(),
+        controlBar,
+        new TitleBar({ keepHiddenWithoutMetadata: true }),
+        ...conditionalComponents,
+        new ErrorMessageOverlay(),
+      ],
+      cssClasses: ['ui-cast-receiver'],
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
+    });
+  }
 
-function tvUILayout() {
-  const seekBar = new SeekBar({ label: new SeekBarLabel() });
-  const subtitleOverlay = new SubtitleOverlay();
-  const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, 5000);
+  export function tvUILayout() {
+    const seekBar = new SeekBar({ label: new SeekBarLabel() });
+    const subtitleOverlay = new SubtitleOverlay();
+    const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, 5000);
 
-  const subtitleListBox = new SubtitleListBox(i18n.getLocalizer('settings.subtitles'));
-  const subtitleListBoxOpenButton = new SettingsToggleButton({
-    settingsPanel: subtitleListBox,
-    autoHideWhenNoActiveSettings: true,
-    cssClass: 'ui-subtitle-list-box-toggle-button',
-    text: i18n.getLocalizer('settings.subtitles'),
-  });
+    const subtitleListBox = new SubtitleListBox(i18n.getLocalizer('settings.subtitles'));
+    const subtitleListBoxOpenButton = new SettingsToggleButton({
+      settingsPanel: subtitleListBox,
+      autoHideWhenNoActiveSettings: true,
+      cssClass: 'ui-subtitle-list-box-toggle-button',
+      text: i18n.getLocalizer('settings.subtitles'),
+    });
 
-  const audioListBox = new AudioTrackListBox(i18n.getLocalizer('settings.audio.track'));
-  const audioListBoxToggleButton = new SettingsToggleButton({
-    settingsPanel: audioListBox,
-    autoHideWhenNoActiveSettings: true,
-    cssClass: 'ui-audio-track-list-box-toggle-button',
-    text: i18n.getLocalizer('settings.audio.track'),
-  });
+    const audioListBox = new AudioTrackListBox(i18n.getLocalizer('settings.audio.track'));
+    const audioListBoxToggleButton = new SettingsToggleButton({
+      settingsPanel: audioListBox,
+      autoHideWhenNoActiveSettings: true,
+      cssClass: 'ui-audio-track-list-box-toggle-button',
+      text: i18n.getLocalizer('settings.audio.track'),
+    });
 
-  const titleBar = new TitleBar({
-    components: [
-      new Container({
-        components: [new MetadataLabel({ content: MetadataLabelContent.Title })],
-        cssClasses: ['ui-titlebar-top'],
-      }),
-      new Container({
-        components: [new MetadataLabel({ content: MetadataLabelContent.Description })],
-        cssClasses: ['ui-titlebar-bottom'],
-      }),
-    ],
-  });
+    const titleBar = new TitleBar({
+      components: [
+        new Container({
+          components: [new MetadataLabel({ content: MetadataLabelContent.Title })],
+          cssClasses: ['ui-titlebar-top'],
+        }),
+        new Container({
+          components: [new MetadataLabel({ content: MetadataLabelContent.Description })],
+          cssClasses: ['ui-titlebar-bottom'],
+        }),
+      ],
+    });
 
-  const playbackToggleButton = new PlaybackToggleButton();
-  const bottomControlBar = new Container({
-    components: [
-      playbackToggleButton,
-      new Spacer(),
-      subtitleListBoxOpenButton,
-      audioListBoxToggleButton,
-      new SettingsToggleButton({ settingsPanel: settingsPanel }),
-    ],
-    cssClasses: ['controlbar-bottom'],
-  });
-  const controlBar = new ControlBar({
-    components: [
-      new Container({
-        components: [
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
-            hideInLivePlayback: true,
-          }),
-          seekBar,
-          new PlaybackTimeLabel({
-            timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-            cssClasses: ['text-right'],
-          }),
-        ],
-        cssClasses: ['controlbar-top'],
-      }),
-      bottomControlBar,
-    ],
-  });
+    const playbackToggleButton = new PlaybackToggleButton();
+    const bottomControlBar = new Container({
+      components: [
+        playbackToggleButton,
+        new Spacer(),
+        subtitleListBoxOpenButton,
+        audioListBoxToggleButton,
+        new SettingsToggleButton({ settingsPanel: settingsPanel }),
+      ],
+      cssClasses: ['controlbar-bottom'],
+    });
+    const controlBar = new ControlBar({
+      components: [
+        new Container({
+          components: [
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+              hideInLivePlayback: true,
+            }),
+            seekBar,
+            new PlaybackTimeLabel({
+              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+              cssClasses: ['text-right'],
+            }),
+          ],
+          cssClasses: ['controlbar-top'],
+        }),
+        bottomControlBar,
+      ],
+    });
 
-  const playbackToggleOverlay = new PlaybackToggleOverlay();
-  const recommendationOverlay = new RecommendationOverlay();
-  const uiContainer = new UIContainer({
-    components: [
-      subtitleOverlay,
-      new BufferingOverlay(),
-      playbackToggleOverlay,
-      controlBar,
-      titleBar,
-      settingsPanel,
-      subtitleListBox,
-      audioListBox,
-      recommendationOverlay,
-      new ErrorMessageOverlay(),
-    ],
-    cssClasses: ['ui-tv'],
-    hidePlayerStateExceptions: [
-      PlayerUtils.PlayerState.Prepared,
-      PlayerUtils.PlayerState.Paused,
-      PlayerUtils.PlayerState.Finished,
-    ],
-  });
+    const playbackToggleOverlay = new PlaybackToggleOverlay();
+    const recommendationOverlay = new RecommendationOverlay();
+    const uiContainer = new UIContainer({
+      components: [
+        subtitleOverlay,
+        new BufferingOverlay(),
+        playbackToggleOverlay,
+        controlBar,
+        titleBar,
+        settingsPanel,
+        subtitleListBox,
+        audioListBox,
+        recommendationOverlay,
+        new ErrorMessageOverlay(),
+      ],
+      cssClasses: ['ui-tv'],
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
+    });
 
-  const spatialNavigation = new SpatialNavigation(
-    new RootNavigationGroup(
-      uiContainer,
-      playbackToggleOverlay,
-      seekBar,
-      new FocusableContainer(bottomControlBar, playbackToggleButton),
-    ),
-    new SettingsPanelNavigationGroup(settingsPanel, { closeOnSelect: false }),
-    new SettingsPanelNavigationGroup(subtitleListBox),
-    new SettingsPanelNavigationGroup(audioListBox),
-    new RecommendationOverlayNavigationGroup(recommendationOverlay),
-  );
+    const spatialNavigation = new SpatialNavigation(
+      new RootNavigationGroup(
+        uiContainer,
+        playbackToggleOverlay,
+        seekBar,
+        new FocusableContainer(bottomControlBar, playbackToggleButton),
+      ),
+      new SettingsPanelNavigationGroup(settingsPanel, { closeOnSelect: false }),
+      new SettingsPanelNavigationGroup(subtitleListBox),
+      new SettingsPanelNavigationGroup(audioListBox),
+      new RecommendationOverlayNavigationGroup(recommendationOverlay),
+    );
 
-  return {
-    ui: uiContainer,
-    spatialNavigation: spatialNavigation,
-  };
-}
+    return {
+      ui: uiContainer,
+      spatialNavigation: spatialNavigation,
+    };
+  }
 
-function tvAdsUILayout() {
-  const playbackToggleOverlay = new PlaybackToggleOverlay();
-  const adStatusOverlay = new AdStatusOverlay();
-  const uiContainer = new UIContainer({
-    components: [
-      new BufferingOverlay(),
-      new AdClickOverlay(),
-      playbackToggleOverlay,
-      adStatusOverlay,
-      new AdControlBar({
-        components: [
-          new Container({
-            components: [
-              new AdCounterLabel(),
-              new SeekBar({ label: new SeekBarLabel() }),
-              new PlaybackTimeLabel({
-                timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
-                cssClasses: ['text-right'],
-              }),
-            ],
-            cssClasses: ['ad-controlbar-top'],
-          }),
-        ],
-      }),
-      new TitleBar({
-        components: [
-          new Container({
-            components: [new AdMessageLabel()],
-            cssClasses: ['ui-titlebar-top'],
-          }),
-        ],
-        keepHiddenWithoutMetadata: true,
-      }),
-      new ErrorMessageOverlay(),
-    ],
-    cssClasses: ['ui-tv', 'ui-ads'],
-    hidePlayerStateExceptions: [
-      PlayerUtils.PlayerState.Prepared,
-      PlayerUtils.PlayerState.Paused,
-      PlayerUtils.PlayerState.Finished,
-    ],
-  });
+  export function tvAdsUILayout() {
+    const playbackToggleOverlay = new PlaybackToggleOverlay();
+    const adStatusOverlay = new AdStatusOverlay();
+    const uiContainer = new UIContainer({
+      components: [
+        new BufferingOverlay(),
+        new AdClickOverlay(),
+        playbackToggleOverlay,
+        adStatusOverlay,
+        new AdControlBar({
+          components: [
+            new Container({
+              components: [
+                new AdCounterLabel(),
+                new SeekBar({ label: new SeekBarLabel() }),
+                new PlaybackTimeLabel({
+                  timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
+                  cssClasses: ['text-right'],
+                }),
+              ],
+              cssClasses: ['ad-controlbar-top'],
+            }),
+          ],
+        }),
+        new TitleBar({
+          components: [
+            new Container({
+              components: [new AdMessageLabel()],
+              cssClasses: ['ui-titlebar-top'],
+            }),
+          ],
+          keepHiddenWithoutMetadata: true,
+        }),
+        new ErrorMessageOverlay(),
+      ],
+      cssClasses: ['ui-tv', 'ui-ads'],
+      hidePlayerStateExceptions: [
+        PlayerUtils.PlayerState.Prepared,
+        PlayerUtils.PlayerState.Paused,
+        PlayerUtils.PlayerState.Finished,
+      ],
+    });
 
-  const spatialNavigation = new SpatialNavigation(
-    new RootNavigationGroup(uiContainer, playbackToggleOverlay, adStatusOverlay.adSkipButton),
-  );
+    const spatialNavigation = new SpatialNavigation(
+      new RootNavigationGroup(uiContainer, playbackToggleOverlay, adStatusOverlay.adSkipButton),
+    );
 
-  return {
-    ui: uiContainer,
-    spatialNavigation: spatialNavigation,
-  };
-}
+    return {
+      ui: uiContainer,
+      spatialNavigation: spatialNavigation,
+    };
+  }
 
-/**
- * Used for the initial startup phase of the UI. Only contains basic components.
- */
-function emptyStateUILayout() {
-  return new UIContainer({
-    components: [new BufferingOverlay(), new PlaybackToggleOverlay(), new ErrorMessageOverlay()],
-    cssClasses: ['ui', 'ui-empty-state'],
-  });
+  /**
+   * Used for the initial startup phase of the UI. Only contains basic components.
+   */
+  export function emptyStateUILayout() {
+    return new UIContainer({
+      components: [new BufferingOverlay(), new PlaybackToggleOverlay(), new ErrorMessageOverlay()],
+      cssClasses: ['ui', 'ui-empty-state'],
+    });
+  }
 }
 
 function buildDefaultSettingsPanel(

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -247,7 +247,7 @@ export namespace UIFactory {
     export function ui(config: UIConfig = {}): UIContainer {
       const subtitleOverlay = new SubtitleOverlay();
 
-      const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode != undefined);
+      const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode === true);
       const controlBar = new ControlBar({
         components: [
           new Container({

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -37,7 +37,7 @@ import { AdControlBar } from './components/ads/AdControlBar';
 import { MetadataLabel, MetadataLabelContent } from './components/labels/MetadataLabel';
 import { PlayerUtils } from './utils/PlayerUtils';
 import { CastUIContainer } from './components/CastUIContainer';
-import { UIConditionContext, UIManager } from './UIManager';
+import { UIConditionContext, UIManager, UIVariant } from './UIManager';
 import { UIConfig } from './UIConfig';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from './localization/i18n';
@@ -240,7 +240,7 @@ export namespace UILayoutFactory {
     });
   }
 
-  export function uiLayout(config: UIConfig) {
+  export function uiLayout(config: UIConfig): UIContainer {
     const subtitleOverlay = new SubtitleOverlay();
 
     const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode != undefined);
@@ -302,7 +302,7 @@ export namespace UILayoutFactory {
     });
   }
 
-  export function adsUILayout() {
+  export function adsUILayout(): UIContainer {
     const controlBar = new AdControlBar({
       components: [
         new Container({
@@ -355,7 +355,7 @@ export namespace UILayoutFactory {
     });
   }
 
-  export function smallScreenUILayout() {
+  export function smallScreenUILayout(): UIContainer {
     const subtitleOverlay = new SubtitleOverlay();
 
     const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
@@ -427,7 +427,7 @@ export namespace UILayoutFactory {
     });
   }
 
-  export function smallScreenAdsUILayout() {
+  export function smallScreenAdsUILayout(): UIContainer {
     const controlBar = new AdControlBar({
       components: [
         new Container({
@@ -480,7 +480,7 @@ export namespace UILayoutFactory {
     });
   }
 
-  export function castReceiverUILayout(config: UIConfig) {
+  export function castReceiverUILayout(config: UIConfig): UIContainer {
     const controlBar = new ControlBar({
       components: [
         new Container({
@@ -521,7 +521,7 @@ export namespace UILayoutFactory {
     });
   }
 
-  export function tvUILayout() {
+  export function tvUILayout(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
     const seekBar = new SeekBar({ label: new SeekBarLabel() });
     const subtitleOverlay = new SubtitleOverlay();
     const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, 5000);
@@ -628,7 +628,7 @@ export namespace UILayoutFactory {
     };
   }
 
-  export function tvAdsUILayout() {
+  export function tvAdsUILayout(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
     const playbackToggleOverlay = new PlaybackToggleOverlay();
     const adStatusOverlay = new AdStatusOverlay();
     const uiContainer = new UIContainer({
@@ -684,7 +684,7 @@ export namespace UILayoutFactory {
   /**
    * Used for the initial startup phase of the UI. Only contains basic components.
    */
-  export function emptyStateUILayout() {
+  export function emptyStateUILayout(): UIContainer {
     return new UIContainer({
       components: [new BufferingOverlay(), new PlaybackToggleOverlay(), new ErrorMessageOverlay()],
       cssClasses: ['ui', 'ui-empty-state'],

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -219,8 +219,8 @@ export namespace UIFactory {
   /**
    * Default layout functions which are used to build the default UI.
    *
-   * Using these methods enable UI customizations of certains aspects of the default UI, without recreating all UI variants.
-   * It can be used to recreate the default UI but change the coniditions based on which the variant switching happens.
+   * Using these methods enables customization of certain aspects of the default UI without recreating all UI variants.
+   * They can be used to recreate the default UI while changing the conditions based on which variant switching happens.
    */
   export namespace defaultLayouts {
     export function subtitleUi(): UIContainer {

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -218,7 +218,10 @@ export namespace UIFactory {
   }
 
   /**
+   * Default layout functions which are used to build the default UI.
    *
+   * Using these methods enable UI customizations of certains aspects of the default UI, without recreating all UI variants.
+   * It can be used to recreate the default UI but change the coniditions based on which the variant switching happens.
    */
   export namespace defaultLayouts {
     export function subtitleUiLayout(): UIContainer {

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -214,7 +214,7 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildSubtitleUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, UIFactory.defaultLayouts.subtitleUiLayout(), config);
+    return new UIManager(player, UIFactory.defaultLayouts.subtitleUi(), config);
   }
 
   /**
@@ -224,7 +224,7 @@ export namespace UIFactory {
    * It can be used to recreate the default UI but change the coniditions based on which the variant switching happens.
    */
   export namespace defaultLayouts {
-    export function subtitleUiLayout(): UIContainer {
+    export function subtitleUi(): UIContainer {
       const subtitleOverlay = new SubtitleOverlay();
 
       // Subtitle styling only works if a `SubtitleSettingsPanelPage` (with the corresponding Subtitle Settings elements)

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -82,43 +82,43 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: UILayoutFactory.emptyStateUILayout(),
+          ui: UIFactory.defaultLayouts.emptyStateUi(),
           condition: context => {
             return !context.isSourceLoaded;
           },
         },
         {
-          ui: UILayoutFactory.smallScreenAdsUILayout(),
+          ui: UIFactory.defaultLayouts.smallScreenAdsUi(),
           condition: (context: UIConditionContext) => {
             return context.documentWidth < smallScreenSwitchWidth && context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: UILayoutFactory.smallScreenUILayout(),
+          ui: UIFactory.defaultLayouts.smallScreenUi(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi && context.documentWidth < smallScreenSwitchWidth;
           },
         },
         {
-          ...UILayoutFactory.tvAdsUILayout(),
+          ...UIFactory.defaultLayouts.tvAdsUi(),
           condition: (context: UIConditionContext) => {
             return context.isTv && context.isAd && context.adRequiresUi;
           },
         },
         {
-          ...UILayoutFactory.tvUILayout(),
+          ...UIFactory.defaultLayouts.tvUi(),
           condition: (context: UIConditionContext) => {
             return context.isTv && !context.isAd && !context.adRequiresUi;
           },
         },
         {
-          ui: UILayoutFactory.adsUILayout(),
+          ui: UIFactory.defaultLayouts.adsUi(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: UILayoutFactory.uiLayout(config),
+          ui: UIFactory.defaultLayouts.ui(config),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -144,13 +144,13 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: UILayoutFactory.smallScreenAdsUILayout(),
+          ui: UIFactory.defaultLayouts.smallScreenAdsUi(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ui: UILayoutFactory.smallScreenUILayout(),
+          ui: UIFactory.defaultLayouts.smallScreenUi(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -170,7 +170,7 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildCastReceiverUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, UILayoutFactory.castReceiverUILayout(config), config);
+    return new UIManager(player, UIFactory.defaultLayouts.castReceiverUi(config), config);
   }
 
   /**
@@ -187,13 +187,13 @@ export namespace UIFactory {
       player,
       [
         {
-          ...UILayoutFactory.tvAdsUILayout(),
+          ...UIFactory.defaultLayouts.tvAdsUi(),
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
         },
         {
-          ...UILayoutFactory.tvUILayout(),
+          ...UIFactory.defaultLayouts.tvUi(),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -214,562 +214,565 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildSubtitleUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, UILayoutFactory.subtitleUiLayout(), config);
-  }
-}
-
-export namespace UILayoutFactory {
-  export function subtitleUiLayout(): UIContainer {
-    const subtitleOverlay = new SubtitleOverlay();
-
-    // Subtitle styling only works if a `SubtitleSettingsPanelPage` (with the corresponding Subtitle Settings elements)
-    // are in the UI tree.
-    const settingsPanel = new SettingsPanel({
-      components: [],
-      hidden: true,
-    });
-    const subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({
-      settingsPanel: settingsPanel,
-      overlay: subtitleOverlay,
-    });
-    settingsPanel.addComponent(subtitleSettingsPanelPage);
-
-    // Create a custom UI structure with only the SubtitleOverlay (and the hidden SettingsPanel to enable UI customizations)
-    return new UIContainer({
-      components: [subtitleOverlay, settingsPanel],
-    });
-  }
-
-  export function uiLayout(config: UIConfig = {}): UIContainer {
-    const subtitleOverlay = new SubtitleOverlay();
-
-    const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode != undefined);
-    const controlBar = new ControlBar({
-      components: [
-        new Container({
-          components: [
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
-              hideInLivePlayback: true,
-            }),
-            new SeekBar({ label: new SeekBarLabel() }),
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-              cssClasses: ['text-right'],
-            }),
-          ],
-          cssClasses: ['controlbar-top'],
-        }),
-        new Container({
-          components: [
-            new PlaybackToggleButton(),
-            new VolumeToggleButton(),
-            new VolumeSlider(),
-            new Spacer(),
-            new PictureInPictureToggleButton(),
-            new AirPlayToggleButton(),
-            new CastToggleButton(),
-            new VRToggleButton(),
-            new SettingsToggleButton({ settingsPanel: settingsPanel }),
-            new FullscreenToggleButton(),
-          ],
-          cssClasses: ['controlbar-bottom'],
-        }),
-      ],
-    });
-
-    const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
-
-    return new UIContainer({
-      components: [
-        subtitleOverlay,
-        new BufferingOverlay(),
-        new PlaybackToggleOverlay(),
-        new CastStatusOverlay(),
-        controlBar,
-        new TitleBar(),
-        new RecommendationOverlay(),
-        ...conditionalComponents,
-        new DismissClickOverlay({ target: settingsPanel }),
-        settingsPanel,
-        new ErrorMessageOverlay(),
-      ],
-      hidePlayerStateExceptions: [
-        PlayerUtils.PlayerState.Prepared,
-        PlayerUtils.PlayerState.Paused,
-        PlayerUtils.PlayerState.Finished,
-      ],
-    });
-  }
-
-  export function adsUILayout(): UIContainer {
-    const controlBar = new AdControlBar({
-      components: [
-        new Container({
-          components: [
-            new AdCounterLabel(),
-            new SeekBar({ label: new SeekBarLabel() }),
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
-              cssClasses: ['text-right'],
-            }),
-          ],
-          cssClasses: ['ad-controlbar-top'],
-        }),
-        new Container({
-          components: [
-            new PlaybackToggleButton(),
-            new VolumeToggleButton(),
-            new Spacer(),
-            new FullscreenToggleButton(),
-          ],
-          cssClasses: ['ad-controlbar-bottom'],
-        }),
-      ],
-    });
-
-    return new UIContainer({
-      components: [
-        new BufferingOverlay(),
-        new AdClickOverlay(),
-        new PlaybackToggleOverlay(),
-        new AdStatusOverlay(),
-        controlBar,
-        new TitleBar({
-          components: [
-            new Container({
-              components: [new AdMessageLabel()],
-              cssClasses: ['ui-titlebar-top'],
-            }),
-          ],
-          keepHiddenWithoutMetadata: true,
-        }),
-        new ErrorMessageOverlay(),
-      ],
-      hidePlayerStateExceptions: [
-        PlayerUtils.PlayerState.Prepared,
-        PlayerUtils.PlayerState.Paused,
-        PlayerUtils.PlayerState.Finished,
-      ],
-      cssClasses: ['ui-ads'],
-    });
-  }
-
-  export function smallScreenUILayout(): UIContainer {
-    const subtitleOverlay = new SubtitleOverlay();
-
-    const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
-
-    const controlBar = new ControlBar({
-      components: [
-        new Container({
-          components: [
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
-              hideInLivePlayback: true,
-            }),
-            new SeekBar({ label: new SeekBarLabel() }),
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-              cssClasses: ['text-right'],
-            }),
-          ],
-          cssClasses: ['controlbar-top'],
-        }),
-        new Container({
-          components: [
-            new PlaybackToggleButton(),
-            new VolumeToggleButton(),
-            new VolumeSlider(),
-            new Spacer(),
-            new PictureInPictureToggleButton(),
-            new SettingsToggleButton({ settingsPanel: settingsPanel }),
-            new FullscreenToggleButton(),
-          ],
-          cssClasses: ['controlbar-bottom'],
-        }),
-      ],
-    });
-
-    return new UIContainer({
-      components: [
-        subtitleOverlay,
-        new BufferingOverlay(),
-        new CastStatusOverlay(),
-        // Use the touch overlay on mobile devices and the regular playback toggle overlay on desktop browsers
-        BrowserUtils.isMobile ? new TouchControlOverlay() : new PlaybackToggleOverlay(),
-        new RecommendationOverlay(),
-        controlBar,
-        new TitleBar({
-          components: [
-            new Container({
-              components: [
-                new MetadataLabel({ content: MetadataLabelContent.Title }),
-                new Spacer(),
-                new CastToggleButton(),
-                new AirPlayToggleButton(),
-                new VRToggleButton(),
-              ],
-              cssClasses: ['titlebar-row'],
-            }),
-          ],
-        }),
-        new DismissClickOverlay({ target: settingsPanel }),
-        settingsPanel,
-        new ErrorMessageOverlay(),
-      ],
-      cssClasses: ['ui-smallscreen'],
-      hidePlayerStateExceptions: [
-        PlayerUtils.PlayerState.Prepared,
-        PlayerUtils.PlayerState.Paused,
-        PlayerUtils.PlayerState.Finished,
-      ],
-    });
-  }
-
-  export function smallScreenAdsUILayout(): UIContainer {
-    const controlBar = new AdControlBar({
-      components: [
-        new Container({
-          components: [
-            new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.CurrentTime }),
-            new SeekBar({ label: new SeekBarLabel() }),
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-              cssClasses: ['text-right'],
-            }),
-          ],
-          cssClasses: ['ad-controlbar-top'],
-        }),
-        new Container({
-          components: [
-            new PlaybackToggleButton(),
-            new VolumeToggleButton(),
-            new Spacer(),
-            new FullscreenToggleButton(),
-          ],
-          cssClasses: ['ad-controlbar-bottom'],
-        }),
-      ],
-    });
-
-    return new UIContainer({
-      components: [
-        new BufferingOverlay(),
-        new AdClickOverlay(),
-        new PlaybackToggleOverlay(),
-        controlBar,
-        new TitleBar({
-          components: [
-            new Container({
-              components: [new AdMessageLabel()],
-              cssClasses: ['ui-titlebar-top'],
-            }),
-          ],
-          keepHiddenWithoutMetadata: true,
-        }),
-        new AdStatusOverlay(),
-        new ErrorMessageOverlay(),
-      ],
-      hidePlayerStateExceptions: [
-        PlayerUtils.PlayerState.Prepared,
-        PlayerUtils.PlayerState.Paused,
-        PlayerUtils.PlayerState.Finished,
-      ],
-      cssClasses: ['ui-smallscreen', 'ui-ads'],
-    });
-  }
-
-  export function castReceiverUILayout(config: UIConfig = {}): UIContainer {
-    const controlBar = new ControlBar({
-      components: [
-        new Container({
-          components: [
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
-              hideInLivePlayback: true,
-            }),
-            new SeekBar({ smoothPlaybackPositionUpdateIntervalMs: -1 }),
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-              cssClasses: ['text-right'],
-            }),
-          ],
-          cssClasses: ['controlbar-top'],
-        }),
-      ],
-    });
-
-    const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
-
-    return new CastUIContainer({
-      components: [
-        new SubtitleOverlay(),
-        new BufferingOverlay(),
-        new PlaybackToggleOverlay(),
-        controlBar,
-        new TitleBar({ keepHiddenWithoutMetadata: true }),
-        ...conditionalComponents,
-        new ErrorMessageOverlay(),
-      ],
-      cssClasses: ['ui-cast-receiver'],
-      hidePlayerStateExceptions: [
-        PlayerUtils.PlayerState.Prepared,
-        PlayerUtils.PlayerState.Paused,
-        PlayerUtils.PlayerState.Finished,
-      ],
-    });
-  }
-
-  export function tvUILayout(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
-    const seekBar = new SeekBar({ label: new SeekBarLabel() });
-    const subtitleOverlay = new SubtitleOverlay();
-    const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, 5000);
-
-    const subtitleListBox = new SubtitleListBox(i18n.getLocalizer('settings.subtitles'));
-    const subtitleListBoxOpenButton = new SettingsToggleButton({
-      settingsPanel: subtitleListBox,
-      autoHideWhenNoActiveSettings: true,
-      cssClass: 'ui-subtitle-list-box-toggle-button',
-      text: i18n.getLocalizer('settings.subtitles'),
-    });
-
-    const audioListBox = new AudioTrackListBox(i18n.getLocalizer('settings.audio.track'));
-    const audioListBoxToggleButton = new SettingsToggleButton({
-      settingsPanel: audioListBox,
-      autoHideWhenNoActiveSettings: true,
-      cssClass: 'ui-audio-track-list-box-toggle-button',
-      text: i18n.getLocalizer('settings.audio.track'),
-    });
-
-    const titleBar = new TitleBar({
-      components: [
-        new Container({
-          components: [new MetadataLabel({ content: MetadataLabelContent.Title })],
-          cssClasses: ['ui-titlebar-top'],
-        }),
-        new Container({
-          components: [new MetadataLabel({ content: MetadataLabelContent.Description })],
-          cssClasses: ['ui-titlebar-bottom'],
-        }),
-      ],
-    });
-
-    const playbackToggleButton = new PlaybackToggleButton();
-    const bottomControlBar = new Container({
-      components: [
-        playbackToggleButton,
-        new Spacer(),
-        subtitleListBoxOpenButton,
-        audioListBoxToggleButton,
-        new SettingsToggleButton({ settingsPanel: settingsPanel }),
-      ],
-      cssClasses: ['controlbar-bottom'],
-    });
-    const controlBar = new ControlBar({
-      components: [
-        new Container({
-          components: [
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
-              hideInLivePlayback: true,
-            }),
-            seekBar,
-            new PlaybackTimeLabel({
-              timeLabelMode: PlaybackTimeLabelMode.TotalTime,
-              cssClasses: ['text-right'],
-            }),
-          ],
-          cssClasses: ['controlbar-top'],
-        }),
-        bottomControlBar,
-      ],
-    });
-
-    const playbackToggleOverlay = new PlaybackToggleOverlay();
-    const recommendationOverlay = new RecommendationOverlay();
-    const uiContainer = new UIContainer({
-      components: [
-        subtitleOverlay,
-        new BufferingOverlay(),
-        playbackToggleOverlay,
-        controlBar,
-        titleBar,
-        settingsPanel,
-        subtitleListBox,
-        audioListBox,
-        recommendationOverlay,
-        new ErrorMessageOverlay(),
-      ],
-      cssClasses: ['ui-tv'],
-      hidePlayerStateExceptions: [
-        PlayerUtils.PlayerState.Prepared,
-        PlayerUtils.PlayerState.Paused,
-        PlayerUtils.PlayerState.Finished,
-      ],
-    });
-
-    const spatialNavigation = new SpatialNavigation(
-      new RootNavigationGroup(
-        uiContainer,
-        playbackToggleOverlay,
-        seekBar,
-        new FocusableContainer(bottomControlBar, playbackToggleButton),
-      ),
-      new SettingsPanelNavigationGroup(settingsPanel, { closeOnSelect: false }),
-      new SettingsPanelNavigationGroup(subtitleListBox),
-      new SettingsPanelNavigationGroup(audioListBox),
-      new RecommendationOverlayNavigationGroup(recommendationOverlay),
-    );
-
-    return {
-      ui: uiContainer,
-      spatialNavigation: spatialNavigation,
-    };
-  }
-
-  export function tvAdsUILayout(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
-    const playbackToggleOverlay = new PlaybackToggleOverlay();
-    const adStatusOverlay = new AdStatusOverlay();
-    const uiContainer = new UIContainer({
-      components: [
-        new BufferingOverlay(),
-        new AdClickOverlay(),
-        playbackToggleOverlay,
-        adStatusOverlay,
-        new AdControlBar({
-          components: [
-            new Container({
-              components: [
-                new AdCounterLabel(),
-                new SeekBar({ label: new SeekBarLabel() }),
-                new PlaybackTimeLabel({
-                  timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
-                  cssClasses: ['text-right'],
-                }),
-              ],
-              cssClasses: ['ad-controlbar-top'],
-            }),
-          ],
-        }),
-        new TitleBar({
-          components: [
-            new Container({
-              components: [new AdMessageLabel()],
-              cssClasses: ['ui-titlebar-top'],
-            }),
-          ],
-          keepHiddenWithoutMetadata: true,
-        }),
-        new ErrorMessageOverlay(),
-      ],
-      cssClasses: ['ui-tv', 'ui-ads'],
-      hidePlayerStateExceptions: [
-        PlayerUtils.PlayerState.Prepared,
-        PlayerUtils.PlayerState.Paused,
-        PlayerUtils.PlayerState.Finished,
-      ],
-    });
-
-    const spatialNavigation = new SpatialNavigation(
-      new RootNavigationGroup(uiContainer, playbackToggleOverlay, adStatusOverlay.adSkipButton),
-    );
-
-    return {
-      ui: uiContainer,
-      spatialNavigation: spatialNavigation,
-    };
+    return new UIManager(player, UIFactory.defaultLayouts.subtitleUiLayout(), config);
   }
 
   /**
-   * Used for the initial startup phase of the UI. Only contains basic components.
+   *
    */
-  export function emptyStateUILayout(): UIContainer {
-    return new UIContainer({
-      components: [new BufferingOverlay(), new PlaybackToggleOverlay(), new ErrorMessageOverlay()],
-      cssClasses: ['ui', 'ui-empty-state'],
+  export namespace defaultLayouts {
+    export function subtitleUiLayout(): UIContainer {
+      const subtitleOverlay = new SubtitleOverlay();
+
+      // Subtitle styling only works if a `SubtitleSettingsPanelPage` (with the corresponding Subtitle Settings elements)
+      // are in the UI tree.
+      const settingsPanel = new SettingsPanel({
+        components: [],
+        hidden: true,
+      });
+      const subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({
+        settingsPanel: settingsPanel,
+        overlay: subtitleOverlay,
+      });
+      settingsPanel.addComponent(subtitleSettingsPanelPage);
+
+      // Create a custom UI structure with only the SubtitleOverlay (and the hidden SettingsPanel to enable UI customizations)
+      return new UIContainer({
+        components: [subtitleOverlay, settingsPanel],
+      });
+    }
+
+    export function ui(config: UIConfig = {}): UIContainer {
+      const subtitleOverlay = new SubtitleOverlay();
+
+      const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode != undefined);
+      const controlBar = new ControlBar({
+        components: [
+          new Container({
+            components: [
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+                hideInLivePlayback: true,
+              }),
+              new SeekBar({ label: new SeekBarLabel() }),
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+                cssClasses: ['text-right'],
+              }),
+            ],
+            cssClasses: ['controlbar-top'],
+          }),
+          new Container({
+            components: [
+              new PlaybackToggleButton(),
+              new VolumeToggleButton(),
+              new VolumeSlider(),
+              new Spacer(),
+              new PictureInPictureToggleButton(),
+              new AirPlayToggleButton(),
+              new CastToggleButton(),
+              new VRToggleButton(),
+              new SettingsToggleButton({ settingsPanel: settingsPanel }),
+              new FullscreenToggleButton(),
+            ],
+            cssClasses: ['controlbar-bottom'],
+          }),
+        ],
+      });
+
+      const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
+
+      return new UIContainer({
+        components: [
+          subtitleOverlay,
+          new BufferingOverlay(),
+          new PlaybackToggleOverlay(),
+          new CastStatusOverlay(),
+          controlBar,
+          new TitleBar(),
+          new RecommendationOverlay(),
+          ...conditionalComponents,
+          new DismissClickOverlay({ target: settingsPanel }),
+          settingsPanel,
+          new ErrorMessageOverlay(),
+        ],
+        hidePlayerStateExceptions: [
+          PlayerUtils.PlayerState.Prepared,
+          PlayerUtils.PlayerState.Paused,
+          PlayerUtils.PlayerState.Finished,
+        ],
+      });
+    }
+
+    export function adsUi(): UIContainer {
+      const controlBar = new AdControlBar({
+        components: [
+          new Container({
+            components: [
+              new AdCounterLabel(),
+              new SeekBar({ label: new SeekBarLabel() }),
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
+                cssClasses: ['text-right'],
+              }),
+            ],
+            cssClasses: ['ad-controlbar-top'],
+          }),
+          new Container({
+            components: [
+              new PlaybackToggleButton(),
+              new VolumeToggleButton(),
+              new Spacer(),
+              new FullscreenToggleButton(),
+            ],
+            cssClasses: ['ad-controlbar-bottom'],
+          }),
+        ],
+      });
+
+      return new UIContainer({
+        components: [
+          new BufferingOverlay(),
+          new AdClickOverlay(),
+          new PlaybackToggleOverlay(),
+          new AdStatusOverlay(),
+          controlBar,
+          new TitleBar({
+            components: [
+              new Container({
+                components: [new AdMessageLabel()],
+                cssClasses: ['ui-titlebar-top'],
+              }),
+            ],
+            keepHiddenWithoutMetadata: true,
+          }),
+          new ErrorMessageOverlay(),
+        ],
+        hidePlayerStateExceptions: [
+          PlayerUtils.PlayerState.Prepared,
+          PlayerUtils.PlayerState.Paused,
+          PlayerUtils.PlayerState.Finished,
+        ],
+        cssClasses: ['ui-ads'],
+      });
+    }
+
+    export function smallScreenUi(): UIContainer {
+      const subtitleOverlay = new SubtitleOverlay();
+
+      const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
+
+      const controlBar = new ControlBar({
+        components: [
+          new Container({
+            components: [
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+                hideInLivePlayback: true,
+              }),
+              new SeekBar({ label: new SeekBarLabel() }),
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+                cssClasses: ['text-right'],
+              }),
+            ],
+            cssClasses: ['controlbar-top'],
+          }),
+          new Container({
+            components: [
+              new PlaybackToggleButton(),
+              new VolumeToggleButton(),
+              new VolumeSlider(),
+              new Spacer(),
+              new PictureInPictureToggleButton(),
+              new SettingsToggleButton({ settingsPanel: settingsPanel }),
+              new FullscreenToggleButton(),
+            ],
+            cssClasses: ['controlbar-bottom'],
+          }),
+        ],
+      });
+
+      return new UIContainer({
+        components: [
+          subtitleOverlay,
+          new BufferingOverlay(),
+          new CastStatusOverlay(),
+          // Use the touch overlay on mobile devices and the regular playback toggle overlay on desktop browsers
+          BrowserUtils.isMobile ? new TouchControlOverlay() : new PlaybackToggleOverlay(),
+          new RecommendationOverlay(),
+          controlBar,
+          new TitleBar({
+            components: [
+              new Container({
+                components: [
+                  new MetadataLabel({ content: MetadataLabelContent.Title }),
+                  new Spacer(),
+                  new CastToggleButton(),
+                  new AirPlayToggleButton(),
+                  new VRToggleButton(),
+                ],
+                cssClasses: ['titlebar-row'],
+              }),
+            ],
+          }),
+          new DismissClickOverlay({ target: settingsPanel }),
+          settingsPanel,
+          new ErrorMessageOverlay(),
+        ],
+        cssClasses: ['ui-smallscreen'],
+        hidePlayerStateExceptions: [
+          PlayerUtils.PlayerState.Prepared,
+          PlayerUtils.PlayerState.Paused,
+          PlayerUtils.PlayerState.Finished,
+        ],
+      });
+    }
+
+    export function smallScreenAdsUi(): UIContainer {
+      const controlBar = new AdControlBar({
+        components: [
+          new Container({
+            components: [
+              new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.CurrentTime }),
+              new SeekBar({ label: new SeekBarLabel() }),
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+                cssClasses: ['text-right'],
+              }),
+            ],
+            cssClasses: ['ad-controlbar-top'],
+          }),
+          new Container({
+            components: [
+              new PlaybackToggleButton(),
+              new VolumeToggleButton(),
+              new Spacer(),
+              new FullscreenToggleButton(),
+            ],
+            cssClasses: ['ad-controlbar-bottom'],
+          }),
+        ],
+      });
+
+      return new UIContainer({
+        components: [
+          new BufferingOverlay(),
+          new AdClickOverlay(),
+          new PlaybackToggleOverlay(),
+          controlBar,
+          new TitleBar({
+            components: [
+              new Container({
+                components: [new AdMessageLabel()],
+                cssClasses: ['ui-titlebar-top'],
+              }),
+            ],
+            keepHiddenWithoutMetadata: true,
+          }),
+          new AdStatusOverlay(),
+          new ErrorMessageOverlay(),
+        ],
+        hidePlayerStateExceptions: [
+          PlayerUtils.PlayerState.Prepared,
+          PlayerUtils.PlayerState.Paused,
+          PlayerUtils.PlayerState.Finished,
+        ],
+        cssClasses: ['ui-smallscreen', 'ui-ads'],
+      });
+    }
+
+    export function castReceiverUi(config: UIConfig = {}): UIContainer {
+      const controlBar = new ControlBar({
+        components: [
+          new Container({
+            components: [
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+                hideInLivePlayback: true,
+              }),
+              new SeekBar({ smoothPlaybackPositionUpdateIntervalMs: -1 }),
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+                cssClasses: ['text-right'],
+              }),
+            ],
+            cssClasses: ['controlbar-top'],
+          }),
+        ],
+      });
+
+      const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
+
+      return new CastUIContainer({
+        components: [
+          new SubtitleOverlay(),
+          new BufferingOverlay(),
+          new PlaybackToggleOverlay(),
+          controlBar,
+          new TitleBar({ keepHiddenWithoutMetadata: true }),
+          ...conditionalComponents,
+          new ErrorMessageOverlay(),
+        ],
+        cssClasses: ['ui-cast-receiver'],
+        hidePlayerStateExceptions: [
+          PlayerUtils.PlayerState.Prepared,
+          PlayerUtils.PlayerState.Paused,
+          PlayerUtils.PlayerState.Finished,
+        ],
+      });
+    }
+
+    export function tvUi(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
+      const seekBar = new SeekBar({ label: new SeekBarLabel() });
+      const subtitleOverlay = new SubtitleOverlay();
+      const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, 5000);
+
+      const subtitleListBox = new SubtitleListBox(i18n.getLocalizer('settings.subtitles'));
+      const subtitleListBoxOpenButton = new SettingsToggleButton({
+        settingsPanel: subtitleListBox,
+        autoHideWhenNoActiveSettings: true,
+        cssClass: 'ui-subtitle-list-box-toggle-button',
+        text: i18n.getLocalizer('settings.subtitles'),
+      });
+
+      const audioListBox = new AudioTrackListBox(i18n.getLocalizer('settings.audio.track'));
+      const audioListBoxToggleButton = new SettingsToggleButton({
+        settingsPanel: audioListBox,
+        autoHideWhenNoActiveSettings: true,
+        cssClass: 'ui-audio-track-list-box-toggle-button',
+        text: i18n.getLocalizer('settings.audio.track'),
+      });
+
+      const titleBar = new TitleBar({
+        components: [
+          new Container({
+            components: [new MetadataLabel({ content: MetadataLabelContent.Title })],
+            cssClasses: ['ui-titlebar-top'],
+          }),
+          new Container({
+            components: [new MetadataLabel({ content: MetadataLabelContent.Description })],
+            cssClasses: ['ui-titlebar-bottom'],
+          }),
+        ],
+      });
+
+      const playbackToggleButton = new PlaybackToggleButton();
+      const bottomControlBar = new Container({
+        components: [
+          playbackToggleButton,
+          new Spacer(),
+          subtitleListBoxOpenButton,
+          audioListBoxToggleButton,
+          new SettingsToggleButton({ settingsPanel: settingsPanel }),
+        ],
+        cssClasses: ['controlbar-bottom'],
+      });
+      const controlBar = new ControlBar({
+        components: [
+          new Container({
+            components: [
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.CurrentTime,
+                hideInLivePlayback: true,
+              }),
+              seekBar,
+              new PlaybackTimeLabel({
+                timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+                cssClasses: ['text-right'],
+              }),
+            ],
+            cssClasses: ['controlbar-top'],
+          }),
+          bottomControlBar,
+        ],
+      });
+
+      const playbackToggleOverlay = new PlaybackToggleOverlay();
+      const recommendationOverlay = new RecommendationOverlay();
+      const uiContainer = new UIContainer({
+        components: [
+          subtitleOverlay,
+          new BufferingOverlay(),
+          playbackToggleOverlay,
+          controlBar,
+          titleBar,
+          settingsPanel,
+          subtitleListBox,
+          audioListBox,
+          recommendationOverlay,
+          new ErrorMessageOverlay(),
+        ],
+        cssClasses: ['ui-tv'],
+        hidePlayerStateExceptions: [
+          PlayerUtils.PlayerState.Prepared,
+          PlayerUtils.PlayerState.Paused,
+          PlayerUtils.PlayerState.Finished,
+        ],
+      });
+
+      const spatialNavigation = new SpatialNavigation(
+        new RootNavigationGroup(
+          uiContainer,
+          playbackToggleOverlay,
+          seekBar,
+          new FocusableContainer(bottomControlBar, playbackToggleButton),
+        ),
+        new SettingsPanelNavigationGroup(settingsPanel, { closeOnSelect: false }),
+        new SettingsPanelNavigationGroup(subtitleListBox),
+        new SettingsPanelNavigationGroup(audioListBox),
+        new RecommendationOverlayNavigationGroup(recommendationOverlay),
+      );
+
+      return {
+        ui: uiContainer,
+        spatialNavigation: spatialNavigation,
+      };
+    }
+
+    export function tvAdsUi(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
+      const playbackToggleOverlay = new PlaybackToggleOverlay();
+      const adStatusOverlay = new AdStatusOverlay();
+      const uiContainer = new UIContainer({
+        components: [
+          new BufferingOverlay(),
+          new AdClickOverlay(),
+          playbackToggleOverlay,
+          adStatusOverlay,
+          new AdControlBar({
+            components: [
+              new Container({
+                components: [
+                  new AdCounterLabel(),
+                  new SeekBar({ label: new SeekBarLabel() }),
+                  new PlaybackTimeLabel({
+                    timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
+                    cssClasses: ['text-right'],
+                  }),
+                ],
+                cssClasses: ['ad-controlbar-top'],
+              }),
+            ],
+          }),
+          new TitleBar({
+            components: [
+              new Container({
+                components: [new AdMessageLabel()],
+                cssClasses: ['ui-titlebar-top'],
+              }),
+            ],
+            keepHiddenWithoutMetadata: true,
+          }),
+          new ErrorMessageOverlay(),
+        ],
+        cssClasses: ['ui-tv', 'ui-ads'],
+        hidePlayerStateExceptions: [
+          PlayerUtils.PlayerState.Prepared,
+          PlayerUtils.PlayerState.Paused,
+          PlayerUtils.PlayerState.Finished,
+        ],
+      });
+
+      const spatialNavigation = new SpatialNavigation(
+        new RootNavigationGroup(uiContainer, playbackToggleOverlay, adStatusOverlay.adSkipButton),
+      );
+
+      return {
+        ui: uiContainer,
+        spatialNavigation: spatialNavigation,
+      };
+    }
+
+    /**
+     * Used for the initial startup phase of the UI. Only contains basic components.
+     */
+    export function emptyStateUi(): UIContainer {
+      return new UIContainer({
+        components: [new BufferingOverlay(), new PlaybackToggleOverlay(), new ErrorMessageOverlay()],
+        cssClasses: ['ui', 'ui-empty-state'],
+      });
+    }
+  }
+
+  function buildDefaultSettingsPanel(
+    subtitleOverlay: SubtitleOverlay,
+    hideDelay: number | undefined = undefined,
+    enableEcoMode: boolean = false,
+  ): SettingsPanel<SettingsPanelConfig> {
+    const settingsPanelConfig: SettingsPanelConfig = {
+      components: [],
+      hidden: true,
+      pageTransitionAnimation: true,
+    };
+
+    if (hideDelay != undefined) {
+      settingsPanelConfig.hideDelay = hideDelay;
+    }
+
+    const settingsPanel = new SettingsPanel(settingsPanelConfig);
+    const components: Container<ContainerConfig>[] = [
+      new DynamicSettingsPanelItem({
+        label: i18n.getLocalizer('settings.video.quality'),
+        settingComponent: new VideoQualitySelectBox(),
+        container: settingsPanel,
+      }),
+      new DynamicSettingsPanelItem({
+        label: i18n.getLocalizer('speed'),
+        settingComponent: new PlaybackSpeedSelectBox(),
+        container: settingsPanel,
+      }),
+      new DynamicSettingsPanelItem({
+        label: i18n.getLocalizer('settings.audio.track'),
+        settingComponent: new AudioTrackSelectBox(),
+        container: settingsPanel,
+      }),
+      new DynamicSettingsPanelItem({
+        label: i18n.getLocalizer('settings.audio.quality'),
+        settingComponent: new AudioQualitySelectBox(),
+        container: settingsPanel,
+      }),
+    ];
+
+    if (enableEcoMode) {
+      const ecoModeContainer = new EcoModeContainer();
+
+      ecoModeContainer.setOnToggleCallback(() => {
+        // forces the browser to re-calculate the height of the settings panel when adding/removing elements
+        settingsPanel.getDomElement().css({ width: '', height: '' });
+      });
+
+      components.unshift(ecoModeContainer);
+    }
+
+    const mainSettingsPanelPage = new SettingsPanelPage({
+      components,
     });
-  }
-}
 
-function buildDefaultSettingsPanel(
-  subtitleOverlay: SubtitleOverlay,
-  hideDelay: number | undefined = undefined,
-  enableEcoMode: boolean = false,
-): SettingsPanel<SettingsPanelConfig> {
-  const settingsPanelConfig: SettingsPanelConfig = {
-    components: [],
-    hidden: true,
-    pageTransitionAnimation: true,
-  };
+    settingsPanel.addComponent(mainSettingsPanelPage);
 
-  if (hideDelay != undefined) {
-    settingsPanelConfig.hideDelay = hideDelay;
-  }
-
-  const settingsPanel = new SettingsPanel(settingsPanelConfig);
-  const components: Container<ContainerConfig>[] = [
-    new DynamicSettingsPanelItem({
-      label: i18n.getLocalizer('settings.video.quality'),
-      settingComponent: new VideoQualitySelectBox(),
-      container: settingsPanel,
-    }),
-    new DynamicSettingsPanelItem({
-      label: i18n.getLocalizer('speed'),
-      settingComponent: new PlaybackSpeedSelectBox(),
-      container: settingsPanel,
-    }),
-    new DynamicSettingsPanelItem({
-      label: i18n.getLocalizer('settings.audio.track'),
-      settingComponent: new AudioTrackSelectBox(),
-      container: settingsPanel,
-    }),
-    new DynamicSettingsPanelItem({
-      label: i18n.getLocalizer('settings.audio.quality'),
-      settingComponent: new AudioQualitySelectBox(),
-      container: settingsPanel,
-    }),
-  ];
-
-  if (enableEcoMode) {
-    const ecoModeContainer = new EcoModeContainer();
-
-    ecoModeContainer.setOnToggleCallback(() => {
-      // forces the browser to re-calculate the height of the settings panel when adding/removing elements
-      settingsPanel.getDomElement().css({ width: '', height: '' });
+    const subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({
+      settingsPanel: settingsPanel,
+      overlay: subtitleOverlay,
+      useDynamicSettingsPanelItem: true,
     });
 
-    components.unshift(ecoModeContainer);
+    const subtitleSettingsOpenButton = new SettingsPanelPageOpenButton({
+      targetPage: subtitleSettingsPanelPage,
+      container: settingsPanel,
+      ariaLabel: i18n.getLocalizer('settings.subtitles'),
+      text: i18n.getLocalizer('settings.subtitles.options'),
+    });
+
+    const subtitleSelectBox = new SubtitleSelectBox();
+    const subtitleSelectItem = new DynamicSettingsPanelItem({
+      label: i18n.getLocalizer('settings.subtitles'),
+      backNavigationRightComponent: subtitleSettingsOpenButton,
+      settingComponent: subtitleSelectBox,
+      container: settingsPanel,
+    });
+    mainSettingsPanelPage.addComponent(subtitleSelectItem);
+    settingsPanel.addComponent(subtitleSettingsPanelPage);
+
+    return settingsPanel;
   }
-
-  const mainSettingsPanelPage = new SettingsPanelPage({
-    components,
-  });
-
-  settingsPanel.addComponent(mainSettingsPanelPage);
-
-  const subtitleSettingsPanelPage = new SubtitleSettingsPanelPage({
-    settingsPanel: settingsPanel,
-    overlay: subtitleOverlay,
-    useDynamicSettingsPanelItem: true,
-  });
-
-  const subtitleSettingsOpenButton = new SettingsPanelPageOpenButton({
-    targetPage: subtitleSettingsPanelPage,
-    container: settingsPanel,
-    ariaLabel: i18n.getLocalizer('settings.subtitles'),
-    text: i18n.getLocalizer('settings.subtitles.options'),
-  });
-
-  const subtitleSelectBox = new SubtitleSelectBox();
-  const subtitleSelectItem = new DynamicSettingsPanelItem({
-    label: i18n.getLocalizer('settings.subtitles'),
-    backNavigationRightComponent: subtitleSettingsOpenButton,
-    settingComponent: subtitleSelectBox,
-    container: settingsPanel,
-  });
-  mainSettingsPanelPage.addComponent(subtitleSelectItem);
-  settingsPanel.addComponent(subtitleSettingsPanelPage);
-
-  return settingsPanel;
 }

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -3,7 +3,7 @@ export const version: string = '{{VERSION}}';
 export * from './UIManager';
 export * from './UIConfig';
 // Factories
-export { UIFactory, UILayoutFactory } from './UIFactory';
+export { UIFactory } from './UIFactory';
 // Utils
 export { ArrayUtils } from './utils/ArrayUtils';
 export { StringUtils } from './utils/StringUtils';

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -3,7 +3,7 @@ export const version: string = '{{VERSION}}';
 export * from './UIManager';
 export * from './UIConfig';
 // Factories
-export { UIFactory } from './UIFactory';
+export { UIFactory, UILayoutFactory } from './UIFactory';
 // Utils
 export { ArrayUtils } from './utils/ArrayUtils';
 export { StringUtils } from './utils/StringUtils';


### PR DESCRIPTION
## Description

Introduces a `UIFactory.defaultLayouts` namespace that exports all UI layout functions (e.g. `smallScreenUi`, `tvUi`, `emptyStateUi`, etc.) so consumers can customize individual UI variants or change the conditions under which each variant is displayed, without having to rewrite the entire UI factory.

Changes:
- Moved all layout functions into a new exported `UIFactory.defaultLayouts` namespace in `UIFactory.ts`
- Fixed inconsistent naming of layout functions
- Added CHANGELOG entry

## Checklist (for PR submitter and reviewers)

- [x] `CHANGELOG` entry