### PR TITLE
Improve CEA captions legibility for small player sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New `UIConfig.ceaCaptionPushupMinHeight` option (default `360`) to configure the rendered player height threshold below which small-player CEA-608 caption adjustments are applied
+
 ### Changed
 
-- CEA-608 captions now render within a centered 80% safe area and keep their row-based placement when the control bar is shown
+- CEA-608 captions on players shorter than `ceaCaptionPushupMinHeight` now render within a centered 80% safe area and keep their row-based placement when the control bar is shown
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- CEA captions not legible on very small player sizes
+- Improve CEA captions legibility when the rendered player size has a small height
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Improve CEA captions legibility when the rendered player size has a small height
+- CEA-608 captions now render within a centered 80% safe area and keep their row-based placement when the control bar is shown
+
+### Fixed
+
+- Reset cached CEA-608 grid sizing when CEA subtitle rendering is disabled so the next CEA session recalculates its layout correctly
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- CEA-608 captions on players shorter than `ceaCaptionPushupMinHeight` now render within a centered 80% safe area and keep their row-based placement when the control bar is shown
+- CEA-608 captions on players with a rendered height below 360 CSS pixels (configurable via `ceaCaptionPushupMinHeight`) now render within a centered 80% safe area and keep their row-based placement when the control bar is shown
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- CEA captions not legible on very small player sizes
+
 ## [4.11.0] - 2026-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- New `UIConfig.ceaCaptionPushupMinHeight` option (default `360`) to configure the rendered player height threshold below which small-player CEA-608 caption adjustments are applied
+- New `UIConfig.cea608SmallPlayerHeightThreshold` option (default `360`) to configure the rendered player height threshold at or below which small-player CEA-608 caption adjustments are applied
 
 ### Changed
 
-- CEA-608 captions on players with a rendered height below 360 CSS pixels (configurable via `ceaCaptionPushupMinHeight`) now render within a centered 80% safe area and keep their row-based placement when the control bar is shown
+- CEA-608 captions on players with a rendered height at or below 360 CSS pixels (configurable via `cea608SmallPlayerHeightThreshold`) now stay readable by using a centered 80% safe area and avoiding control-bar pushup that can crowd caption rows on small players
 
 ### Fixed
 
-- Reset cached CEA-608 grid sizing when CEA subtitle rendering is disabled so the next CEA session recalculates its layout correctly
+- CEA-608 captions could keep stale sizing after CEA subtitle rendering was disabled and re-enabled, causing captions to appear incorrectly scaled or positioned
 
 ## [4.11.0] - 2026-04-03
 

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -175,32 +175,18 @@ describe('SubtitleOverlay', () => {
       expect((subtitleOverlay as any).cea608Enabled).toBe(false);
     });
 
-    it('recalculates the CEA grid after controlbar show even when no transition event fires', async () => {
-      jest.useFakeTimers();
+    it('skips CEA grid recalculation after controlbar show when pushup is disabled', () => {
+      (subtitleOverlay as any).cea608Enabled = true;
+      (subtitleOverlay as any).ensureCea608GridSizeUpdated = jest.fn();
+      jest.spyOn(mockDomElement, 'hasClass').mockReturnValue(true);
 
-      const getComputedStyleSpy = jest.spyOn(window, 'getComputedStyle').mockReturnValue({
-        transitionProperty: 'bottom',
-        transitionDuration: '150ms',
-        transitionDelay: '0s',
-      } as CSSStyleDeclaration);
+      const onComponentShowHandler = MockHelper.getMockCallArg<(component: unknown) => void>(
+        uiInstanceManagerMock.onComponentShow.subscribe as jest.Mock,
+      );
 
-      try {
-        (subtitleOverlay as any).cea608Enabled = true;
-        (subtitleOverlay as any).ensureCea608GridSizeUpdated = jest.fn();
+      onComponentShowHandler(new ControlBar({}));
 
-        const onComponentShowHandler = MockHelper.getMockCallArg<(component: unknown) => void>(
-          uiInstanceManagerMock.onComponentShow.subscribe as jest.Mock,
-        );
-
-        onComponentShowHandler(new ControlBar({}));
-        jest.advanceTimersByTime(200);
-        await Promise.resolve();
-
-        expect((subtitleOverlay as any).ensureCea608GridSizeUpdated).toHaveBeenCalled();
-      } finally {
-        getComputedStyleSpy.mockRestore();
-        jest.useRealTimers();
-      }
+      expect((subtitleOverlay as any).ensureCea608GridSizeUpdated).not.toHaveBeenCalled();
     });
   });
 

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -221,7 +221,7 @@ describe('SubtitleOverlay', () => {
       jest.restoreAllMocks();
     });
 
-    const pushupDisabledClass = expect.stringContaining('cea-pushup-disabled');
+    const pushupDisabledClass = expect.stringContaining('cea608-pushup-disabled');
 
     it('adds the pushup-disabled class on configure when player height is below the default threshold', () => {
       jest.spyOn(DOM.prototype, 'height').mockReturnValue(180);
@@ -257,9 +257,9 @@ describe('SubtitleOverlay', () => {
       expect(mockDomElement.removeClass).toHaveBeenCalledWith(pushupDisabledClass);
     });
 
-    it('respects a custom ceaCaptionPushupMinHeight config value', () => {
+    it('respects a custom cea608SmallPlayerHeightThreshold config value', () => {
       (uiInstanceManagerMock.getConfig as jest.Mock).mockReturnValue({
-        ceaCaptionPushupMinHeight: 500,
+        cea608SmallPlayerHeightThreshold: 500,
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
         metadata: { markers: [] },
       });
@@ -269,9 +269,9 @@ describe('SubtitleOverlay', () => {
       expect(mockDomElement.addClass).toHaveBeenCalledWith(pushupDisabledClass);
     });
 
-    it('never adds the pushup-disabled class when ceaCaptionPushupMinHeight is 0', () => {
+    it('never adds the pushup-disabled class when cea608SmallPlayerHeightThreshold is 0', () => {
       (uiInstanceManagerMock.getConfig as jest.Mock).mockReturnValue({
-        ceaCaptionPushupMinHeight: 0,
+        cea608SmallPlayerHeightThreshold: 0,
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
         metadata: { markers: [] },
       });

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -216,11 +216,11 @@ describe('SubtitleOverlay', () => {
       expect(mockDomElement.addClass).toHaveBeenCalledWith(pushupDisabledClass);
     });
 
-    it('does not add the pushup-disabled class on configure when player height meets the default threshold', () => {
+    it('adds the pushup-disabled class on configure when player height meets the default threshold', () => {
       jest.spyOn(DOM.prototype, 'height').mockReturnValue(360);
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
 
-      expect(mockDomElement.addClass).not.toHaveBeenCalledWith(pushupDisabledClass);
+      expect(mockDomElement.addClass).toHaveBeenCalledWith(pushupDisabledClass);
     });
 
     it('adds the pushup-disabled class when PlayerResized fires below the threshold', () => {
@@ -228,17 +228,42 @@ describe('SubtitleOverlay', () => {
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
       (mockDomElement.addClass as jest.Mock).mockClear();
 
-      playerMock.eventEmitter.fireEvent({ type: PlayerEvent.PlayerResized, height: '180px', width: '320px', timestamp: Date.now() } as PlayerResizedEvent);
+      playerMock.eventEmitter.fireEvent({
+        type: PlayerEvent.PlayerResized,
+        height: '180px',
+        width: '320px',
+        timestamp: Date.now(),
+      } as PlayerResizedEvent);
 
       expect(mockDomElement.addClass).toHaveBeenCalledWith(pushupDisabledClass);
     });
 
-    it('removes the pushup-disabled class when PlayerResized fires at or above the threshold', () => {
+    it('adds the pushup-disabled class when PlayerResized fires at the threshold', () => {
+      jest.spyOn(DOM.prototype, 'height').mockReturnValue(400);
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+      (mockDomElement.addClass as jest.Mock).mockClear();
+
+      playerMock.eventEmitter.fireEvent({
+        type: PlayerEvent.PlayerResized,
+        height: '360px',
+        width: '640px',
+        timestamp: Date.now(),
+      } as PlayerResizedEvent);
+
+      expect(mockDomElement.addClass).toHaveBeenCalledWith(pushupDisabledClass);
+    });
+
+    it('removes the pushup-disabled class when PlayerResized fires above the threshold', () => {
       jest.spyOn(DOM.prototype, 'height').mockReturnValue(180);
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
       (mockDomElement.removeClass as jest.Mock).mockClear();
 
-      playerMock.eventEmitter.fireEvent({ type: PlayerEvent.PlayerResized, height: '400px', width: '640px', timestamp: Date.now() } as PlayerResizedEvent);
+      playerMock.eventEmitter.fireEvent({
+        type: PlayerEvent.PlayerResized,
+        height: '400px',
+        width: '640px',
+        timestamp: Date.now(),
+      } as PlayerResizedEvent);
 
       expect(mockDomElement.removeClass).toHaveBeenCalledWith(pushupDisabledClass);
     });

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -7,7 +7,7 @@ import {
   SubtitleRegionContainerManager,
 } from '../../../src/ts/components/overlays/SubtitleOverlay';
 import { DOM } from '../../../src/ts/DOM';
-import { PlayerEvent, SubtitleCueEvent } from 'bitmovin-player';
+import { PlayerEvent, PlayerResizedEvent, SubtitleCueEvent } from 'bitmovin-player';
 import { ControlBar } from '../../../src/ts/components/ControlBar';
 
 let playerMock: jest.Mocked<TestingPlayerAPI>;
@@ -26,11 +26,10 @@ describe('SubtitleOverlay', () => {
       uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
 
       subtitleOverlay = new SubtitleOverlay();
-      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
-      subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
-
       mockDomElement = MockHelper.generateDOMMock();
       jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+      subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
     });
 
     it('adds a subtitle label on cueEnter', () => {
@@ -91,6 +90,7 @@ describe('SubtitleOverlay', () => {
       playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
       uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
       subtitleOverlay = new SubtitleOverlay();
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
       subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
     });
 
@@ -119,13 +119,14 @@ describe('SubtitleOverlay', () => {
       playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
       uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
       subtitleOverlay = new SubtitleOverlay();
-      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
 
       mockDomElement = MockHelper.generateDOMMock();
       jest.spyOn(mockDomElement, 'width').mockReturnValue(320);
       jest.spyOn(mockDomElement, 'height').mockReturnValue(180);
       jest.spyOn(mockDomElement, 'get').mockReturnValue([document.createElement('div')] as any);
       jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
+
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
     });
 
     it('normalizes positioned cues into CEA row regions', () => {
@@ -200,6 +201,84 @@ describe('SubtitleOverlay', () => {
         getComputedStyleSpy.mockRestore();
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe('CEA 608 pushup class', () => {
+    let mockDomElement: DOM;
+
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
+      uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+      subtitleOverlay = new SubtitleOverlay();
+      mockDomElement = MockHelper.generateDOMMock();
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
+      // Container is mocked, so prefixCss() returns undefined by default — provide a real implementation.
+      jest.spyOn(subtitleOverlay as any, 'prefixCss').mockImplementation((cls: string) => `bmpui-${cls}`);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const pushupDisabledClass = expect.stringContaining('cea-pushup-disabled');
+
+    it('adds the pushup-disabled class on configure when player height is below the default threshold', () => {
+      jest.spyOn(DOM.prototype, 'height').mockReturnValue(180);
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+
+      expect(mockDomElement.addClass).toHaveBeenCalledWith(pushupDisabledClass);
+    });
+
+    it('does not add the pushup-disabled class on configure when player height meets the default threshold', () => {
+      jest.spyOn(DOM.prototype, 'height').mockReturnValue(360);
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+
+      expect(mockDomElement.addClass).not.toHaveBeenCalledWith(pushupDisabledClass);
+    });
+
+    it('adds the pushup-disabled class when PlayerResized fires below the threshold', () => {
+      jest.spyOn(DOM.prototype, 'height').mockReturnValue(400);
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+      (mockDomElement.addClass as jest.Mock).mockClear();
+
+      playerMock.eventEmitter.fireEvent({ type: PlayerEvent.PlayerResized, height: '180px', width: '320px', timestamp: Date.now() } as PlayerResizedEvent);
+
+      expect(mockDomElement.addClass).toHaveBeenCalledWith(pushupDisabledClass);
+    });
+
+    it('removes the pushup-disabled class when PlayerResized fires at or above the threshold', () => {
+      jest.spyOn(DOM.prototype, 'height').mockReturnValue(180);
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+      (mockDomElement.removeClass as jest.Mock).mockClear();
+
+      playerMock.eventEmitter.fireEvent({ type: PlayerEvent.PlayerResized, height: '400px', width: '640px', timestamp: Date.now() } as PlayerResizedEvent);
+
+      expect(mockDomElement.removeClass).toHaveBeenCalledWith(pushupDisabledClass);
+    });
+
+    it('respects a custom ceaCaptionPushupMinHeight config value', () => {
+      (uiInstanceManagerMock.getConfig as jest.Mock).mockReturnValue({
+        ceaCaptionPushupMinHeight: 500,
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        metadata: { markers: [] },
+      });
+      jest.spyOn(DOM.prototype, 'height').mockReturnValue(400);
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+
+      expect(mockDomElement.addClass).toHaveBeenCalledWith(pushupDisabledClass);
+    });
+
+    it('never adds the pushup-disabled class when ceaCaptionPushupMinHeight is 0', () => {
+      (uiInstanceManagerMock.getConfig as jest.Mock).mockReturnValue({
+        ceaCaptionPushupMinHeight: 0,
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        metadata: { markers: [] },
+      });
+      jest.spyOn(DOM.prototype, 'height').mockReturnValue(180);
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+
+      expect(mockDomElement.addClass).not.toHaveBeenCalledWith(pushupDisabledClass);
     });
   });
 });

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../src/ts/components/overlays/SubtitleOverlay';
 import { DOM } from '../../../src/ts/DOM';
 import { PlayerEvent, SubtitleCueEvent } from 'bitmovin-player';
+import { ControlBar } from '../../../src/ts/components/ControlBar';
 
 let playerMock: jest.Mocked<TestingPlayerAPI>;
 let uiInstanceManagerMock: UIInstanceManager;
@@ -171,6 +172,34 @@ describe('SubtitleOverlay', () => {
       });
 
       expect((subtitleOverlay as any).cea608Enabled).toBe(false);
+    });
+
+    it('recalculates the CEA grid after controlbar show even when no transition event fires', async () => {
+      jest.useFakeTimers();
+
+      const getComputedStyleSpy = jest.spyOn(window, 'getComputedStyle').mockReturnValue({
+        transitionProperty: 'bottom',
+        transitionDuration: '150ms',
+        transitionDelay: '0s',
+      } as CSSStyleDeclaration);
+
+      try {
+        (subtitleOverlay as any).cea608Enabled = true;
+        (subtitleOverlay as any).ensureCea608GridSizeUpdated = jest.fn();
+
+        const onComponentShowHandler = MockHelper.getMockCallArg<(component: unknown) => void>(
+          uiInstanceManagerMock.onComponentShow.subscribe as jest.Mock,
+        );
+
+        onComponentShowHandler(new ControlBar({}));
+        jest.advanceTimersByTime(200);
+        await Promise.resolve();
+
+        expect((subtitleOverlay as any).ensureCea608GridSizeUpdated).toHaveBeenCalled();
+      } finally {
+        getComputedStyleSpy.mockRestore();
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -2,10 +2,12 @@ import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
 import { UIInstanceManager } from '../../../src/ts/UIManager';
 import {
   SubtitleOverlay,
+  SubtitleLabel,
   SubtitleRegionContainer,
   SubtitleRegionContainerManager,
 } from '../../../src/ts/components/overlays/SubtitleOverlay';
 import { DOM } from '../../../src/ts/DOM';
+import { PlayerEvent, SubtitleCueEvent } from 'bitmovin-player';
 
 let playerMock: jest.Mocked<TestingPlayerAPI>;
 let uiInstanceManagerMock: UIInstanceManager;
@@ -106,6 +108,69 @@ describe('SubtitleOverlay', () => {
     ])('setFontSizeFactor(%f) results in cea608FontSizeFactor = %f', (inputFactor, expectedFactor) => {
       subtitleOverlay.setFontSizeFactor(inputFactor);
       expect(subtitleOverlay['cea608FontSizeFactor']).toBe(expectedFactor);
+    });
+  });
+
+  describe('CEA 608 behavior', () => {
+    let mockDomElement: DOM;
+
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
+      uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+      subtitleOverlay = new SubtitleOverlay();
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+
+      mockDomElement = MockHelper.generateDOMMock();
+      jest.spyOn(mockDomElement, 'width').mockReturnValue(320);
+      jest.spyOn(mockDomElement, 'height').mockReturnValue(180);
+      jest.spyOn(mockDomElement, 'get').mockReturnValue([document.createElement('div')] as any);
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue(mockDomElement);
+    });
+
+    it('normalizes positioned cues into CEA row regions', () => {
+      const cue = {
+        subtitleId: 'subtitleId',
+        start: 0,
+        end: 10,
+        text: 'CEA cue',
+        type: PlayerEvent.CueEnter,
+        position: {
+          row: 4,
+        },
+      } as SubtitleCueEvent;
+
+      const label = subtitleOverlay.generateLabel(cue) as SubtitleLabel;
+
+      expect(cue.position.column).toBe(0);
+      expect(label.region).toBe('cea608-row-4');
+      expect(label.originalRowPosition).toBe(4);
+    });
+
+    it('toggles CEA mode on positioned cue enter and last cue exit', () => {
+      jest.spyOn((subtitleOverlay as any).subtitleContainerManager, 'addLabel').mockImplementation(() => undefined);
+      jest.spyOn((subtitleOverlay as any).subtitleContainerManager, 'removeLabel').mockImplementation(() => undefined);
+      const cue = {
+        subtitleId: 'subtitleId',
+        start: 0,
+        end: 10,
+        text: 'CEA cue',
+        type: PlayerEvent.CueEnter,
+        position: {
+          row: 2,
+          column: 6,
+        },
+      } as SubtitleCueEvent;
+
+      playerMock.eventEmitter.fireEvent<SubtitleCueEvent>(cue);
+
+      expect((subtitleOverlay as any).cea608Enabled).toBe(true);
+
+      playerMock.eventEmitter.fireEvent<SubtitleCueEvent>({
+        ...cue,
+        type: PlayerEvent.CueExit,
+      });
+
+      expect((subtitleOverlay as any).cea608Enabled).toBe(false);
     });
   });
 });

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -76,6 +76,7 @@ export namespace MockHelper {
     const mockedDomElement = {
       addClass: jest.fn(),
       removeClass: jest.fn(),
+      hasClass: jest.fn(),
       on: jest.fn(),
       off: jest.fn(),
       html: jest.fn(),

--- a/src/scss/components/overlays/_subtitle-overlay-cea608.scss
+++ b/src/scss/components/overlays/_subtitle-overlay-cea608.scss
@@ -4,10 +4,15 @@
   --cea608-row-height: math.div(100%, 15);
 
   &.#{$prefix}-cea608 {
-    bottom: 2em;
-    left: 3em;
-    right: 3em;
-    top: 2em;
+    // CEA-608 is rendered inside its centered 80% safe area.
+    bottom: math.percentage(math.div(1 - 0.8, 2));
+    left: math.percentage(math.div(1 - 0.8, 2));
+    right: math.percentage(math.div(1 - 0.8, 2));
+    top: math.percentage(math.div(1 - 0.8, 2));
+
+    &.#{$prefix}-controlbar-visible {
+      bottom: math.percentage(math.div(1 - 0.8, 2));
+    }
 
     .#{$prefix}-subtitle-region-container {
       height: var(--cea608-row-height);
@@ -17,11 +22,9 @@
       text-align: left;
 
       // Define positions for all 15 rows.
-      // --cea608-grid-offset shifts the grid upward when a minimum font size causes the full
-      // 15-row grid to exceed the overlay height, keeping bottom rows in view.
       @for $i from 0 through 14 {
         &.#{$prefix}-subtitle-position-cea608-row-#{$i} {
-          top: calc(var(--cea608-row-height) * #{$i} - var(--cea608-grid-offset, 0px));
+          top: calc(var(--cea608-row-height) * #{$i});
         }
       }
     }

--- a/src/scss/components/overlays/_subtitle-overlay-cea608.scss
+++ b/src/scss/components/overlays/_subtitle-overlay-cea608.scss
@@ -2,7 +2,7 @@
 
 // Inset applied on all four sides when the player is below the height threshold.
 // Keeps captions within the broadcast-standard 80% safe area at small sizes.
-$cea-safe-area-inset: math.percentage(math.div(1 - 0.8, 2));
+$cea608-safe-area-inset: math.percentage(math.div(1 - 0.8, 2));
 
 .#{$prefix}-ui-subtitle-overlay {
   --cea608-row-height: math.div(100%, 15);
@@ -13,20 +13,16 @@ $cea-safe-area-inset: math.percentage(math.div(1 - 0.8, 2));
     right: 3em;
     top: 2em;
 
-    // Below the rendered-height threshold the overlay is constrained to an 80% safe area and the controlbar pushup
-    // is disabled. Pushing captions further up at small player sizes reduces legibility, and the safe area keeps
-    // them away from the edges without relying on fixed em values that do not scale with player size.
-    &.#{$prefix}-cea-pushup-disabled {
-      bottom: $cea-safe-area-inset;
-      left: $cea-safe-area-inset;
-      right: $cea-safe-area-inset;
-      top: $cea-safe-area-inset;
+    // Constrains the overlay to the 80% safe area and suppresses the controlbar pushup at small player sizes.
+    &.#{$prefix}-cea608-pushup-disabled {
+      bottom: $cea608-safe-area-inset;
+      left: $cea608-safe-area-inset;
+      right: $cea608-safe-area-inset;
+      top: $cea608-safe-area-inset;
 
-      // Suppresses the controlbar pushup from _subtitle-overlay.scss. Both selectors compile to 0,3,0 specificity;
-      // this rule wins via source order (this file is imported after _subtitle-overlay.scss). Kept explicit for
-      // clarity and resilience against import-order changes.
+      // Higher-specificity override of the controlbar pushup from _subtitle-overlay.scss.
       &.#{$prefix}-controlbar-visible {
-        bottom: $cea-safe-area-inset;
+        bottom: $cea608-safe-area-inset;
       }
     }
 

--- a/src/scss/components/overlays/_subtitle-overlay-cea608.scss
+++ b/src/scss/components/overlays/_subtitle-overlay-cea608.scss
@@ -10,7 +10,9 @@
     right: math.percentage(math.div(1 - 0.8, 2));
     top: math.percentage(math.div(1 - 0.8, 2));
 
-    &.#{$prefix}-controlbar-visible {
+    // Below the small-player height threshold the controlbar pushup is disabled: captions stay anchored to the safe
+    // area regardless of controlbar state, since pushing them further up at small sizes reduces legibility.
+    &.#{$prefix}-cea-pushup-disabled.#{$prefix}-controlbar-visible {
       bottom: math.percentage(math.div(1 - 0.8, 2));
     }
 

--- a/src/scss/components/overlays/_subtitle-overlay-cea608.scss
+++ b/src/scss/components/overlays/_subtitle-overlay-cea608.scss
@@ -1,9 +1,5 @@
 @use 'sass:math';
 
-// Inset applied on all four sides when the player is below the height threshold.
-// Keeps captions within the broadcast-standard 80% safe area at small sizes.
-$cea608-safe-area-inset: math.percentage(math.div(1 - 0.8, 2));
-
 .#{$prefix}-ui-subtitle-overlay {
   --cea608-row-height: math.div(100%, 15);
 
@@ -15,6 +11,10 @@ $cea608-safe-area-inset: math.percentage(math.div(1 - 0.8, 2));
 
     // Constrains the overlay to the 80% safe area and suppresses the controlbar pushup at small player sizes.
     &.#{$prefix}-cea608-pushup-disabled {
+      // Inset applied on all four sides when the player is at or below the height threshold.
+      // Keeps captions within the broadcast-standard 80% safe area at small sizes.
+      $cea608-safe-area-inset: math.percentage(math.div(1 - 0.8, 2));
+
       bottom: $cea608-safe-area-inset;
       left: $cea608-safe-area-inset;
       right: $cea608-safe-area-inset;

--- a/src/scss/components/overlays/_subtitle-overlay-cea608.scss
+++ b/src/scss/components/overlays/_subtitle-overlay-cea608.scss
@@ -1,5 +1,9 @@
 @use 'sass:math';
 
+// Inset applied on all four sides when the player is below the height threshold.
+// Keeps captions within the broadcast-standard 80% safe area at small sizes.
+$cea-safe-area-inset: math.percentage(math.div(1 - 0.8, 2));
+
 .#{$prefix}-ui-subtitle-overlay {
   --cea608-row-height: math.div(100%, 15);
 
@@ -13,13 +17,16 @@
     // is disabled. Pushing captions further up at small player sizes reduces legibility, and the safe area keeps
     // them away from the edges without relying on fixed em values that do not scale with player size.
     &.#{$prefix}-cea-pushup-disabled {
-      bottom: math.percentage(math.div(1 - 0.8, 2));
-      left: math.percentage(math.div(1 - 0.8, 2));
-      right: math.percentage(math.div(1 - 0.8, 2));
-      top: math.percentage(math.div(1 - 0.8, 2));
+      bottom: $cea-safe-area-inset;
+      left: $cea-safe-area-inset;
+      right: $cea-safe-area-inset;
+      top: $cea-safe-area-inset;
 
+      // Suppresses the controlbar pushup from _subtitle-overlay.scss. Both selectors compile to 0,3,0 specificity;
+      // this rule wins via source order (this file is imported after _subtitle-overlay.scss). Kept explicit for
+      // clarity and resilience against import-order changes.
       &.#{$prefix}-controlbar-visible {
-        bottom: math.percentage(math.div(1 - 0.8, 2));
+        bottom: $cea-safe-area-inset;
       }
     }
 

--- a/src/scss/components/overlays/_subtitle-overlay-cea608.scss
+++ b/src/scss/components/overlays/_subtitle-overlay-cea608.scss
@@ -4,16 +4,23 @@
   --cea608-row-height: math.div(100%, 15);
 
   &.#{$prefix}-cea608 {
-    // CEA-608 is rendered inside its centered 80% safe area.
-    bottom: math.percentage(math.div(1 - 0.8, 2));
-    left: math.percentage(math.div(1 - 0.8, 2));
-    right: math.percentage(math.div(1 - 0.8, 2));
-    top: math.percentage(math.div(1 - 0.8, 2));
+    bottom: 2em;
+    left: 3em;
+    right: 3em;
+    top: 2em;
 
-    // Below the small-player height threshold the controlbar pushup is disabled: captions stay anchored to the safe
-    // area regardless of controlbar state, since pushing them further up at small sizes reduces legibility.
-    &.#{$prefix}-cea-pushup-disabled.#{$prefix}-controlbar-visible {
+    // Below the rendered-height threshold the overlay is constrained to an 80% safe area and the controlbar pushup
+    // is disabled. Pushing captions further up at small player sizes reduces legibility, and the safe area keeps
+    // them away from the edges without relying on fixed em values that do not scale with player size.
+    &.#{$prefix}-cea-pushup-disabled {
       bottom: math.percentage(math.div(1 - 0.8, 2));
+      left: math.percentage(math.div(1 - 0.8, 2));
+      right: math.percentage(math.div(1 - 0.8, 2));
+      top: math.percentage(math.div(1 - 0.8, 2));
+
+      &.#{$prefix}-controlbar-visible {
+        bottom: math.percentage(math.div(1 - 0.8, 2));
+      }
     }
 
     .#{$prefix}-subtitle-region-container {

--- a/src/scss/components/overlays/_subtitle-overlay-cea608.scss
+++ b/src/scss/components/overlays/_subtitle-overlay-cea608.scss
@@ -16,10 +16,12 @@
       right: 0;
       text-align: left;
 
-      // Define positions for all 15 rows
+      // Define positions for all 15 rows.
+      // --cea608-grid-offset shifts the grid upward when a minimum font size causes the full
+      // 15-row grid to exceed the overlay height, keeping bottom rows in view.
       @for $i from 0 through 14 {
         &.#{$prefix}-subtitle-position-cea608-row-#{$i} {
-          top: calc(var(--cea608-row-height) * #{$i});
+          top: calc(var(--cea608-row-height) * #{$i} - var(--cea608-grid-offset, 0px));
         }
       }
     }

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -207,7 +207,7 @@ export interface UIConfig {
    *
    * Default: `360`
    */
-  ceaCaptionPushupMinHeight?: number;
+  cea608SmallPlayerHeightThreshold?: number;
 }
 
 export interface ShadowDomConfig {

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -188,15 +188,22 @@ export interface UIConfig {
   localization?: LocalizationConfig;
 
   /**
-   * The rendered player height threshold in pixels below which the controlbar pushup is disabled for CEA-608
-   * captions. "Rendered height" refers to the actual on-screen height of the player DOM element, not the video
-   * resolution.
+   * The rendered player height threshold in pixels below which small-player adjustments are applied to
+   * CEA-608 captions:
    *
-   * At small player sizes, CEA-608 captions are already constrained to an 80% safe area, so pushing them further
-   * up when the controlbar appears yields little benefit and can make them illegible. Disabling the pushup below
-   * this threshold keeps captions in the safe area regardless of controlbar state.
+   * 1. The caption overlay is constrained to a centered 80% safe area (proportional margins on all four sides),
+   *    replacing the fixed `em`-based margins used at larger sizes.
+   * 2. The controlbar pushup is disabled, keeping captions anchored to the safe area regardless of controlbar state.
    *
-   * Set to `0` to always enable the pushup (restoring the default behaviour for all sizes).
+   * "Rendered height" refers to the actual on-screen height of the player DOM element in CSS pixels, not the
+   * video resolution.
+   *
+   * At small player sizes fixed `em` margins take up a disproportionate share of the available space, and pushing
+   * captions up when the controlbar appears can make them illegible. The 80% safe area and the suppressed pushup
+   * together keep CEA-608 captions legible and correctly positioned at these sizes.
+   *
+   * Set to `0` to disable both adjustments for all player sizes (restoring the default large-player behaviour
+   * everywhere).
    *
    * Default: `360`
    */

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -186,6 +186,21 @@ export interface UIConfig {
    * Allows setting a {@link LocalizationConfig} to specify language details of the UI.
    */
   localization?: LocalizationConfig;
+
+  /**
+   * The rendered player height threshold in pixels below which the controlbar pushup is disabled for CEA-608
+   * captions. "Rendered height" refers to the actual on-screen height of the player DOM element, not the video
+   * resolution.
+   *
+   * At small player sizes, CEA-608 captions are already constrained to an 80% safe area, so pushing them further
+   * up when the controlbar appears yields little benefit and can make them illegible. Disabling the pushup below
+   * this threshold keeps captions in the safe area regardless of controlbar state.
+   *
+   * Set to `0` to always enable the pushup (restoring the default behaviour for all sizes).
+   *
+   * Default: `360`
+   */
+  ceaCaptionPushupMinHeight?: number;
 }
 
 export interface ShadowDomConfig {

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -188,7 +188,7 @@ export interface UIConfig {
   localization?: LocalizationConfig;
 
   /**
-   * The rendered player height threshold in pixels below which small-player adjustments are applied to
+   * The rendered player height threshold in pixels at or below which small-player adjustments are applied to
    * CEA-608 captions:
    *
    * 1. The caption overlay is constrained to a centered 80% safe area (proportional margins on all four sides),

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -379,19 +379,32 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         fontLetterSpacing = 0;
       }
 
-      // Ensure a minimum font size for legibility on small players.
+      // Enforce a minimum font size for legibility on small players.
       // Use the player container's full height rather than the overlay height, which may be reduced
-      // when the controlbar is visible (overlay shifts up via bottom offset).
-      // Note: rowHeight is intentionally not recalculated here — adjusting it would shift row positions
-      // and cause the 15-row grid to exceed the player bounds on small players.
+      // when the controlbar is visible, so that font size stays stable as the controlbar appears.
+      // When the minimum kicks in, rowHeight is increased to match, and the grid is shifted upward
+      // via --cea608-grid-offset so that bottom rows (where CEA-608 content typically appears)
+      // remain visible while top rows clip above the overlay.
       const playerHeight = new DOM(player.getContainer()).height();
-      fontSize = Math.max(fontSize, playerHeight * SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO);
+      const minFontSize = playerHeight * SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO;
+      const minRowHeight = minFontSize / (fontSize100PercentRatio * (1 - windowMarginRatio) * this.cea608FontSizeFactor);
+      if (minRowHeight > rowHeight) {
+        rowHeight = minRowHeight;
+        fontSize = minFontSize;
+        // Recalculate letter spacing for the updated font size
+        const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
+        fontLetterSpacing = Math.max(gridSlotWidth - fontSize * fontSizeRatio, 0);
+      }
 
       windowMargin = rowHeight * windowMarginRatio;
 
-      // Update the CSS custom property on the overlay DOM element
+      // Shift the grid upward when it exceeds the overlay height, keeping bottom rows in view
+      const gridOffset = Math.max(0, rowHeight * SubtitleOverlay.CEA608_NUM_ROWS - subtitleOverlayHeight);
+
+      // Update the CSS custom properties on the overlay DOM element
       overlayElement.get().forEach(el => {
         el.style.setProperty('--cea608-row-height', `${rowHeight}px`);
+        el.style.setProperty('--cea608-grid-offset', `${gridOffset}px`);
       });
 
       // Update font-size of all active subtitle labels
@@ -459,6 +472,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     const reset = () => {
       this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
       this.cea608Enabled = false;
+      this.getDomElement().get().forEach(el => {
+        el.style.removeProperty('--cea608-grid-offset');
+      });
     };
 
     player.on(player.exports.PlayerEvent.CueExit, () => {

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -387,11 +387,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // remain visible while top rows clip above the overlay.
       const playerHeight = new DOM(player.getContainer()).height();
       const minFontSize = playerHeight * SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO;
-      const minRowHeight = minFontSize / (fontSize100PercentRatio * (1 - windowMarginRatio) * this.cea608FontSizeFactor);
+      const minRowHeight =
+        minFontSize / (fontSize100PercentRatio * (1 - windowMarginRatio) * this.cea608FontSizeFactor);
       if (minRowHeight > rowHeight) {
         rowHeight = minRowHeight;
         fontSize = minFontSize;
-        // Recalculate letter spacing for the updated font size
         const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
         fontLetterSpacing = Math.max(gridSlotWidth - fontSize * fontSizeRatio, 0);
       }
@@ -401,7 +401,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // Shift the grid upward when it exceeds the overlay height, keeping bottom rows in view
       const gridOffset = Math.max(0, rowHeight * SubtitleOverlay.CEA608_NUM_ROWS - subtitleOverlayHeight);
 
-      // Update the CSS custom properties on the overlay DOM element
       overlayElement.get().forEach(el => {
         el.style.setProperty('--cea608-row-height', `${rowHeight}px`);
         el.style.setProperty('--cea608-grid-offset', `${gridOffset}px`);
@@ -471,14 +470,18 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     const reset = () => {
       this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
+      if (this.cea608Enabled) {
+        // Reset the cache so the next CEA-608 session always runs a fresh recalculation.
+        // Without this, ensureCea608GridSizeUpdated returns early on unchanged dimensions
+        // and --cea608-grid-offset never gets re-applied after a reset.
+        lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
+        this.getDomElement()
+          .get()
+          .forEach(el => {
+            el.style.removeProperty('--cea608-grid-offset');
+          });
+      }
       this.cea608Enabled = false;
-      // Reset the cache so the next CEA-608 session always runs a fresh recalculation.
-      // Without this, ensureCea608GridSizeUpdated returns early on unchanged dimensions
-      // and --cea608-grid-offset never gets re-applied after a reset.
-      lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
-      this.getDomElement().get().forEach(el => {
-        el.style.removeProperty('--cea608-grid-offset');
-      });
     };
 
     player.on(player.exports.PlayerEvent.CueExit, () => {

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -38,6 +38,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
   private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
   private static readonly CEA608_MIN_FONT_SIZE_RATIO = 0.07;
+  /** Players at or below this height (px) are considered small and get the minimum font size floor */
+  private static readonly CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD = 240;
 
   private cea608Enabled = false;
   private cea608FontSizeFactor = 1;
@@ -386,14 +388,16 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // via --cea608-grid-offset so that bottom rows (where CEA-608 content typically appears)
       // remain visible while top rows clip above the overlay.
       const playerHeight = new DOM(player.getContainer()).height();
-      const minFontSize = playerHeight * SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO;
-      const minRowHeight =
-        minFontSize / (fontSize100PercentRatio * (1 - windowMarginRatio) * this.cea608FontSizeFactor);
-      if (minRowHeight > rowHeight) {
-        rowHeight = minRowHeight;
-        fontSize = minFontSize;
-        const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
-        fontLetterSpacing = Math.max(gridSlotWidth - fontSize * fontSizeRatio, 0);
+      if (playerHeight <= SubtitleOverlay.CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD) {
+        const minFontSize = playerHeight * SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO;
+        const minRowHeight =
+          minFontSize / (fontSize100PercentRatio * (1 - windowMarginRatio) * this.cea608FontSizeFactor);
+        if (minRowHeight > rowHeight) {
+          rowHeight = minRowHeight;
+          fontSize = minFontSize;
+          const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
+          fontLetterSpacing = Math.max(gridSlotWidth - fontSize * fontSizeRatio, 0);
+        }
       }
 
       windowMargin = rowHeight * windowMarginRatio;

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -37,10 +37,6 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CEA608_NUM_COLUMNS = 32;
   private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
   private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
-  private static readonly CEA608_MIN_FONT_SIZE_RATIO = 0.07;
-  private static readonly CEA608_MIN_FONT_SIZE_RATIO_MEDIUM = 0.05;
-  private static readonly CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD = 240;
-  private static readonly CEA608_MEDIUM_PLAYER_HEIGHT_THRESHOLD = 360;
 
   private cea608Enabled = false;
   private cea608FontSizeFactor = 1;
@@ -382,39 +378,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         fontLetterSpacing = 0;
       }
 
-      // Enforce a minimum font size for legibility on small players.
-      // Use the player container's full height rather than the overlay height, which may be reduced
-      // when the controlbar is visible, so that font size stays stable as the controlbar appears.
-      // When the minimum kicks in, rowHeight is increased to match, and the grid is shifted upward
-      // via --cea608-grid-offset so that bottom rows (where CEA-608 content typically appears)
-      // remain visible while top rows clip above the overlay.
-      const playerHeight = new DOM(player.getContainer()).height();
-      const minFontSizeRatio =
-        playerHeight <= SubtitleOverlay.CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD
-          ? SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO
-          : playerHeight <= SubtitleOverlay.CEA608_MEDIUM_PLAYER_HEIGHT_THRESHOLD
-            ? SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO_MEDIUM
-            : 0;
-      if (minFontSizeRatio > 0) {
-        const minFontSize = playerHeight * minFontSizeRatio;
-        const minRowHeight =
-          minFontSize / (fontSize100PercentRatio * (1 - windowMarginRatio) * this.cea608FontSizeFactor);
-        if (minRowHeight > rowHeight) {
-          rowHeight = minRowHeight;
-          fontSize = minFontSize;
-          const gridSlotWidth = subtitleOverlayWidth / SubtitleOverlay.CEA608_NUM_COLUMNS;
-          fontLetterSpacing = Math.max(gridSlotWidth - fontSize * fontSizeRatio, 0);
-        }
-      }
-
       windowMargin = rowHeight * windowMarginRatio;
-
-      // Shift the grid upward when it exceeds the overlay height, keeping bottom rows in view
-      const gridOffset = Math.max(0, rowHeight * SubtitleOverlay.CEA608_NUM_ROWS - subtitleOverlayHeight);
 
       overlayElement.get().forEach(el => {
         el.style.setProperty('--cea608-row-height', `${rowHeight}px`);
-        el.style.setProperty('--cea608-grid-offset', `${gridOffset}px`);
       });
 
       // Update font-size of all active subtitle labels
@@ -483,14 +450,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
       if (this.cea608Enabled) {
         // Reset the cache so the next CEA-608 session always runs a fresh recalculation.
-        // Without this, ensureCea608GridSizeUpdated returns early on unchanged dimensions
-        // and --cea608-grid-offset never gets re-applied after a reset.
         lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
-        this.getDomElement()
-          .get()
-          .forEach(el => {
-            el.style.removeProperty('--cea608-grid-offset');
-          });
       }
       this.cea608Enabled = false;
     };

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -432,8 +432,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     };
 
     player.on(player.exports.PlayerEvent.PlayerResized, (e: PlayerResizedEvent) => {
-      const playerHeight = Math.round(Number(e.height.substring(0, e.height.length - 2)));
-      this.updateCeaPushupClass(playerHeight);
+      this.updateCeaPushupClass(parseFloat(e.height));
 
       if (this.cea608Enabled) {
         this.ensureCea608GridSizeUpdated();

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -472,6 +472,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     const reset = () => {
       this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
       this.cea608Enabled = false;
+      // Reset the cache so the next CEA-608 session always runs a fresh recalculation.
+      // Without this, ensureCea608GridSizeUpdated returns early on unchanged dimensions
+      // and --cea608-grid-offset never gets re-applied after a reset.
+      lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
       this.getDomElement().get().forEach(el => {
         el.style.removeProperty('--cea608-grid-offset');
       });

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -33,8 +33,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   private static readonly CLASS_CONTROLBAR_VISIBLE = 'controlbar-visible';
   private static readonly CLASS_CEA_608 = 'cea608';
-  private static readonly CLASS_CEA_PUSHUP_DISABLED = 'cea-pushup-disabled';
-  private static readonly DEFAULT_CEA_CAPTION_PUSHUP_MIN_HEIGHT = 360;
+  private static readonly CLASS_CEA608_PUSHUP_DISABLED = 'cea608-pushup-disabled';
+  private static readonly DEFAULT_CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD = 360;
   private static readonly CEA608_NUM_ROWS = 15;
   private static readonly CEA608_NUM_COLUMNS = 32;
   private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
@@ -43,7 +43,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private cea608Enabled = false;
   private cea608FontSizeFactor = 1;
   private ensureCea608GridSizeUpdated: () => void;
-  private ceaCaptionPushupMinHeight = SubtitleOverlay.DEFAULT_CEA_CAPTION_PUSHUP_MIN_HEIGHT;
+  private cea608SmallPlayerHeightThreshold = SubtitleOverlay.DEFAULT_CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
@@ -65,8 +65,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
     const uiConfig = uimanager.getConfig();
 
-    if (uiConfig.ceaCaptionPushupMinHeight !== undefined) {
-      this.ceaCaptionPushupMinHeight = uiConfig.ceaCaptionPushupMinHeight;
+    if (uiConfig.cea608SmallPlayerHeightThreshold !== undefined) {
+      this.cea608SmallPlayerHeightThreshold = uiConfig.cea608SmallPlayerHeightThreshold;
     }
 
     const subtitleManager = new ActiveSubtitleManager();
@@ -154,7 +154,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       if (component instanceof ControlBar) {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
 
-        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated) {
+        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated &&
+            !this.getDomElement().hasClass(this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED))) {
           awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
         }
       }
@@ -164,7 +165,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       if (component instanceof ControlBar) {
         this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
 
-        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated) {
+        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated &&
+            !this.getDomElement().hasClass(this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED))) {
           awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
         }
       }
@@ -177,10 +179,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   }
 
   private updateCeaPushupClass(playerHeight: number): void {
-    if (playerHeight < this.ceaCaptionPushupMinHeight) {
-      this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_PUSHUP_DISABLED));
+    if (playerHeight < this.cea608SmallPlayerHeightThreshold) {
+      this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED));
     } else {
-      this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_PUSHUP_DISABLED));
+      this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED));
     }
   }
 
@@ -863,54 +865,19 @@ function isCea608SubtitleCue(cue: SubtitleCueEvent): boolean {
 }
 
 function awaitTransitionEnd(domElement: DOM) {
-  const computedStyle = getComputedStyle(domElement.get(0));
-  const hasTransition = computedStyle.transitionProperty !== 'none';
+  const hasTransition = getComputedStyle(domElement.get(0)).transitionProperty !== 'none';
 
   if (!hasTransition) {
     return Promise.resolve();
   }
 
   return new Promise<void>(resolve => {
-    let transitionTimeout = 0;
-
     const transitionHandler = () => {
-      window.clearTimeout(transitionTimeout);
       domElement.off('transitionend', transitionHandler);
       domElement.off('transitioncancel', transitionHandler);
       resolve();
     };
-
-    transitionTimeout = window.setTimeout(transitionHandler, getMaximumTransitionTimeoutMs(computedStyle) + 50);
     domElement.on('transitionend', transitionHandler);
     domElement.on('transitioncancel', transitionHandler);
   });
-}
-
-function getMaximumTransitionTimeoutMs(computedStyle: CSSStyleDeclaration): number {
-  const durations = computedStyle.transitionDuration.split(',').map(parseCssTimeToMs);
-  const delays = computedStyle.transitionDelay.split(',').map(parseCssTimeToMs);
-  const transitionCount = Math.max(durations.length, delays.length);
-  let maximumTransitionTimeoutMs = 0;
-
-  for (let index = 0; index < transitionCount; index++) {
-    const duration = durations[Math.min(index, durations.length - 1)] || 0;
-    const delay = delays[Math.min(index, delays.length - 1)] || 0;
-    maximumTransitionTimeoutMs = Math.max(maximumTransitionTimeoutMs, duration + delay);
-  }
-
-  return maximumTransitionTimeoutMs;
-}
-
-function parseCssTimeToMs(value: string): number {
-  const trimmedValue = value.trim();
-
-  if (trimmedValue.endsWith('ms')) {
-    return parseFloat(trimmedValue);
-  }
-
-  if (trimmedValue.endsWith('s')) {
-    return parseFloat(trimmedValue) * 1000;
-  }
-
-  return 0;
 }

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -38,8 +38,9 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
   private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
   private static readonly CEA608_MIN_FONT_SIZE_RATIO = 0.07;
-  /** Players at or below this height (px) are considered small and get the minimum font size floor */
+  private static readonly CEA608_MIN_FONT_SIZE_RATIO_MEDIUM = 0.05;
   private static readonly CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD = 240;
+  private static readonly CEA608_MEDIUM_PLAYER_HEIGHT_THRESHOLD = 360;
 
   private cea608Enabled = false;
   private cea608FontSizeFactor = 1;
@@ -388,8 +389,14 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // via --cea608-grid-offset so that bottom rows (where CEA-608 content typically appears)
       // remain visible while top rows clip above the overlay.
       const playerHeight = new DOM(player.getContainer()).height();
-      if (playerHeight <= SubtitleOverlay.CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD) {
-        const minFontSize = playerHeight * SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO;
+      const minFontSizeRatio =
+        playerHeight <= SubtitleOverlay.CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD
+          ? SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO
+          : playerHeight <= SubtitleOverlay.CEA608_MEDIUM_PLAYER_HEIGHT_THRESHOLD
+            ? SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO_MEDIUM
+            : 0;
+      if (minFontSizeRatio > 0) {
+        const minFontSize = playerHeight * minFontSizeRatio;
         const minRowHeight =
           minFontSize / (fontSize100PercentRatio * (1 - windowMarginRatio) * this.cea608FontSizeFactor);
         if (minRowHeight > rowHeight) {

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -153,9 +153,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     uimanager.onComponentShow.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
+        const isCea608PushupTransitionEnabled = !this.getDomElement().hasClass(
+          this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED),
+        );
 
-        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated &&
-            !this.getDomElement().hasClass(this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED))) {
+        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated && isCea608PushupTransitionEnabled) {
           awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
         }
       }
@@ -164,9 +166,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     uimanager.onComponentHide.subscribe((component: Component<ComponentConfig>) => {
       if (component instanceof ControlBar) {
         this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CONTROLBAR_VISIBLE));
+        const isCea608PushupTransitionEnabled = !this.getDomElement().hasClass(
+          this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED),
+        );
 
-        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated &&
-            !this.getDomElement().hasClass(this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED))) {
+        if (this.cea608Enabled && this.ensureCea608GridSizeUpdated && isCea608PushupTransitionEnabled) {
           awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
         }
       }
@@ -175,11 +179,11 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     this.configureCea608Captions(player, uimanager);
     // Init
     subtitleClearHandler();
-    this.updateCeaPushupClass(new DOM(player.getContainer()).height());
+    this.updateCea608PushupFromPlayerHeight(new DOM(player.getContainer()).height());
   }
 
-  private updateCeaPushupClass(playerHeight: number): void {
-    if (playerHeight < this.cea608SmallPlayerHeightThreshold) {
+  private updateCea608PushupFromPlayerHeight(playerHeight: number): void {
+    if (this.cea608SmallPlayerHeightThreshold > 0 && playerHeight <= this.cea608SmallPlayerHeightThreshold) {
       this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED));
     } else {
       this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA608_PUSHUP_DISABLED));
@@ -434,7 +438,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     };
 
     player.on(player.exports.PlayerEvent.PlayerResized, (e: PlayerResizedEvent) => {
-      this.updateCeaPushupClass(parseFloat(e.height));
+      this.updateCea608PushupFromPlayerHeight(parseFloat(e.height));
 
       if (this.cea608Enabled) {
         this.ensureCea608GridSizeUpdated();

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -5,7 +5,7 @@ import { ComponentConfig, Component } from '../Component';
 import { ControlBar } from '../ControlBar';
 import { EventDispatcher } from '../../EventDispatcher';
 import { DOM, Size } from '../../DOM';
-import { PlayerAPI, SubtitleCueEvent } from 'bitmovin-player';
+import { PlayerAPI, PlayerResizedEvent, SubtitleCueEvent } from 'bitmovin-player';
 import { i18n } from '../../localization/i18n';
 import { VttUtils } from '../../utils/VttUtils';
 import { VTTProperties } from 'bitmovin-player/types/subtitles/vtt/API';
@@ -33,6 +33,8 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   private static readonly CLASS_CONTROLBAR_VISIBLE = 'controlbar-visible';
   private static readonly CLASS_CEA_608 = 'cea608';
+  private static readonly CLASS_CEA_PUSHUP_DISABLED = 'cea-pushup-disabled';
+  private static readonly DEFAULT_CEA_CAPTION_PUSHUP_MIN_HEIGHT = 360;
   private static readonly CEA608_NUM_ROWS = 15;
   private static readonly CEA608_NUM_COLUMNS = 32;
   private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
@@ -41,6 +43,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private cea608Enabled = false;
   private cea608FontSizeFactor = 1;
   private ensureCea608GridSizeUpdated: () => void;
+  private ceaCaptionPushupMinHeight = SubtitleOverlay.DEFAULT_CEA_CAPTION_PUSHUP_MIN_HEIGHT;
 
   constructor(config: ContainerConfig = {}) {
     super(config);
@@ -59,6 +62,12 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
+
+    const uiConfig = uimanager.getConfig();
+
+    if (uiConfig.ceaCaptionPushupMinHeight !== undefined) {
+      this.ceaCaptionPushupMinHeight = uiConfig.ceaCaptionPushupMinHeight;
+    }
 
     const subtitleManager = new ActiveSubtitleManager();
     this.subtitleManager = subtitleManager;
@@ -164,6 +173,15 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
     this.configureCea608Captions(player, uimanager);
     // Init
     subtitleClearHandler();
+    this.updateCeaPushupClass(new DOM(player.getContainer()).height());
+  }
+
+  private updateCeaPushupClass(playerHeight: number): void {
+    if (playerHeight < this.ceaCaptionPushupMinHeight) {
+      this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_PUSHUP_DISABLED));
+    } else {
+      this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_PUSHUP_DISABLED));
+    }
   }
 
   setFontSizeFactor(factor: number): void {
@@ -413,7 +431,10 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       }
     };
 
-    player.on(player.exports.PlayerEvent.PlayerResized, () => {
+    player.on(player.exports.PlayerEvent.PlayerResized, (e: PlayerResizedEvent) => {
+      const playerHeight = Math.round(Number(e.height.substring(0, e.height.length - 2)));
+      this.updateCeaPushupClass(playerHeight);
+
       if (this.cea608Enabled) {
         this.ensureCea608GridSizeUpdated();
       }

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -843,19 +843,54 @@ function isCea608SubtitleCue(cue: SubtitleCueEvent): boolean {
 }
 
 function awaitTransitionEnd(domElement: DOM) {
-  const hasTransition = getComputedStyle(domElement.get(0)).transitionProperty !== 'none';
+  const computedStyle = getComputedStyle(domElement.get(0));
+  const hasTransition = computedStyle.transitionProperty !== 'none';
 
   if (!hasTransition) {
     return Promise.resolve();
   }
 
   return new Promise<void>(resolve => {
+    let transitionTimeout = 0;
+
     const transitionHandler = () => {
+      window.clearTimeout(transitionTimeout);
       domElement.off('transitionend', transitionHandler);
       domElement.off('transitioncancel', transitionHandler);
       resolve();
     };
+
+    transitionTimeout = window.setTimeout(transitionHandler, getMaximumTransitionTimeoutMs(computedStyle) + 50);
     domElement.on('transitionend', transitionHandler);
     domElement.on('transitioncancel', transitionHandler);
   });
+}
+
+function getMaximumTransitionTimeoutMs(computedStyle: CSSStyleDeclaration): number {
+  const durations = computedStyle.transitionDuration.split(',').map(parseCssTimeToMs);
+  const delays = computedStyle.transitionDelay.split(',').map(parseCssTimeToMs);
+  const transitionCount = Math.max(durations.length, delays.length);
+  let maximumTransitionTimeoutMs = 0;
+
+  for (let index = 0; index < transitionCount; index++) {
+    const duration = durations[Math.min(index, durations.length - 1)] || 0;
+    const delay = delays[Math.min(index, delays.length - 1)] || 0;
+    maximumTransitionTimeoutMs = Math.max(maximumTransitionTimeoutMs, duration + delay);
+  }
+
+  return maximumTransitionTimeoutMs;
+}
+
+function parseCssTimeToMs(value: string): number {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.endsWith('ms')) {
+    return parseFloat(trimmedValue);
+  }
+
+  if (trimmedValue.endsWith('s')) {
+    return parseFloat(trimmedValue) * 1000;
+  }
+
+  return 0;
 }

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -37,6 +37,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private static readonly CEA608_NUM_COLUMNS = 32;
   private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
   private static readonly DEFAULT_CAPTION_LEFT_OFFSET = '0.5%';
+  private static readonly CEA608_MIN_FONT_SIZE_RATIO = 0.07;
 
   private cea608Enabled = false;
   private cea608FontSizeFactor = 1;
@@ -377,6 +378,14 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         fontSize = fontSize100Percent * this.cea608FontSizeFactor;
         fontLetterSpacing = 0;
       }
+
+      // Ensure a minimum font size for legibility on small players.
+      // Use the player container's full height rather than the overlay height, which may be reduced
+      // when the controlbar is visible (overlay shifts up via bottom offset).
+      // Note: rowHeight is intentionally not recalculated here — adjusting it would shift row positions
+      // and cause the 15-row grid to exceed the player bounds on small players.
+      const playerHeight = new DOM(player.getContainer()).height();
+      fontSize = Math.max(fontSize, playerHeight * SubtitleOverlay.CEA608_MIN_FONT_SIZE_RATIO);
 
       windowMargin = rowHeight * windowMarginRatio;
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Issue: CEA captions are not legible on very small players


**Before**

<img width="499" height="281" alt="image" src="https://github.com/user-attachments/assets/c2c6eb49-4457-45be-b618-18da9bbd8926" />

**After**

<img width="346" height="187" alt="image" src="https://github.com/user-attachments/assets/ea04607a-7957-48bb-946d-16d1d4af1777" />


## Changes
- CEA-608 small-player legibility: captions on players rendered at or below 360px in height now use a proportional 80% safe area instead of fixed em margins, and the controlbar pushup is suppressed. Threshold is configurable via `UIConfig.cea608SmallPlayerHeightThreshold`.
- CEA grid stale cache: CEA-608 captions no longer keep stale sizing after CEA subtitle rendering is disabled and re-enabled, which could make captions appear incorrectly scaled or positioned.

## Manual testing

Use this quick sample to test the rendering on various player sizes:


```html
<!doctype html>
<html lang="en">
  <head>
    <title>Bitmovin Small Player Test</title>
    <meta charset="UTF-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />

    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/bitmovin-player@8/bitmovinplayer.js"></script>
    <script src="js/bitmovinplayer-ui.js"></script>
    <link rel="stylesheet" href="css/bitmovinplayer-ui.css" />

    <style>
      body {
        margin: 0;
        padding: 24px;
        font-family: Arial, sans-serif;
        background: #101114;
        color: #fff;
      }

      a {
        color: #8cc8ff;
      }

      .page {
        display: flex;
        flex-direction: column;
        gap: 16px;
      }

      .controls {
        display: flex;
        align-items: center;
        gap: 12px;
        flex-wrap: wrap;
      }

      .controls label {
        font-size: 13px;
        color: #aaa;
      }

      .controls select,
      .controls input {
        background: #1e1e1e;
        border: 1px solid #444;
        color: #fff;
        padding: 4px 8px;
        font-size: 13px;
      }

      .controls button {
        background: #2a2a2a;
        border: 1px solid #555;
        color: #fff;
        padding: 4px 12px;
        font-size: 13px;
        cursor: pointer;
      }

      .controls button:hover {
        background: #3a3a3a;
      }

      .size-indicator {
        font-size: 13px;
        color: #e6b31e;
        font-family: monospace;
      }

      .player-wrapper {
        box-shadow: 0 0 24px rgba(0, 0, 0, 0.45);
        transition: width 0.2s, height 0.2s;
      }

      #player {
        width: 100%;
        height: 100%;
      }

      .meta {
        max-width: 720px;
        font-size: 13px;
        line-height: 1.6;
        color: #aaa;
      }

      .test-actions {
        display: flex;
        gap: 8px;
        flex-wrap: wrap;
      }

      .font-controls {
        display: flex;
        align-items: center;
        gap: 8px;
        flex-wrap: wrap;
      }
    </style>
  </head>
  <body>
    <div class="page">
      <div><a href="index.html">&lt;- Back to playground</a></div>

      <div class="controls">
        <label>Preset:</label>
        <select id="preset">
          <option value="320x180">320×180 — well below threshold</option>
          <option value="400x225">400×225 — below threshold</option>
          <option value="427x240">427×240 — below threshold</option>
          <option value="480x270">480×270 — below threshold</option>
          <option value="640x360">640×360 — at threshold (≤360)</option>
          <option value="1280x720">1280×720 — above threshold</option>
        </select>

        <label>or custom W×H:</label>
        <input id="custom-w" type="number" value="320" min="100" max="1920" style="width:60px" />
        <span style="color:#aaa">×</span>
        <input id="custom-h" type="number" value="180" min="56" max="1080" style="width:60px" />
        <button id="apply-custom">Apply</button>

        <span class="size-indicator" id="size-indicator">320×180</span>
      </div>

      <div class="test-actions">
        <button id="run-cea608-row-test">Run CEA-608 All Rows Test</button>
        <button id="run-cea608-long-text-test">Run Long Text Test</button>
        <button id="clear-cea608-row-test">Clear Test Cues</button>
      </div>

      <div class="font-controls">
        <label for="cea608-font-size">CEA font size:</label>
        <select id="cea608-font-size">
          <option value="100">100%</option>
          <option value="150">150%</option>
          <option value="200">200%</option>
        </select>
        <button id="apply-cea608-font-size">Apply Font Size</button>
      </div>

      <div class="player-wrapper" id="player-wrapper">
        <div id="player"></div>
      </div>

      <div class="meta">
        Uses the same synthetic CEA-608 row pattern as the main playground, but in a constrained player so you can verify row placement across all 15 rows.
      </div>
    </div>

    <script type="text/javascript">
      var wrapper = document.getElementById('player-wrapper');
      var indicator = document.getElementById('size-indicator');
      var activeTestCues = [];

      function applySize(w, h) {
        wrapper.style.width = w + 'px';
        wrapper.style.height = h + 'px';
        indicator.textContent = w + '×' + h;
      }

      document.getElementById('preset').addEventListener('change', function () {
        var parts = this.value.split('x');
        var w = parseInt(parts[0]);
        var h = parseInt(parts[1]);
        document.getElementById('custom-w').value = w;
        document.getElementById('custom-h').value = h;
        applySize(w, h);
      });

      document.getElementById('apply-custom').addEventListener('click', function () {
        var w = parseInt(document.getElementById('custom-w').value);
        var h = parseInt(document.getElementById('custom-h').value);
        applySize(w, h);
      });

      applySize(320, 180);

      var playerConfig = {
        key: '',
        ui: false,
        playback: {
          autoplay: true,
          muted: true,
        },
      };

      var source = {
        // <your source with CEA captions>
      };

      window.player = new bitmovin.player.Player(document.getElementById('player'), playerConfig);
      window.uiManager = bitmovin.playerui.UIFactory.buildUI(window.player, { forceSubtitlesIntoViewContainer: true });

      function getUiPlayer() {
        return window.uiManager.currentUi.playerWrapper.getPlayer();
      }

      function cueEnter(text, row, column) {
        var cue = {
          text: text,
          position: {
            row: row,
            column: column,
          },
        };

        getUiPlayer().fireEventInUI(bitmovin.player.PlayerEvent.CueEnter, cue);
        return cue;
      }

      function cueExit(cue) {
        getUiPlayer().fireEventInUI(bitmovin.player.PlayerEvent.CueExit, cue);
      }

      function clearCea608RowTest() {
        activeTestCues.forEach(function (cue) {
          cueExit(cue);
        });
        activeTestCues = [];
      }

      function runCea608RowTest() {
        clearCea608RowTest();

        for (var row = 0; row < 15; row++) {
          var text = 'Test' + (row + 1);
          activeTestCues.push(cueEnter(text, row, 0));
          activeTestCues.push(cueEnter(text, row, 15 - text.length / 2 + 1));
          activeTestCues.push(cueEnter(text, row, 31 - text.length + 1));
        }
      }

      function runCea608LongTextTest() {
        var longText = 'XOXOX XOXO OXOX XOXOXOXOXOX XOXO';

        clearCea608RowTest();
        activeTestCues.push(cueEnter(longText.substring(0, 32), 0, 0));
        activeTestCues.push(cueEnter(longText.substring(0, 24), 7, 4));
        activeTestCues.push(cueEnter(longText.substring(0, 18), 14, 14));
      }

      function applyCea608FontSize() {
        var value = document.getElementById('cea608-font-size').value;
        window.uiManager.getSubtitleSettingsManager().fontSize.value = value;
      }

      document.getElementById('run-cea608-row-test').addEventListener('click', runCea608RowTest);
      document.getElementById('run-cea608-long-text-test').addEventListener('click', runCea608LongTextTest);
      document.getElementById('clear-cea608-row-test').addEventListener('click', clearCea608RowTest);
      document.getElementById('apply-cea608-font-size').addEventListener('click', applyCea608FontSize);

      window.player.load(source).catch(function (error) {
        console.error('Failed to load test stream', error);
      });
    </script>
  </body>
</html>
```


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
