### PR TITLE
Add comparator funcs to control audio and subtitle tracks ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `AudioTrackListBox` and `SubtitleListBox` now accept config objects that extend `ListBoxConfig` without `listSelector`
 - `ListSelectorConfig.comparator` to customize the display order of list-backed selection UIs such as `AudioTrackSelectBox`, `SubtitleSelectBox`, `AudioTrackListBox`, and `SubtitleListBox`. For subtitle selection UIs, the built-in `Off` option remains fixed at the top.
   Example:
   ```ts
@@ -18,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     comparator: (a, b) => String(a.label).localeCompare(String(b.label)), // A-Z
   });
   ```
+- `AudioTrackListBox` and `SubtitleListBox` now can accept config objects that extend `ListBoxConfig` without `listSelector`.
+  This enables configuring list-selector behavior such as `comparator`, `filter`, and `translator`, as well as list-box/settings-panel options like `title`, `hideDelay`, and related panel settings.
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `ListSelectorConfig.comparator` to customize the display order of list-backed selection UIs such as `AudioTrackSelectBox`, `SubtitleSelectBox`, `AudioTrackListBox`, and `SubtitleListBox`.
+- `AudioTrackListBox` and `SubtitleListBox` now accept config objects that extend `ListBoxConfig` without `listSelector`
+- `ListSelectorConfig.comparator` to customize the display order of list-backed selection UIs such as `AudioTrackSelectBox`, `SubtitleSelectBox`, `AudioTrackListBox`, and `SubtitleListBox`. For subtitle selection UIs, the built-in `Off` option remains fixed at the top.
   Example:
   ```ts
-    const subtitleListBox = new SubtitleListBox({
-      title: i18n.getLocalizer('settings.subtitles'),
-      comparator: (a, b) => String(a.label).localeCompare(String(b.label)), // A-Z
-    });
+  const subtitleListBox = new SubtitleListBox({
+    title: i18n.getLocalizer('settings.subtitles'),
+    comparator: (a, b) => String(a.label).localeCompare(String(b.label)), // A-Z
+  });
   ```
 
 ## [4.11.0] - 2026-04-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ```
 - `AudioTrackListBox` and `SubtitleListBox` now can accept config objects that extend `ListBoxConfig` without `listSelector`.
   This enables configuring list-selector behavior such as `comparator`, `filter`, and `translator`, as well as list-box/settings-panel options like `title`, `hideDelay`, and related panel settings.
+- `ListSelector.onItemsChanged` event that fires whenever the effective item collection changes, including item additions, removals, reordering, and item property updates that affect rendering
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `UIConfig.audioTrackComparator` and `UIConfig.subtitleComparator` to control the display order of audio and subtitle tracks in the selection UI
+
 ## [4.11.0] - 2026-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `ListSelectorConfig.comparator` to control the display order of list-backed selection UIs such as audio and subtitle track lists
+- `ListSelectorConfig.comparator` to customize the display order of list-backed selection UIs such as `AudioTrackSelectBox`, `SubtitleSelectBox`, `AudioTrackListBox`, and `SubtitleListBox`.
+  Example:
+  ```ts
+    const subtitleListBox = new SubtitleListBox({
+      title: i18n.getLocalizer('settings.subtitles'),
+      comparator: (a, b) => String(a.label).localeCompare(String(b.label)), // A-Z
+    });
+  ```
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ```
 - `AudioTrackListBox` and `SubtitleListBox` now can accept config objects that extend `ListBoxConfig` without `listSelector`.
   This enables configuring list-selector behavior such as `comparator`, `filter`, and `translator`, as well as list-box/settings-panel options like `title`, `hideDelay`, and related panel settings.
-- `ListSelector.onItemsChanged` event that fires whenever the effective item collection changes, including item additions, removals, reordering, and item property updates that affect rendering
+- `ListSelector.onItemsChanged` event that fires whenever the effective item collection changes, including item additions, removals, reordering, or updates to rendered item data such as `label` and `ariaLabel`.
+  This event should be used by consumers that rebuild the full list UI from `getItems()`, while `onItemAdded` and `onItemRemoved` remain strict membership-change events.
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     comparator: (a, b) => String(a.label).localeCompare(String(b.label)), // A-Z
   });
   ```
+  > **Note**: Requires building a custom UI. The default `UIFactory` presets do not expose this option.
 - `AudioTrackListBox` and `SubtitleListBox` now can accept config objects that extend `ListBoxConfig` without `listSelector`.
   This enables configuring list-selector behavior such as `comparator`, `filter`, and `translator`, as well as list-box/settings-panel options like `title`, `hideDelay`, and related panel settings.
 - `ListSelector.onItemsChanged` event that fires whenever the effective item collection changes, including item additions, removals, reordering, or updates to rendered item data such as `label` and `ariaLabel`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `UIConfig.audioTrackComparator` and `UIConfig.subtitleComparator` to control the display order of audio and subtitle tracks in the selection UI
+- `ListSelectorConfig.comparator` to control the display order of list-backed selection UIs such as audio and subtitle track lists
 
 ## [4.11.0] - 2026-04-03
 

--- a/spec/components/lists/ListSelector.spec.ts
+++ b/spec/components/lists/ListSelector.spec.ts
@@ -1,4 +1,5 @@
 import { ListItem, ListSelector, ListSelectorConfig } from '../../../src/ts/components/lists/ListSelector';
+import { i18n } from '../../../src/ts/localization/i18n';
 
 class ListSelectorTestClass extends ListSelector<ListSelectorConfig> {}
 
@@ -345,6 +346,23 @@ describe('ListSelector', () => {
         {
           key: 'I-3',
           label: 'L-3',
+        },
+      ]);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger onItemsChangedEvent when localized labels are recreated but unchanged', () => {
+      listSelector = new ListSelectorTestClass();
+      listSelector.addItem('null', i18n.getLocalizer('off'));
+
+      const spy = jest.fn();
+      listSelector.onItemsChanged.subscribe(spy);
+
+      listSelector.synchronizeItems([
+        {
+          key: 'null',
+          label: i18n.getLocalizer('off'),
         },
       ]);
 

--- a/spec/components/lists/ListSelector.spec.ts
+++ b/spec/components/lists/ListSelector.spec.ts
@@ -51,6 +51,22 @@ describe('ListSelector', () => {
       expect(listSelector.getItems()).toEqual([{ key: 'itemKey', label: 'itemLabelNew' }]);
     });
 
+    it('adds items respecting comparator order when a comparator is configured', () => {
+      listSelector = new ListSelectorTestClass({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+
+      listSelector.addItem('I-3', 'L-3');
+      listSelector.addItem('I-1', 'L-1');
+      listSelector.addItem('I-2', 'L-2');
+
+      expect(listSelector.getItems()).toEqual([
+        { key: 'I-1', label: 'L-1' },
+        { key: 'I-2', label: 'L-2' },
+        { key: 'I-3', label: 'L-3' },
+      ]);
+    });
+
     it('triggers onItemAddedEvent', () => {
       const spy = jest.fn();
       listSelector.onItemAdded.subscribe(spy);
@@ -410,11 +426,22 @@ describe('ListSelector', () => {
 
     it('triggers onItemsChangedEvent when only the order changes', () => {
       listSelector = new ListSelectorTestClass({
+        items: [
+          {
+            key: 'I-3',
+            label: 'L-3',
+          },
+          {
+            key: 'I-1',
+            label: 'L-1',
+          },
+          {
+            key: 'I-2',
+            label: 'L-2',
+          },
+        ],
         comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
       });
-      listSelector.addItem('I-3', 'L-3');
-      listSelector.addItem('I-1', 'L-1');
-      listSelector.addItem('I-2', 'L-2');
 
       const itemsChangedSpy = jest.fn();
       const itemAddedSpy = jest.fn();

--- a/spec/components/lists/ListSelector.spec.ts
+++ b/spec/components/lists/ListSelector.spec.ts
@@ -292,5 +292,44 @@ describe('ListSelector', () => {
       expect(spy).not.toHaveBeenCalledWith(expect.anything(), 'I-2');
       expect(spy).not.toHaveBeenCalledWith(expect.anything(), 'I-3');
     });
+
+    it('reorders synchronized items when a comparator is configured', () => {
+      listSelector = new ListSelectorTestClass({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      listSelector.addItem('I-3', 'L-3');
+      listSelector.addItem('I-1', 'L-1');
+      listSelector.addItem('I-2', 'L-2');
+
+      listSelector.synchronizeItems([
+        {
+          key: 'I-3',
+          label: 'L-3',
+        },
+        {
+          key: 'I-1',
+          label: 'L-1',
+        },
+        {
+          key: 'I-2',
+          label: 'L-2',
+        },
+      ]);
+
+      expect(listSelector.getItems()).toEqual([
+        {
+          key: 'I-1',
+          label: 'L-1',
+        },
+        {
+          key: 'I-2',
+          label: 'L-2',
+        },
+        {
+          key: 'I-3',
+          label: 'L-3',
+        },
+      ]);
+    });
   });
 });

--- a/spec/components/lists/ListSelector.spec.ts
+++ b/spec/components/lists/ListSelector.spec.ts
@@ -57,6 +57,15 @@ describe('ListSelector', () => {
 
       expect(spy).toHaveBeenCalled();
     });
+
+    it('triggers onItemsChangedEvent', () => {
+      const spy = jest.fn();
+      listSelector.onItemsChanged.subscribe(spy);
+
+      listSelector.addItem('itemKeyNew', 'itemLabelNew');
+
+      expect(spy).toHaveBeenCalledWith(listSelector, null);
+    });
   });
 
   describe('addItem with custom aria label', () => {
@@ -125,6 +134,15 @@ describe('ListSelector', () => {
 
       expect(spy).toHaveBeenCalled();
     });
+
+    it('triggers onItemsChangedEvent when removal succeeds', () => {
+      const spy = jest.fn();
+      listSelector.onItemsChanged.subscribe(spy);
+
+      listSelector.removeItem('itemKey');
+
+      expect(spy).toHaveBeenCalledWith(listSelector, null);
+    });
   });
 
   describe('clearItems', () => {
@@ -150,6 +168,15 @@ describe('ListSelector', () => {
 
       listSelector.clearItems();
       expect(spy).toHaveBeenCalledTimes(3);
+    });
+
+    it('triggers onItemsChangedEvent', () => {
+      const spy = jest.fn();
+      listSelector.onItemsChanged.subscribe(spy);
+
+      listSelector.clearItems();
+
+      expect(spy).toHaveBeenCalledWith(listSelector, null);
     });
   });
 
@@ -293,6 +320,37 @@ describe('ListSelector', () => {
       expect(spy).not.toHaveBeenCalledWith(expect.anything(), 'I-3');
     });
 
+    it('triggers onItemsChangedEvent when the effective list changes', () => {
+      const spy = jest.fn();
+      listSelector.onItemsChanged.subscribe(spy);
+
+      listSelector.synchronizeItems(newItems);
+
+      expect(spy).toHaveBeenCalledWith(listSelector, null);
+    });
+
+    it('does not trigger onItemsChangedEvent when the effective list stays the same', () => {
+      const spy = jest.fn();
+      listSelector.onItemsChanged.subscribe(spy);
+
+      listSelector.synchronizeItems([
+        {
+          key: 'I-1',
+          label: 'L-1',
+        },
+        {
+          key: 'I-2',
+          label: 'L-2',
+        },
+        {
+          key: 'I-3',
+          label: 'L-3',
+        },
+      ]);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     it('reorders synchronized items when a comparator is configured', () => {
       listSelector = new ListSelectorTestClass({
         comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
@@ -330,6 +388,41 @@ describe('ListSelector', () => {
           label: 'L-3',
         },
       ]);
+    });
+
+    it('triggers onItemsChangedEvent when only the order changes', () => {
+      listSelector = new ListSelectorTestClass({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      listSelector.addItem('I-3', 'L-3');
+      listSelector.addItem('I-1', 'L-1');
+      listSelector.addItem('I-2', 'L-2');
+
+      const itemsChangedSpy = jest.fn();
+      const itemAddedSpy = jest.fn();
+      const itemRemovedSpy = jest.fn();
+      listSelector.onItemsChanged.subscribe(itemsChangedSpy);
+      listSelector.onItemAdded.subscribe(itemAddedSpy);
+      listSelector.onItemRemoved.subscribe(itemRemovedSpy);
+
+      listSelector.synchronizeItems([
+        {
+          key: 'I-3',
+          label: 'L-3',
+        },
+        {
+          key: 'I-1',
+          label: 'L-1',
+        },
+        {
+          key: 'I-2',
+          label: 'L-2',
+        },
+      ]);
+
+      expect(itemsChangedSpy).toHaveBeenCalledWith(listSelector, null);
+      expect(itemAddedSpy).not.toHaveBeenCalled();
+      expect(itemRemovedSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/spec/components/lists/ListSelector.spec.ts
+++ b/spec/components/lists/ListSelector.spec.ts
@@ -67,6 +67,23 @@ describe('ListSelector', () => {
       ]);
     });
 
+    it('produces the same order via addItem as synchronizeItems when a comparator is configured', () => {
+      const comparator = (itemA: ListItem, itemB: ListItem) => String(itemA.label).localeCompare(String(itemB.label));
+      const items = [
+        { key: 'I-3', label: 'L-3' },
+        { key: 'I-1', label: 'L-1' },
+        { key: 'I-2', label: 'L-2' },
+      ];
+
+      const byAddItem = new ListSelectorTestClass({ comparator });
+      items.forEach(item => byAddItem.addItem(item.key, item.label));
+
+      const bySynchronize = new ListSelectorTestClass({ comparator });
+      bySynchronize.synchronizeItems(items);
+
+      expect(byAddItem.getItems()).toEqual(bySynchronize.getItems());
+    });
+
     it('triggers onItemAddedEvent', () => {
       const spy = jest.fn();
       listSelector.onItemAdded.subscribe(spy);

--- a/spec/components/lists/TrackListBox.spec.ts
+++ b/spec/components/lists/TrackListBox.spec.ts
@@ -19,6 +19,17 @@ describe('TrackListBox constructors', () => {
     expect((audioTrackListBox as any).config.listSelector.getConfig().comparator).toBe(comparator);
   });
 
+  it('passes settings panel config through AudioTrackListBox config objects', () => {
+    const audioTrackListBox = new AudioTrackListBox({
+      title: 'Audio Tracks',
+      hideDelay: 1234,
+      pageTransitionAnimation: false,
+    });
+
+    expect((audioTrackListBox as any).config.hideDelay).toBe(1234);
+    expect((audioTrackListBox as any).config.pageTransitionAnimation).toBe(false);
+  });
+
   it('allows SubtitleListBox title-only construction', () => {
     const subtitleListBox = new SubtitleListBox('Subtitles');
 
@@ -35,5 +46,18 @@ describe('TrackListBox constructors', () => {
     expect((subtitleListBox as any).config.title).toBe('Subtitles');
     expect((subtitleListBox as any).config.listSelector.getConfig().comparator).toBeDefined();
     expect((subtitleListBox as any).config.listSelector.getConfig().comparator).not.toBe(comparator);
+  });
+
+  it('passes list selector config through SubtitleListBox config objects', () => {
+    const translator = jest.fn().mockImplementation(item => item.label);
+    const filter = jest.fn().mockReturnValue(true);
+    const subtitleListBox = new SubtitleListBox({
+      title: 'Subtitles',
+      translator,
+      filter,
+    });
+
+    expect((subtitleListBox as any).config.listSelector.getConfig().translator).toBe(translator);
+    expect((subtitleListBox as any).config.listSelector.getConfig().filter).toBe(filter);
   });
 });

--- a/spec/components/lists/TrackListBox.spec.ts
+++ b/spec/components/lists/TrackListBox.spec.ts
@@ -1,0 +1,39 @@
+import { AudioTrackListBox } from '../../../src/ts/components/lists/AudioTrackListBox';
+import { SubtitleListBox } from '../../../src/ts/components/lists/SubtitleListBox';
+
+describe('TrackListBox constructors', () => {
+  it('allows AudioTrackListBox title-only construction', () => {
+    const audioTrackListBox = new AudioTrackListBox('Audio Tracks');
+
+    expect((audioTrackListBox as any).config.title).toBe('Audio Tracks');
+  });
+
+  it('allows AudioTrackListBox config-object construction with comparator', () => {
+    const comparator = jest.fn();
+    const audioTrackListBox = new AudioTrackListBox({
+      title: 'Audio Tracks',
+      comparator,
+    });
+
+    expect((audioTrackListBox as any).config.title).toBe('Audio Tracks');
+    expect((audioTrackListBox as any).config.listSelector.getConfig().comparator).toBe(comparator);
+  });
+
+  it('allows SubtitleListBox title-only construction', () => {
+    const subtitleListBox = new SubtitleListBox('Subtitles');
+
+    expect((subtitleListBox as any).config.title).toBe('Subtitles');
+  });
+
+  it('allows SubtitleListBox config-object construction with comparator', () => {
+    const comparator = jest.fn();
+    const subtitleListBox = new SubtitleListBox({
+      title: 'Subtitles',
+      comparator,
+    });
+
+    expect((subtitleListBox as any).config.title).toBe('Subtitles');
+    expect((subtitleListBox as any).config.listSelector.getConfig().comparator).toBeDefined();
+    expect((subtitleListBox as any).config.listSelector.getConfig().comparator).not.toBe(comparator);
+  });
+});

--- a/spec/components/lists/TrackListBox.spec.ts
+++ b/spec/components/lists/TrackListBox.spec.ts
@@ -48,6 +48,23 @@ describe('TrackListBox constructors', () => {
     expect((subtitleListBox as any).config.listSelector.getConfig().comparator).not.toBe(comparator);
   });
 
+  it('keeps the Off item (key "null") pinned first even when the comparator would sort it last', () => {
+    // Z→A comparator would place 'null' last alphabetically if not wrapped
+    const comparator = (a: any, b: any) => String(b.label).localeCompare(String(a.label));
+    const subtitleListBox = new SubtitleListBox({ title: 'Subtitles', comparator });
+    const innerComparator = (subtitleListBox as any).config.listSelector.getConfig().comparator;
+
+    const offItem = { key: 'null', label: 'Off' };
+    const englishItem = { key: 's-1', label: 'English' };
+    const vietnameseItem = { key: 's-2', label: 'Vietnamese' };
+
+    expect(innerComparator(offItem, englishItem)).toBeLessThan(0);
+    expect(innerComparator(offItem, vietnameseItem)).toBeLessThan(0);
+    expect(innerComparator(englishItem, offItem)).toBeGreaterThan(0);
+    // Non-null items are still sorted by the user comparator (Z→A: Vietnamese before English)
+    expect(innerComparator(vietnameseItem, englishItem)).toBeLessThan(0);
+  });
+
   it('passes list selector config through SubtitleListBox config objects', () => {
     const translator = jest.fn().mockImplementation(item => item.label);
     const filter = jest.fn().mockReturnValue(true);

--- a/spec/components/lists/TrackListBox.spec.ts
+++ b/spec/components/lists/TrackListBox.spec.ts
@@ -61,6 +61,7 @@ describe('TrackListBox constructors', () => {
     expect(innerComparator(offItem, englishItem)).toBeLessThan(0);
     expect(innerComparator(offItem, vietnameseItem)).toBeLessThan(0);
     expect(innerComparator(englishItem, offItem)).toBeGreaterThan(0);
+    expect(innerComparator(offItem, offItem)).toBe(0);
     // Non-null items are still sorted by the user comparator (Z→A: Vietnamese before English)
     expect(innerComparator(vietnameseItem, englishItem)).toBeLessThan(0);
   });

--- a/spec/components/settings/SelectBox.spec.ts
+++ b/spec/components/settings/SelectBox.spec.ts
@@ -102,14 +102,15 @@ describe('SelectBox', () => {
 
     it('rebuilds the DOM options when synchronizeItems only changes order', () => {
       selectBox = new SelectBox({
+        items: [
+          { key: 'I-3', label: 'L-3' },
+          { key: 'I-1', label: 'L-1' },
+          { key: 'I-2', label: 'L-2' },
+        ],
         comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
       });
       selectBox.getDomElement();
       const updateDomItemsSpy = jest.spyOn(selectBox as any, 'updateDomItems');
-
-      selectBox.addItem('I-3', 'L-3');
-      selectBox.addItem('I-1', 'L-1');
-      selectBox.addItem('I-2', 'L-2');
       updateDomItemsSpy.mockClear();
 
       selectBox.synchronizeItems([

--- a/spec/components/settings/SelectBox.spec.ts
+++ b/spec/components/settings/SelectBox.spec.ts
@@ -99,6 +99,28 @@ describe('SelectBox', () => {
 
       expect(domElement.on).toHaveBeenCalled();
     });
+
+    it('rebuilds the DOM options when synchronizeItems only changes order', () => {
+      selectBox = new SelectBox({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      selectBox.getDomElement();
+      const updateDomItemsSpy = jest.spyOn(selectBox as any, 'updateDomItems');
+
+      selectBox.addItem('I-3', 'L-3');
+      selectBox.addItem('I-1', 'L-1');
+      selectBox.addItem('I-2', 'L-2');
+      updateDomItemsSpy.mockClear();
+
+      selectBox.synchronizeItems([
+        { key: 'I-3', label: 'L-3' },
+        { key: 'I-1', label: 'L-1' },
+        { key: 'I-2', label: 'L-2' },
+      ]);
+
+      expect(updateDomItemsSpy).toHaveBeenCalledWith(null);
+      expect(selectBox.getItems().map(item => item.key)).toEqual(['I-1', 'I-2', 'I-3']);
+    });
   });
 
   describe('configure', () => {

--- a/spec/utils/AudioTrackUtils.spec.ts
+++ b/spec/utils/AudioTrackUtils.spec.ts
@@ -68,13 +68,12 @@ describe('AudioTrackUtils', () => {
     });
   });
 
-  describe('audioTrackComparator', () => {
+  describe('list selector comparator', () => {
     it('re-sorts visible items on UI config updates and keeps the current selection', () => {
       const onUpdated = MockHelper.getEventDispatcherMock();
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated },
-        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       playerMock.getAvailableAudio = jest.fn().mockReturnValue([
@@ -83,8 +82,10 @@ describe('AudioTrackUtils', () => {
       ]);
       playerMock.getAudio = jest.fn().mockReturnValue({ id: 'a-3', label: 'Vietnamese' });
 
-      const localListSelector = new ListSelectorTestClass();
-      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new ListSelectorTestClass({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       expect(localListSelector.getItems().map(i => i.key)).toEqual(['a-1', 'a-3']);
       expect(localListSelector.getSelectedItem()).toBe('a-3');
@@ -97,17 +98,16 @@ describe('AudioTrackUtils', () => {
       playerMock.getAudio = jest.fn().mockReturnValue({ id: 'a-2', label: 'French' });
 
       const refreshAudioTracks = MockHelper.getMockCallArg<(sender: unknown) => void>(onUpdated.subscribe);
-      refreshAudioTracks(uiManagerWithComparator);
+      refreshAudioTracks(uiManagerWithEvents);
 
       expect(localListSelector.getItems().map(i => i.key)).toEqual(['a-1', 'a-2', 'a-3']);
       expect(localListSelector.getSelectedItem()).toBe('a-2');
     });
 
-    it('sorts audio tracks by the comparator defined in UIConfig', () => {
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+    it('sorts audio tracks by the comparator defined in the list selector config', () => {
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
-        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       playerMock.getAvailableAudio = jest.fn().mockReturnValue([
@@ -116,18 +116,18 @@ describe('AudioTrackUtils', () => {
         { id: 'a-3', label: 'Vietnamese' },
       ]);
 
-      const localListSelector = new ListSelectorMockClass();
-      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new ListSelectorTestClass({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
-      const items: { key: string }[] = (localListSelector.synchronizeItems as jest.Mock).mock.calls[0][0];
-      expect(items.map(i => i.key)).toEqual(['a-1', 'a-2', 'a-3']);
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['a-1', 'a-2', 'a-3']);
     });
 
     it('does not mutate the original array returned by the player', () => {
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
-        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       const originalTracks = [
@@ -136,8 +136,10 @@ describe('AudioTrackUtils', () => {
       ];
       playerMock.getAvailableAudio = jest.fn().mockReturnValue(originalTracks);
 
-      const localListSelector = new ListSelectorMockClass();
-      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new ListSelectorTestClass({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       expect(originalTracks[0].id).toBe('a-2');
     });
@@ -148,15 +150,16 @@ describe('AudioTrackUtils', () => {
     });
 
     it('sorts correctly when AudioAdded events fire incrementally', () => {
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
-        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       playerMock.getAvailableAudio = jest.fn().mockReturnValue([]);
-      const localListSelector = new ListSelectorMockClass();
-      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new ListSelectorTestClass({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       // First AudioAdded: only Vietnamese available
       playerMock.getAvailableAudio = jest.fn().mockReturnValue([{ id: 'a-3', label: 'Vietnamese' }]);
@@ -169,30 +172,27 @@ describe('AudioTrackUtils', () => {
       ]);
       playerMock.eventEmitter.fireAudioAddedEvent('a-1', 'English');
 
-      const lastCall: { key: string }[] = (localListSelector.synchronizeItems as jest.Mock).mock.calls.slice(-1)[0][0];
-      expect(lastCall.map(i => i.key)).toEqual(['a-1', 'a-3']);
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['a-1', 'a-3']);
     });
 
     it('reselects the current audio track after applying the comparator', () => {
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
-        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
       playerMock.getAudio = jest.fn().mockReturnValue({ id: 'a-3', label: 'Vietnamese' });
 
       const localListSelector = new ListSelectorMockClass();
-      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       expect(localListSelector.selectItem).toHaveBeenCalledWith('a-3');
     });
 
     it('preserves the previous selection on refresh when the player does not expose a current audio track', () => {
       const onUpdated = MockHelper.getEventDispatcherMock();
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated },
-        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       playerMock.getAvailableAudio = jest.fn().mockReturnValue([
@@ -201,8 +201,10 @@ describe('AudioTrackUtils', () => {
       ]);
       playerMock.getAudio = jest.fn().mockReturnValue({ id: 'a-2', label: 'Taiwanese' });
 
-      const localListSelector = new ListSelectorTestClass();
-      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new ListSelectorTestClass({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       expect(localListSelector.getSelectedItem()).toBe('a-2');
 
@@ -214,7 +216,7 @@ describe('AudioTrackUtils', () => {
       playerMock.getAudio = jest.fn().mockReturnValue(undefined);
 
       const refreshAudioTracks = MockHelper.getMockCallArg<(sender: unknown) => void>(onUpdated.subscribe);
-      refreshAudioTracks(uiManagerWithComparator);
+      refreshAudioTracks(uiManagerWithEvents);
 
       expect(localListSelector.getItems().map(i => i.key)).toEqual(['a-1', 'a-3', 'a-2']);
       expect(localListSelector.getSelectedItem()).toBe('a-2');

--- a/spec/utils/AudioTrackUtils.spec.ts
+++ b/spec/utils/AudioTrackUtils.spec.ts
@@ -1,0 +1,189 @@
+import { AudioTrackSwitchHandler } from '../../src/ts/utils/AudioTrackUtils';
+import { MockHelper } from '../helper/MockHelper';
+import { ListSelector, ListSelectorConfig } from '../../src/ts/components/lists/ListSelector';
+
+let playerMock = MockHelper.getPlayerMock();
+const uiManagerMock = MockHelper.getUiInstanceManagerMock();
+
+const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.fn().mockImplementation(() => ({
+  onItemSelected: MockHelper.getEventDispatcherMock(),
+  onItemSelectionChanged: MockHelper.getEventDispatcherMock(),
+  hasItem: jest.fn(),
+  addItem: jest.fn(),
+  removeItem: jest.fn(),
+  getItems: jest.fn().mockReturnValue([]),
+  synchronizeItems: jest.fn(),
+  selectItem: jest.fn(),
+  clearItems: jest.fn(),
+}));
+
+let listSelectorMock: ListSelector<ListSelectorConfig>;
+class ListSelectorTestClass extends ListSelector<ListSelectorConfig> {}
+
+describe('AudioTrackUtils', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    listSelectorMock = new ListSelectorMockClass();
+
+    playerMock.getAvailableAudio = jest.fn().mockReturnValue([
+      { id: 'a-1', label: 'English' },
+      { id: 'a-2', label: 'Taiwanese' },
+      { id: 'a-3', label: 'Vietnamese' },
+    ]);
+
+    new AudioTrackSwitchHandler(playerMock, listSelectorMock, uiManagerMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('adds audio tracks to the listSelector', () => {
+    it('on initial setup via synchronizeItems', () => {
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalled();
+    });
+
+    it('on audioAdded event via synchronizeItems', () => {
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([
+        { id: 'a-1', label: 'English' },
+        { id: 'a-4', label: 'French' },
+      ]);
+      playerMock.eventEmitter.fireAudioAddedEvent('a-4', 'French');
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('removes audio tracks from the listSelector', () => {
+    it('on audioRemoved event', () => {
+      jest.spyOn(listSelectorMock, 'hasItem').mockReturnValue(true);
+      playerMock.eventEmitter.fireAudioRemovedEvent('a-1');
+      expect(listSelectorMock.removeItem).toHaveBeenCalledWith('a-1');
+    });
+
+    it('does not call removeItem for item that does not exist', () => {
+      jest.spyOn(listSelectorMock, 'hasItem').mockReturnValue(false);
+      playerMock.eventEmitter.fireAudioRemovedEvent('a-1');
+      expect(listSelectorMock.removeItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('audioTrackComparator', () => {
+    it('re-sorts visible items on UI config updates and keeps the current selection', () => {
+      const onUpdated = MockHelper.getEventDispatcherMock();
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated },
+        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([
+        { id: 'a-3', label: 'Vietnamese' },
+        { id: 'a-1', label: 'English' },
+      ]);
+      playerMock.getAudio = jest.fn().mockReturnValue({ id: 'a-3', label: 'Vietnamese' });
+
+      const localListSelector = new ListSelectorTestClass();
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['a-1', 'a-3']);
+      expect(localListSelector.getSelectedItem()).toBe('a-3');
+
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([
+        { id: 'a-3', label: 'Vietnamese' },
+        { id: 'a-2', label: 'French' },
+        { id: 'a-1', label: 'English' },
+      ]);
+      playerMock.getAudio = jest.fn().mockReturnValue({ id: 'a-2', label: 'French' });
+
+      const refreshAudioTracks = MockHelper.getMockCallArg<(sender: unknown) => void>(onUpdated.subscribe);
+      refreshAudioTracks(uiManagerWithComparator);
+
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['a-1', 'a-2', 'a-3']);
+      expect(localListSelector.getSelectedItem()).toBe('a-2');
+    });
+
+    it('sorts audio tracks by the comparator defined in UIConfig', () => {
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([
+        { id: 'a-2', label: 'Taiwanese' },
+        { id: 'a-1', label: 'English' },
+        { id: 'a-3', label: 'Vietnamese' },
+      ]);
+
+      const localListSelector = new ListSelectorMockClass();
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      const items: { key: string }[] = (localListSelector.synchronizeItems as jest.Mock).mock.calls[0][0];
+      expect(items.map(i => i.key)).toEqual(['a-1', 'a-2', 'a-3']);
+    });
+
+    it('does not mutate the original array returned by the player', () => {
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      const originalTracks = [
+        { id: 'a-2', label: 'Taiwanese' },
+        { id: 'a-1', label: 'English' },
+      ];
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue(originalTracks);
+
+      const localListSelector = new ListSelectorMockClass();
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      expect(originalTracks[0].id).toBe('a-2');
+    });
+
+    it('preserves original order when no comparator is set', () => {
+      const items: { key: string }[] = (listSelectorMock.synchronizeItems as jest.Mock).mock.calls[0][0];
+      expect(items.map(i => i.key)).toEqual(['a-1', 'a-2', 'a-3']);
+    });
+
+    it('sorts correctly when AudioAdded events fire incrementally', () => {
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([]);
+      const localListSelector = new ListSelectorMockClass();
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      // First AudioAdded: only Vietnamese available
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([{ id: 'a-3', label: 'Vietnamese' }]);
+      playerMock.eventEmitter.fireAudioAddedEvent('a-3', 'Vietnamese');
+
+      // Second AudioAdded: English now also available
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([
+        { id: 'a-3', label: 'Vietnamese' },
+        { id: 'a-1', label: 'English' },
+      ]);
+      playerMock.eventEmitter.fireAudioAddedEvent('a-1', 'English');
+
+      const lastCall: { key: string }[] = (localListSelector.synchronizeItems as jest.Mock).mock.calls.slice(-1)[0][0];
+      expect(lastCall.map(i => i.key)).toEqual(['a-1', 'a-3']);
+    });
+
+    it('reselects the current audio track after applying the comparator', () => {
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+      playerMock.getAudio = jest.fn().mockReturnValue({ id: 'a-3', label: 'Vietnamese' });
+
+      const localListSelector = new ListSelectorMockClass();
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      expect(localListSelector.selectItem).toHaveBeenCalledWith('a-3');
+    });
+  });
+});

--- a/spec/utils/AudioTrackUtils.spec.ts
+++ b/spec/utils/AudioTrackUtils.spec.ts
@@ -12,6 +12,7 @@ const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.
   addItem: jest.fn(),
   removeItem: jest.fn(),
   getItems: jest.fn().mockReturnValue([]),
+  getSelectedItem: jest.fn().mockReturnValue(null),
   synchronizeItems: jest.fn(),
   selectItem: jest.fn(),
   clearItems: jest.fn(),
@@ -184,6 +185,39 @@ describe('AudioTrackUtils', () => {
       new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
 
       expect(localListSelector.selectItem).toHaveBeenCalledWith('a-3');
+    });
+
+    it('preserves the previous selection on refresh when the player does not expose a current audio track', () => {
+      const onUpdated = MockHelper.getEventDispatcherMock();
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated },
+        audioTrackComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([
+        { id: 'a-2', label: 'Taiwanese' },
+        { id: 'a-1', label: 'English' },
+      ]);
+      playerMock.getAudio = jest.fn().mockReturnValue({ id: 'a-2', label: 'Taiwanese' });
+
+      const localListSelector = new ListSelectorTestClass();
+      new AudioTrackSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      expect(localListSelector.getSelectedItem()).toBe('a-2');
+
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([
+        { id: 'a-3', label: 'French' },
+        { id: 'a-2', label: 'Taiwanese' },
+        { id: 'a-1', label: 'English' },
+      ]);
+      playerMock.getAudio = jest.fn().mockReturnValue(undefined);
+
+      const refreshAudioTracks = MockHelper.getMockCallArg<(sender: unknown) => void>(onUpdated.subscribe);
+      refreshAudioTracks(uiManagerWithComparator);
+
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['a-1', 'a-3', 'a-2']);
+      expect(localListSelector.getSelectedItem()).toBe('a-2');
     });
   });
 });

--- a/spec/utils/AudioTrackUtils.spec.ts
+++ b/spec/utils/AudioTrackUtils.spec.ts
@@ -13,6 +13,7 @@ const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.
   removeItem: jest.fn(),
   getItems: jest.fn().mockReturnValue([]),
   getSelectedItem: jest.fn().mockReturnValue(null),
+  getConfig: jest.fn().mockReturnValue({}),
   synchronizeItems: jest.fn(),
   selectItem: jest.fn(),
   clearItems: jest.fn(),
@@ -44,13 +45,23 @@ describe('AudioTrackUtils', () => {
       expect(listSelectorMock.synchronizeItems).toHaveBeenCalled();
     });
 
-    it('on audioAdded event via synchronizeItems', () => {
+    it('on audioAdded event via addItem when no comparator is configured', () => {
       playerMock.getAvailableAudio = jest.fn().mockReturnValue([
         { id: 'a-1', label: 'English' },
         { id: 'a-4', label: 'French' },
       ]);
       playerMock.eventEmitter.fireAudioAddedEvent('a-4', 'French');
-      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(2);
+      expect(listSelectorMock.addItem).toHaveBeenCalledWith('a-4', expect.any(Function), true);
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the event payload when the getter is stale and no comparator is configured', () => {
+      playerMock.getAvailableAudio = jest.fn().mockReturnValue([{ id: 'a-1', label: 'English' }]);
+
+      playerMock.eventEmitter.fireAudioAddedEvent('a-4', 'French');
+
+      expect(listSelectorMock.addItem).toHaveBeenCalledWith('a-4', expect.any(Function), true);
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/spec/utils/AudioUtils.spec.ts
+++ b/spec/utils/AudioUtils.spec.ts
@@ -16,6 +16,7 @@ const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.
   getItems: jest.fn().mockReturnValue([]),
   synchronizeItems: jest.fn(),
   selectItem: jest.fn(),
+  clearItems: jest.fn(),
 }));
 
 let listSelectorMock: ListSelector<ListSelectorConfig>;
@@ -51,9 +52,9 @@ describe('AudioUtils', () => {
       expect(listSelectorMock.synchronizeItems).toHaveBeenCalled();
     });
 
-    it('on audioAdded event', () => {
+    it('on audioAdded event via synchronizeItems', () => {
       playerMock.eventEmitter.fireAudioAddedEvent('a-3', 'A3');
-      expect(listSelectorMock.addItem).toHaveBeenCalledWith('a-3', expect.any(Function), true);
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/spec/utils/AudioUtils.spec.ts
+++ b/spec/utils/AudioUtils.spec.ts
@@ -14,6 +14,7 @@ const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.
   addItem: jest.fn(),
   removeItem: jest.fn(),
   getItems: jest.fn().mockReturnValue([]),
+  getSelectedItem: jest.fn().mockReturnValue(null),
   synchronizeItems: jest.fn(),
   selectItem: jest.fn(),
   clearItems: jest.fn(),

--- a/spec/utils/AudioUtils.spec.ts
+++ b/spec/utils/AudioUtils.spec.ts
@@ -15,6 +15,7 @@ const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.
   removeItem: jest.fn(),
   getItems: jest.fn().mockReturnValue([]),
   getSelectedItem: jest.fn().mockReturnValue(null),
+  getConfig: jest.fn().mockReturnValue({}),
   synchronizeItems: jest.fn(),
   selectItem: jest.fn(),
   clearItems: jest.fn(),
@@ -53,9 +54,10 @@ describe('AudioUtils', () => {
       expect(listSelectorMock.synchronizeItems).toHaveBeenCalled();
     });
 
-    it('on audioAdded event via synchronizeItems', () => {
+    it('on audioAdded event via addItem when no comparator is configured', () => {
       playerMock.eventEmitter.fireAudioAddedEvent('a-3', 'A3');
-      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(2);
+      expect(listSelectorMock.addItem).toHaveBeenCalledWith('a-3', expect.any(Function), true);
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/spec/utils/SubtitleUtils.spec.ts
+++ b/spec/utils/SubtitleUtils.spec.ts
@@ -1,6 +1,7 @@
 import { SubtitleSwitchHandler } from '../../src/ts/utils/SubtitleUtils';
 import { MockHelper } from '../helper/MockHelper';
 import { ListSelector, ListSelectorConfig } from '../../src/ts/components/lists/ListSelector';
+import { SubtitleSelectBox } from '../../src/ts/components/settings/SubtitleSelectBox';
 import { i18n } from '../../src/ts/localization/i18n';
 
 let playerMock = MockHelper.getPlayerMock();
@@ -230,13 +231,12 @@ describe('SubtitleUtils', () => {
     });
   });
 
-  describe('subtitleComparator', () => {
+  describe('list selector comparator', () => {
     it('re-sorts visible subtitles on UI config updates, keeps off first, and preserves selection', () => {
       const onUpdated = MockHelper.getEventDispatcherMock();
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated },
-        subtitleComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       playerMock.subtitles.list = jest.fn().mockReturnValue([
@@ -244,8 +244,10 @@ describe('SubtitleUtils', () => {
         { id: 's-1', label: 'English', enabled: false },
       ]);
 
-      const localListSelector = new ListSelectorTestClass();
-      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new SubtitleSelectBox({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       expect(localListSelector.getItems().map(i => i.key)).toEqual(['null', 's-1', 's-3']);
       expect(localListSelector.getSelectedItem()).toBe('s-3');
@@ -257,17 +259,16 @@ describe('SubtitleUtils', () => {
       ]);
 
       const refreshSubtitles = MockHelper.getMockCallArg<(sender: unknown) => void>(onUpdated.subscribe);
-      refreshSubtitles(uiManagerWithComparator);
+      refreshSubtitles(uiManagerWithEvents);
 
       expect(localListSelector.getItems().map(i => i.key)).toEqual(['null', 's-1', 's-2', 's-3']);
       expect(localListSelector.getSelectedItem()).toBe('s-2');
     });
 
-    it('sorts subtitles by the comparator defined in UIConfig', () => {
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+    it('sorts subtitles by the comparator defined in the list selector config', () => {
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
-        subtitleComparator: (a: { label: string }, b: { label: string }) => b.label.localeCompare(a.label),
       } as any);
 
       playerMock.subtitles.list = jest.fn().mockReturnValue([
@@ -276,19 +277,18 @@ describe('SubtitleUtils', () => {
         { id: 's-3', label: 'Taiwanese', enabled: false },
       ]);
 
-      const localListSelector = new ListSelectorMockClass();
-      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new SubtitleSelectBox({
+        comparator: (itemA, itemB) => String(itemB.label).localeCompare(String(itemA.label)),
+      });
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
-      const items: { key: string }[] = (localListSelector.synchronizeItems as jest.Mock).mock.calls[0][0];
-      // off item is always first, then tracks in comparator order (descending: Vietnamese, Taiwanese, English)
-      expect(items.map(i => i.key)).toEqual(['null', 's-2', 's-3', 's-1']);
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['null', 's-2', 's-3', 's-1']);
     });
 
     it('does not mutate the original array returned by the player', () => {
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
-        subtitleComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       const originalSubtitles = [
@@ -297,8 +297,10 @@ describe('SubtitleUtils', () => {
       ];
       playerMock.subtitles.list = jest.fn().mockReturnValue(originalSubtitles);
 
-      const localListSelector = new ListSelectorMockClass();
-      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new SubtitleSelectBox({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       expect(originalSubtitles[0].id).toBe('s-3');
     });
@@ -309,15 +311,16 @@ describe('SubtitleUtils', () => {
     });
 
     it('sorts correctly when SubtitleAdded events fire incrementally', () => {
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
-        subtitleComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       playerMock.subtitles.list = jest.fn().mockReturnValue([]);
-      const localListSelector = new ListSelectorMockClass();
-      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      const localListSelector = new SubtitleSelectBox({
+        comparator: (itemA, itemB) => String(itemA.label).localeCompare(String(itemB.label)),
+      });
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       // First SubtitleAdded: only Vietnamese available
       playerMock.subtitles.list = jest.fn().mockReturnValue([{ id: 's-3', label: 'Vietnamese', enabled: false }]);
@@ -330,16 +333,13 @@ describe('SubtitleUtils', () => {
       ]);
       playerMock.eventEmitter.fireSubtitleAddedEvent('s-1', 'English');
 
-      const lastCall: { key: string }[] = (localListSelector.synchronizeItems as jest.Mock).mock.calls.slice(-1)[0][0];
-      // off item always first, then tracks in comparator order
-      expect(lastCall.map(i => i.key)).toEqual(['null', 's-1', 's-3']);
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['null', 's-1', 's-3']);
     });
 
     it('reselects the current subtitle after applying the comparator', () => {
-      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
-      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+      const uiManagerWithEvents = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithEvents, 'getConfig').mockReturnValue({
         events: { onUpdated: MockHelper.getEventDispatcherMock() },
-        subtitleComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
       } as any);
 
       playerMock.subtitles.list = jest.fn().mockReturnValue([
@@ -348,7 +348,7 @@ describe('SubtitleUtils', () => {
       ]);
 
       const localListSelector = new ListSelectorMockClass();
-      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithEvents);
 
       expect(localListSelector.selectItem).toHaveBeenCalledWith('s-1');
     });

--- a/spec/utils/SubtitleUtils.spec.ts
+++ b/spec/utils/SubtitleUtils.spec.ts
@@ -52,9 +52,13 @@ describe('SubtitleUtils', () => {
       expect(listSelectorMock.synchronizeItems).toHaveBeenCalled();
     });
 
-    it('on subtitleAdded event', () => {
+    it('on subtitleAdded event via synchronizeItems', () => {
+      playerMock.subtitles.list = jest.fn().mockReturnValue([
+        { id: 's-1', label: 'S1', enabled: true },
+        { id: 's-3', label: 'S3', enabled: false },
+      ]);
       playerMock.eventEmitter.fireSubtitleAddedEvent('s-3', 'S3');
-      expect(listSelectorMock.addItem).toHaveBeenCalledWith('s-3', 'S3');
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -223,6 +227,130 @@ describe('SubtitleUtils', () => {
 
       expect(player.subtitles.enable).not.toHaveBeenCalled();
       expect(player.subtitles.disable).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subtitleComparator', () => {
+    it('re-sorts visible subtitles on UI config updates, keeps off first, and preserves selection', () => {
+      const onUpdated = MockHelper.getEventDispatcherMock();
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated },
+        subtitleComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      playerMock.subtitles.list = jest.fn().mockReturnValue([
+        { id: 's-3', label: 'Vietnamese', enabled: true },
+        { id: 's-1', label: 'English', enabled: false },
+      ]);
+
+      const localListSelector = new ListSelectorTestClass();
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['null', 's-1', 's-3']);
+      expect(localListSelector.getSelectedItem()).toBe('s-3');
+
+      playerMock.subtitles.list = jest.fn().mockReturnValue([
+        { id: 's-3', label: 'Vietnamese', enabled: false },
+        { id: 's-2', label: 'French', enabled: true },
+        { id: 's-1', label: 'English', enabled: false },
+      ]);
+
+      const refreshSubtitles = MockHelper.getMockCallArg<(sender: unknown) => void>(onUpdated.subscribe);
+      refreshSubtitles(uiManagerWithComparator);
+
+      expect(localListSelector.getItems().map(i => i.key)).toEqual(['null', 's-1', 's-2', 's-3']);
+      expect(localListSelector.getSelectedItem()).toBe('s-2');
+    });
+
+    it('sorts subtitles by the comparator defined in UIConfig', () => {
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        subtitleComparator: (a: { label: string }, b: { label: string }) => b.label.localeCompare(a.label),
+      } as any);
+
+      playerMock.subtitles.list = jest.fn().mockReturnValue([
+        { id: 's-1', label: 'English', enabled: false },
+        { id: 's-2', label: 'Vietnamese', enabled: false },
+        { id: 's-3', label: 'Taiwanese', enabled: false },
+      ]);
+
+      const localListSelector = new ListSelectorMockClass();
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      const items: { key: string }[] = (localListSelector.synchronizeItems as jest.Mock).mock.calls[0][0];
+      // off item is always first, then tracks in comparator order (descending: Vietnamese, Taiwanese, English)
+      expect(items.map(i => i.key)).toEqual(['null', 's-2', 's-3', 's-1']);
+    });
+
+    it('does not mutate the original array returned by the player', () => {
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        subtitleComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      const originalSubtitles = [
+        { id: 's-3', label: 'Vietnamese', enabled: false },
+        { id: 's-1', label: 'English', enabled: false },
+      ];
+      playerMock.subtitles.list = jest.fn().mockReturnValue(originalSubtitles);
+
+      const localListSelector = new ListSelectorMockClass();
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      expect(originalSubtitles[0].id).toBe('s-3');
+    });
+
+    it('preserves original order when no comparator is set', () => {
+      const items: { key: string }[] = (listSelectorMock.synchronizeItems as jest.Mock).mock.calls[0][0];
+      expect(items.map(i => i.key)).toEqual(['null', 's-1', 's-2']);
+    });
+
+    it('sorts correctly when SubtitleAdded events fire incrementally', () => {
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        subtitleComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      playerMock.subtitles.list = jest.fn().mockReturnValue([]);
+      const localListSelector = new ListSelectorMockClass();
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      // First SubtitleAdded: only Vietnamese available
+      playerMock.subtitles.list = jest.fn().mockReturnValue([{ id: 's-3', label: 'Vietnamese', enabled: false }]);
+      playerMock.eventEmitter.fireSubtitleAddedEvent('s-3', 'Vietnamese');
+
+      // Second SubtitleAdded: English now also available
+      playerMock.subtitles.list = jest.fn().mockReturnValue([
+        { id: 's-3', label: 'Vietnamese', enabled: false },
+        { id: 's-1', label: 'English', enabled: false },
+      ]);
+      playerMock.eventEmitter.fireSubtitleAddedEvent('s-1', 'English');
+
+      const lastCall: { key: string }[] = (localListSelector.synchronizeItems as jest.Mock).mock.calls.slice(-1)[0][0];
+      // off item always first, then tracks in comparator order
+      expect(lastCall.map(i => i.key)).toEqual(['null', 's-1', 's-3']);
+    });
+
+    it('reselects the current subtitle after applying the comparator', () => {
+      const uiManagerWithComparator = MockHelper.getUiInstanceManagerMock();
+      jest.spyOn(uiManagerWithComparator, 'getConfig').mockReturnValue({
+        events: { onUpdated: MockHelper.getEventDispatcherMock() },
+        subtitleComparator: (a: { label: string }, b: { label: string }) => a.label.localeCompare(b.label),
+      } as any);
+
+      playerMock.subtitles.list = jest.fn().mockReturnValue([
+        { id: 's-2', label: 'Vietnamese', enabled: false },
+        { id: 's-1', label: 'English', enabled: true },
+      ]);
+
+      const localListSelector = new ListSelectorMockClass();
+      new SubtitleSwitchHandler(playerMock, localListSelector, uiManagerWithComparator);
+
+      expect(localListSelector.selectItem).toHaveBeenCalledWith('s-1');
     });
   });
 

--- a/spec/utils/SubtitleUtils.spec.ts
+++ b/spec/utils/SubtitleUtils.spec.ts
@@ -15,6 +15,7 @@ const ListSelectorMockClass: jest.Mock<ListSelector<ListSelectorConfig>> = jest.
   addItem: jest.fn(),
   removeItem: jest.fn(),
   getItems: jest.fn().mockReturnValue([]),
+  getConfig: jest.fn().mockReturnValue({}),
   synchronizeItems: jest.fn(),
   selectItem: jest.fn(),
   clearItems: jest.fn(),
@@ -53,13 +54,23 @@ describe('SubtitleUtils', () => {
       expect(listSelectorMock.synchronizeItems).toHaveBeenCalled();
     });
 
-    it('on subtitleAdded event via synchronizeItems', () => {
+    it('on subtitleAdded event via addItem when no comparator is configured', () => {
       playerMock.subtitles.list = jest.fn().mockReturnValue([
         { id: 's-1', label: 'S1', enabled: true },
         { id: 's-3', label: 'S3', enabled: false },
       ]);
       playerMock.eventEmitter.fireSubtitleAddedEvent('s-3', 'S3');
-      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(2);
+      expect(listSelectorMock.addItem).toHaveBeenCalledWith('s-3', 'S3');
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the event payload when the getter is stale and no comparator is configured', () => {
+      playerMock.subtitles.list = jest.fn().mockReturnValue([{ id: 's-1', label: 'S1', enabled: true }]);
+
+      playerMock.eventEmitter.fireSubtitleAddedEvent('s-3', 'S3');
+
+      expect(listSelectorMock.addItem).toHaveBeenCalledWith('s-3', 'S3');
+      expect(listSelectorMock.synchronizeItems).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -1,5 +1,5 @@
 import { ErrorMessageMap, ErrorMessageTranslator } from './components/overlays/ErrorMessageOverlay';
-import { SourceConfig } from 'bitmovin-player';
+import { AudioTrack, SourceConfig, SubtitleTrack } from 'bitmovin-player';
 import { LocalizationConfig } from './UIManager';
 
 /**
@@ -186,6 +186,28 @@ export interface UIConfig {
    * Allows setting a {@link LocalizationConfig} to specify language details of the UI.
    */
   localization?: LocalizationConfig;
+  /**
+   * Comparator function to define a custom display order for audio tracks in the audio track selection UI.
+   *
+   * When set, audio tracks returned by the player will be sorted using this comparator before being displayed.
+   * The function follows the same contract as {@link Array.prototype.sort}.
+   *
+   * @example
+   * // Sort audio tracks alphabetically by label
+   * audioTrackComparator: (a, b) => a.label.localeCompare(b.label)
+   */
+  audioTrackComparator?: (a: AudioTrack, b: AudioTrack) => number;
+  /**
+   * Comparator function to define a custom display order for subtitle tracks in the subtitle selection UI.
+   *
+   * When set, subtitle tracks returned by the player will be sorted using this comparator before being displayed.
+   * The function follows the same contract as {@link Array.prototype.sort}.
+   *
+   * @example
+   * // Sort subtitle tracks alphabetically by label
+   * subtitleComparator: (a, b) => a.label.localeCompare(b.label)
+   */
+  subtitleComparator?: (a: SubtitleTrack, b: SubtitleTrack) => number;
 }
 
 export interface ShadowDomConfig {

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -1,5 +1,5 @@
 import { ErrorMessageMap, ErrorMessageTranslator } from './components/overlays/ErrorMessageOverlay';
-import { AudioTrack, SourceConfig, SubtitleTrack } from 'bitmovin-player';
+import { SourceConfig } from 'bitmovin-player';
 import { LocalizationConfig } from './UIManager';
 
 /**
@@ -186,28 +186,6 @@ export interface UIConfig {
    * Allows setting a {@link LocalizationConfig} to specify language details of the UI.
    */
   localization?: LocalizationConfig;
-  /**
-   * Comparator function to define a custom display order for audio tracks in the audio track selection UI.
-   *
-   * When set, audio tracks returned by the player will be sorted using this comparator before being displayed.
-   * The function follows the same contract as {@link Array.prototype.sort}.
-   *
-   * @example
-   * // Sort audio tracks alphabetically by label
-   * audioTrackComparator: (a, b) => a.label.localeCompare(b.label)
-   */
-  audioTrackComparator?: (a: AudioTrack, b: AudioTrack) => number;
-  /**
-   * Comparator function to define a custom display order for subtitle tracks in the subtitle selection UI.
-   *
-   * When set, subtitle tracks returned by the player will be sorted using this comparator before being displayed.
-   * The function follows the same contract as {@link Array.prototype.sort}.
-   *
-   * @example
-   * // Sort subtitle tracks alphabetically by label
-   * subtitleComparator: (a, b) => a.label.localeCompare(b.label)
-   */
-  subtitleComparator?: (a: SubtitleTrack, b: SubtitleTrack) => number;
 }
 
 export interface ShadowDomConfig {

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -530,7 +530,7 @@ export namespace UIFactory {
       const subtitleOverlay = new SubtitleOverlay();
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, 5000);
 
-      const subtitleListBox = new SubtitleListBox(i18n.getLocalizer('settings.subtitles'));
+      const subtitleListBox = new SubtitleListBox({ title: i18n.getLocalizer('settings.subtitles') });
       const subtitleListBoxOpenButton = new SettingsToggleButton({
         settingsPanel: subtitleListBox,
         autoHideWhenNoActiveSettings: true,
@@ -538,7 +538,7 @@ export namespace UIFactory {
         text: i18n.getLocalizer('settings.subtitles'),
       });
 
-      const audioListBox = new AudioTrackListBox(i18n.getLocalizer('settings.audio.track'));
+      const audioListBox = new AudioTrackListBox({ title: i18n.getLocalizer('settings.audio.track') });
       const audioListBoxToggleButton = new SettingsToggleButton({
         settingsPanel: audioListBox,
         autoHideWhenNoActiveSettings: true,

--- a/src/ts/components/lists/AudioTrackListBox.ts
+++ b/src/ts/components/lists/AudioTrackListBox.ts
@@ -16,7 +16,7 @@ export class AudioTrackListBox extends ListBox {
   constructor(title?: LocalizableText);
   constructor(config?: AudioTrackListBoxConfig);
   constructor(configOrTitle: LocalizableText | AudioTrackListBoxConfig = {}) {
-    const config =
+    const config: AudioTrackListBoxConfig =
       typeof configOrTitle === 'string' || typeof configOrTitle === 'function'
         ? { title: configOrTitle }
         : configOrTitle;
@@ -24,8 +24,7 @@ export class AudioTrackListBox extends ListBox {
     super({
       ...config,
       listSelector: new AudioTrackSelectBox(config),
-      title: config.title,
-    } as ListBoxConfig);
+    });
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/lists/AudioTrackListBox.ts
+++ b/src/ts/components/lists/AudioTrackListBox.ts
@@ -8,7 +8,7 @@ import { LocalizableText } from '../../localization/i18n';
 export interface AudioTrackListBoxConfig extends Omit<ListBoxConfig, 'listSelector'> {}
 
 /**
- * A element that is similar to a select box where the user can select a subtitle
+ * An element that is similar to a select box where the user can select an audio track
  *
  * @category Components
  */

--- a/src/ts/components/lists/AudioTrackListBox.ts
+++ b/src/ts/components/lists/AudioTrackListBox.ts
@@ -4,6 +4,11 @@ import { AudioTrackSwitchHandler } from '../../utils/AudioTrackUtils';
 import { PlayerAPI } from 'bitmovin-player';
 import { AudioTrackSelectBox } from '../settings/AudioTrackSelectBox';
 import { LocalizableText } from '../../localization/i18n';
+import { ListSelectorConfig } from './ListSelector';
+
+export interface AudioTrackListBoxConfig extends ListSelectorConfig {
+  title?: LocalizableText;
+}
 
 /**
  * A element that is similar to a select box where the user can select a subtitle
@@ -11,11 +16,12 @@ import { LocalizableText } from '../../localization/i18n';
  * @category Components
  */
 export class AudioTrackListBox extends ListBox {
-  constructor(title?: LocalizableText) {
+  constructor(config: AudioTrackListBoxConfig = {}) {
     super({
-      listSelector: new AudioTrackSelectBox(),
-      title: title,
-    });
+      ...config,
+      listSelector: new AudioTrackSelectBox(config),
+      title: config.title,
+    } as ListBoxConfig);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/lists/AudioTrackListBox.ts
+++ b/src/ts/components/lists/AudioTrackListBox.ts
@@ -4,11 +4,8 @@ import { AudioTrackSwitchHandler } from '../../utils/AudioTrackUtils';
 import { PlayerAPI } from 'bitmovin-player';
 import { AudioTrackSelectBox } from '../settings/AudioTrackSelectBox';
 import { LocalizableText } from '../../localization/i18n';
-import { ListSelectorConfig } from './ListSelector';
 
-export interface AudioTrackListBoxConfig extends ListSelectorConfig {
-  title?: LocalizableText;
-}
+export interface AudioTrackListBoxConfig extends Omit<ListBoxConfig, 'listSelector'> {}
 
 /**
  * A element that is similar to a select box where the user can select a subtitle
@@ -16,7 +13,14 @@ export interface AudioTrackListBoxConfig extends ListSelectorConfig {
  * @category Components
  */
 export class AudioTrackListBox extends ListBox {
-  constructor(config: AudioTrackListBoxConfig = {}) {
+  constructor(title?: LocalizableText);
+  constructor(config?: AudioTrackListBoxConfig);
+  constructor(configOrTitle: LocalizableText | AudioTrackListBoxConfig = {}) {
+    const config =
+      typeof configOrTitle === 'string' || typeof configOrTitle === 'function'
+        ? { title: configOrTitle }
+        : configOrTitle;
+
     super({
       ...config,
       listSelector: new AudioTrackSelectBox(config),

--- a/src/ts/components/lists/ItemSelectionList.ts
+++ b/src/ts/components/lists/ItemSelectionList.ts
@@ -97,13 +97,8 @@ export class ItemSelectionList extends ListSelector<ListSelectorConfig> {
     }
   }
 
-  protected onItemAddedEvent(value: string) {
-    super.onItemAddedEvent(value);
-    this.updateDomItems(this.selectedItem);
-  }
-
-  protected onItemRemovedEvent(value: string) {
-    super.onItemRemovedEvent(value);
+  protected onItemsChangedEvent() {
+    super.onItemsChangedEvent();
     this.updateDomItems(this.selectedItem);
   }
 

--- a/src/ts/components/lists/ListBox.ts
+++ b/src/ts/components/lists/ListBox.ts
@@ -76,7 +76,8 @@ export class ListBox extends SettingsPanel<ListBoxConfig> {
     };
 
     const rebuildItems = () => {
-      const settingsPanelItems = this.settingsPanelPage.getComponents()
+      const settingsPanelItems = this.settingsPanelPage
+        .getComponents()
         .filter(component => component instanceof SettingsPanelSelectOption) as SettingsPanelItem<any>[];
 
       for (const settingsPanelItem of settingsPanelItems) {
@@ -94,9 +95,9 @@ export class ListBox extends SettingsPanel<ListBoxConfig> {
       this.onSettingsStateChangedEvent();
     };
 
-    let initialBuildDone = false;
+    let rebuiltDuringListSelectorConfigure = false;
     const onItemsChanged = () => {
-      initialBuildDone = true;
+      rebuiltDuringListSelectorConfigure = true;
       rebuildItems();
     };
 
@@ -105,7 +106,9 @@ export class ListBox extends SettingsPanel<ListBoxConfig> {
     this.settingsPanelPage.configure(player, uimanager);
     this.listSelector.configure(player, uimanager);
 
-    if (!initialBuildDone) {
+    // `listSelector.configure()` may synchronously emit `onItemsChanged`, so only run the fallback rebuild
+    // when configuration did not already trigger one.
+    if (!rebuiltDuringListSelectorConfigure) {
       rebuildItems();
     }
   }

--- a/src/ts/components/lists/ListBox.ts
+++ b/src/ts/components/lists/ListBox.ts
@@ -94,10 +94,19 @@ export class ListBox extends SettingsPanel<ListBoxConfig> {
       this.onSettingsStateChangedEvent();
     };
 
-    this.listSelector.onItemsChanged.subscribe(rebuildItems);
+    let initialBuildDone = false;
+    const onItemsChanged = () => {
+      initialBuildDone = true;
+      rebuildItems();
+    };
+
+    this.listSelector.onItemsChanged.subscribe(onItemsChanged);
 
     this.settingsPanelPage.configure(player, uimanager);
     this.listSelector.configure(player, uimanager);
-    rebuildItems();
+
+    if (!initialBuildDone) {
+      rebuildItems();
+    }
   }
 }

--- a/src/ts/components/lists/ListBox.ts
+++ b/src/ts/components/lists/ListBox.ts
@@ -55,8 +55,13 @@ export class ListBox extends SettingsPanel<ListBoxConfig> {
   public configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    const onItemAdded = (_: any, itemKey: string) => {
+    const createSelectOption = (itemKey: string) => {
       const item = this.listSelector.getItemForKey(itemKey);
+
+      if (!item) {
+        return null;
+      }
+
       const selectOption = new SettingsPanelSelectOption({
         label: item.label,
         labelStyle: LabelStyle.TextWithLeadingIcon,
@@ -66,31 +71,33 @@ export class ListBox extends SettingsPanel<ListBoxConfig> {
       });
 
       selectOption.configure(player, uimanager);
-      this.settingsPanelPage.addSettingsPanelItem(selectOption);
-      this.onSettingsStateChangedEvent();
+
+      return selectOption;
     };
 
-    const onItemRemoved = (_: any, itemKey: string) => {
-      const settingsPanelItem = this.settingsPanelPage.getComponents().find(item => {
-        if (!(item instanceof SettingsPanelSelectOption)) {
-          return false;
-        }
+    const rebuildItems = () => {
+      const settingsPanelItems = this.settingsPanelPage.getComponents()
+        .filter(component => component instanceof SettingsPanelSelectOption) as SettingsPanelItem<any>[];
 
-        return item.getConfig().settingsValue === itemKey;
-      });
-
-      if (!settingsPanelItem || !(settingsPanelItem instanceof SettingsPanelItem)) {
-        return;
+      for (const settingsPanelItem of settingsPanelItems) {
+        this.settingsPanelPage.removeSettingsPanelItem(settingsPanelItem);
       }
 
-      this.settingsPanelPage.removeSettingsPanelItem(settingsPanelItem);
+      for (const item of this.listSelector.getItems()) {
+        const selectOption = createSelectOption(item.key);
+
+        if (selectOption) {
+          this.settingsPanelPage.addSettingsPanelItem(selectOption);
+        }
+      }
+
       this.onSettingsStateChangedEvent();
     };
 
-    this.listSelector.onItemAdded.subscribe(onItemAdded);
-    this.listSelector.onItemRemoved.subscribe(onItemRemoved);
+    this.listSelector.onItemsChanged.subscribe(rebuildItems);
 
     this.settingsPanelPage.configure(player, uimanager);
     this.listSelector.configure(player, uimanager);
+    rebuildItems();
   }
 }

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -242,18 +242,25 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     const currentKeys = new Set(this.items.map(item => item.key));
     const nextKeys = new Set(normalizedItems.map(item => item.key));
 
-    this.items
+    const removedKeys = this.items
       .filter(item => !nextKeys.has(item.key))
-      .forEach(item => this.onItemRemovedEvent(item.key));
+      .map(item => item.key);
+
+    const addedKeys = normalizedItems
+      .filter(item => !currentKeys.has(item.key))
+      .map(item => item.key);
 
     this.items = normalizedItems;
 
-    normalizedItems
-      .filter(item => !currentKeys.has(item.key))
-      .forEach(item => this.onItemAddedEvent(item.key));
-
     if (this.selectedItem !== null && !nextKeys.has(this.selectedItem)) {
       this.selectedItem = null;
+    }
+
+    for (const key of removedKeys) {
+      this.onItemRemovedEvent(key);
+    }
+    for (const key of addedKeys) {
+      this.onItemAddedEvent(key);
     }
   }
 

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -45,17 +45,14 @@ export interface ListItemLabelTranslator {
 
 /**
  * Comparator function to define a custom display order for list items.
+ *
+ * Follows the same contract as {@link Array.prototype.sort}.
+ *
+ * @param listItemA the first item to compare
+ * @param listItemB the second item to compare
+ * @returns negative when A should come first, positive when B should come first, `0` if equal
  */
-export interface ListItemComparator {
-  /**
-   * Compares two list items and returns their relative order.
-   * Follows the same contract as {@link Array.prototype.sort}.
-   * @param {ListItem} listItemA the first item to compare
-   * @param {ListItem} listItemB the second item to compare
-   * @returns {number} negative when A should come first, positive when B should come first, 0 if equal
-   */
-  (listItemA: ListItem, listItemB: ListItem): number;
-}
+export type ListItemComparator = (listItemA: ListItem, listItemB: ListItem) => number;
 
 /**
  * Configuration interface for a {@link ListSelector}.

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -242,12 +242,15 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     const currentKeys = new Set(this.items.map(item => item.key));
     const nextKeys = new Set(normalizedItems.map(item => item.key));
 
+    // When a comparator is configured, items may be reordered on every sync. Treat the sync
+    // as a full rebuild so subscribers (e.g. DOM renderers) can reflect the new sorted order.
+    // Without a comparator, use a minimal diff (only add/remove changed items).
     const removedKeys = this.items
-      .filter(item => !nextKeys.has(item.key))
+      .filter(item => this.config.comparator || !nextKeys.has(item.key))
       .map(item => item.key);
 
     const addedKeys = normalizedItems
-      .filter(item => !currentKeys.has(item.key))
+      .filter(item => this.config.comparator || !currentKeys.has(item.key))
       .map(item => item.key);
 
     this.items = normalizedItems;

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -274,6 +274,11 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    * Synchronize the current items of this selector with the given ones. This will remove and add items selectively.
    * For each removed item the ItemRemovedEvent and for each added item the ItemAddedEvent will be triggered. Favour
    * this method over using clearItems and adding all items again afterwards.
+   *
+   * If the currently selected item is not present in `newItems`, the selection is cleared silently:
+   * no selection event is fired. Callers that need to preserve or restore selection should call
+   * {@link selectItem} after synchronizing.
+   *
    * @param newItems
    */
   synchronizeItems(newItems: ListItem[]): void {

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -140,6 +140,32 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     return false;
   }
 
+  private insertItem(normalizedItem: ListItem, sortedInsert: boolean): void {
+    if (this.config.comparator) {
+      const index = this.items.findIndex(existingItem => this.config.comparator(normalizedItem, existingItem) < 0);
+
+      if (index < 0) {
+        this.items.push(normalizedItem);
+      } else {
+        this.items.splice(index, 0, normalizedItem);
+      }
+
+      return;
+    }
+
+    if (sortedInsert) {
+      const index = this.items.findIndex(entry => entry.key > normalizedItem.key);
+      if (index < 0) {
+        this.items.push(normalizedItem);
+      } else {
+        this.items.splice(index, 0, normalizedItem);
+      }
+      return;
+    }
+
+    this.items.push(normalizedItem);
+  }
+
   /**
    * Returns all current items of this selector.
    * * @returns {ListItem[]}
@@ -177,17 +203,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
       this.onItemRemovedEvent(key);
     }
 
-    // Add the item to the list
-    if (sortedInsert) {
-      const index = this.items.findIndex(entry => entry.key > key);
-      if (index < 0) {
-        this.items.push(normalizedItem);
-      } else {
-        this.items.splice(index, 0, normalizedItem);
-      }
-    } else {
-      this.items.push(normalizedItem);
-    }
+    this.insertItem(normalizedItem, sortedInsert);
     this.onItemAddedEvent(key);
     this.onItemsChangedEvent();
   }

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -149,14 +149,8 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
 
   private insertItem(normalizedItem: ListItem, sortedInsert: boolean): void {
     if (this.config.comparator) {
-      const index = this.items.findIndex(existingItem => this.config.comparator(normalizedItem, existingItem) < 0);
-
-      if (index < 0) {
-        this.items.push(normalizedItem);
-      } else {
-        this.items.splice(index, 0, normalizedItem);
-      }
-
+      this.items.push(normalizedItem);
+      this.items.sort(this.config.comparator);
       return;
     }
 

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -44,6 +44,20 @@ export interface ListItemLabelTranslator {
 }
 
 /**
+ * Comparator function to define a custom display order for list items.
+ */
+export interface ListItemComparator {
+  /**
+   * Compares two list items and returns their relative order.
+   * Follows the same contract as {@link Array.prototype.sort}.
+   * @param {ListItem} listItemA the first item to compare
+   * @param {ListItem} listItemB the second item to compare
+   * @returns {number} negative when A should come first, positive when B should come first, 0 if equal
+   */
+  (listItemA: ListItem, listItemB: ListItem): number;
+}
+
+/**
  * Configuration interface for a {@link ListSelector}.
  *
  * @category Configs
@@ -52,6 +66,7 @@ export interface ListSelectorConfig extends ComponentConfig {
   items?: ListItem[];
   filter?: ListItemFilter;
   translator?: ListItemLabelTranslator;
+  comparator?: ListItemComparator;
 }
 
 export abstract class ListSelector<Config extends ListSelectorConfig> extends Component<ListSelectorConfig> {
@@ -78,6 +93,20 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     );
 
     this.items = this.config.items;
+  }
+
+  private normalizeItem(listItem: ListItem): ListItem | null {
+    const normalizedItem: ListItem = { ...listItem };
+
+    if (this.config.filter && !this.config.filter(normalizedItem)) {
+      return null;
+    }
+
+    if (this.config.translator) {
+      normalizedItem.label = this.config.translator(normalizedItem);
+    }
+
+    return normalizedItem;
   }
 
   private getItemIndex(key: string): number {
@@ -116,16 +145,9 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    * @param ariaLabel custom aria label for the listItem
    */
   addItem(key: string | null, label: LocalizableText, sortedInsert = false, ariaLabel = '') {
-    const listItem: ListItem = { key: key, label: label, ...(ariaLabel && { ariaLabel }) };
-
-    // Apply filter function
-    if (this.config.filter && !this.config.filter(listItem)) {
+    const normalizedItem = this.normalizeItem({ key: key, label: label, ...(ariaLabel && { ariaLabel }) });
+    if (!normalizedItem) {
       return;
-    }
-
-    // Apply translator function
-    if (this.config.translator) {
-      listItem.label = this.config.translator(listItem);
     }
 
     // Try to remove key first to get overwrite behavior and avoid duplicate keys
@@ -135,12 +157,12 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     if (sortedInsert) {
       const index = this.items.findIndex(entry => entry.key > key);
       if (index < 0) {
-        this.items.push(listItem);
+        this.items.push(normalizedItem);
       } else {
-        this.items.splice(index, 0, listItem);
+        this.items.splice(index, 0, normalizedItem);
       }
     } else {
-      this.items.push(listItem);
+      this.items.push(normalizedItem);
     }
     this.onItemAddedEvent(key);
   }
@@ -212,13 +234,30 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    * @param newItems
    */
   synchronizeItems(newItems: ListItem[]): void {
-    newItems
-      .filter(item => !this.hasItem(item.key))
-      .forEach(item => this.addItem(item.key, item.label, item.sortedInsert, item.ariaLabel));
+    const normalizedItems = newItems
+      .map(item => this.normalizeItem(item))
+      .filter((item): item is ListItem => item !== null);
+
+    if (this.config.comparator) {
+      normalizedItems.sort(this.config.comparator);
+    }
+
+    const currentKeys = new Set(this.items.map(item => item.key));
+    const nextKeys = new Set(normalizedItems.map(item => item.key));
 
     this.items
-      .filter(item => newItems.filter(i => i.key === item.key).length === 0)
-      .forEach(item => this.removeItem(item.key));
+      .filter(item => !nextKeys.has(item.key))
+      .forEach(item => this.onItemRemovedEvent(item.key));
+
+    this.items = normalizedItems;
+
+    normalizedItems
+      .filter(item => !currentKeys.has(item.key))
+      .forEach(item => this.onItemAddedEvent(item.key));
+
+    if (this.selectedItem !== null && !nextKeys.has(this.selectedItem)) {
+      this.selectedItem = null;
+    }
   }
 
   /**

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -301,7 +301,6 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     const nextKeys = new Set(normalizedItems.map(item => item.key));
 
     const removedKeys = this.items.filter(item => !nextKeys.has(item.key)).map(item => item.key);
-
     const addedKeys = normalizedItems.filter(item => !currentKeys.has(item.key)).map(item => item.key);
 
     this.items = normalizedItems;
@@ -360,6 +359,14 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     this.listSelectorEvents.onItemRemoved.dispatch(this, key);
   }
 
+  /**
+   * Fired after the selector's effective item state has changed.
+   *
+   * This includes item additions/removals, order changes, localized label changes,
+   * and aria-label changes. The event is dispatched only after `items` and
+   * `selectedItem` have been fully synchronized, so listeners always observe
+   * the final state.
+   */
   protected onItemsChangedEvent() {
     this.listSelectorEvents.onItemsChanged.dispatch(this);
   }
@@ -406,11 +413,13 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
   }
 
   /**
-   * Gets the event that is fired when the effective items collection changes.
+   * Gets the event that is fired after the selector's effective item state has changed.
    *
-   * Use this to react to list-wide changes such as additions, removals, reordering, or
-   * item property updates that should trigger a rebuild from {@link getItems()}.
-   *
+   * Includes additions/removals, order changes, localized label changes, and
+   * aria-label changes. Dispatched after internal state has been fully synchronized.
+   * 
+   * Use this to rebuild from {@link getItems()} when the effective list changes.
+   * 
    * @returns {Event<ListSelector<Config>, NoArgs>}
    */
   get onItemsChanged(): Event<ListSelector<Config>, NoArgs> {

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -68,7 +68,7 @@ export interface ListSelectorConfig extends ComponentConfig {
    * Optional comparator to control the display order of list items.
    *
    * Requires a custom UI. The default {@link UIFactory} presets do not expose this option.
-   * 
+   *
    * Note: For subtitle UIs, the built-in `Off` option is pinned at the top regardless of the
    * comparator result.
    */
@@ -102,6 +102,9 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     this.items = this.config.items;
   }
 
+  /**
+   * Applies list-item filtering and label translation before the item enters the effective selector state.
+   */
   private normalizeItem(listItem: ListItem): ListItem | null {
     const normalizedItem: ListItem = { ...listItem };
 
@@ -126,6 +129,9 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     return -1;
   }
 
+  /**
+   * Detects whether the effective UI items changed, including localized labels and aria labels.
+   */
   private haveItemsChanged(previousItems: ListItem[], nextItems: ListItem[]): boolean {
     if (previousItems.length !== nextItems.length) {
       return true;
@@ -294,13 +300,9 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     const currentKeys = new Set(this.items.map(item => item.key));
     const nextKeys = new Set(normalizedItems.map(item => item.key));
 
-    const removedKeys = this.items
-      .filter(item => !nextKeys.has(item.key))
-      .map(item => item.key);
+    const removedKeys = this.items.filter(item => !nextKeys.has(item.key)).map(item => item.key);
 
-    const addedKeys = normalizedItems
-      .filter(item => !currentKeys.has(item.key))
-      .map(item => item.key);
+    const addedKeys = normalizedItems.filter(item => !currentKeys.has(item.key)).map(item => item.key);
 
     this.items = normalizedItems;
 

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -1,5 +1,6 @@
 import { Component, ComponentConfig } from '../Component';
 import { EventDispatcher, Event } from '../../EventDispatcher';
+import { NoArgs } from '../../EventDispatcher';
 import { ArrayUtils } from '../../utils/ArrayUtils';
 import { LocalizableText } from '../../localization/i18n';
 
@@ -73,6 +74,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
   private listSelectorEvents = {
     onItemAdded: new EventDispatcher<ListSelector<Config>, string>(),
     onItemRemoved: new EventDispatcher<ListSelector<Config>, string>(),
+    onItemsChanged: new EventDispatcher<ListSelector<Config>, NoArgs>(),
     onItemSelected: new EventDispatcher<ListSelector<Config>, string>(),
     onItemSelectionChanged: new EventDispatcher<ListSelector<Config>, string>(),
   };
@@ -116,6 +118,28 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     return -1;
   }
 
+  private haveItemsChanged(previousItems: ListItem[], nextItems: ListItem[]): boolean {
+    if (previousItems.length !== nextItems.length) {
+      return true;
+    }
+
+    for (let i = 0; i < previousItems.length; i++) {
+      const previousItem = previousItems[i];
+      const nextItem = nextItems[i];
+
+      if (
+        previousItem.key !== nextItem.key ||
+        previousItem.label !== nextItem.label ||
+        previousItem.sortedInsert !== nextItem.sortedInsert ||
+        previousItem.ariaLabel !== nextItem.ariaLabel
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   /**
    * Returns all current items of this selector.
    * * @returns {ListItem[]}
@@ -147,8 +171,11 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
       return;
     }
 
-    // Try to remove key first to get overwrite behavior and avoid duplicate keys
-    this.removeItem(key); // This will trigger an ItemRemoved and an ItemAdded event
+    const existingIndex = this.getItemIndex(key);
+    if (existingIndex > -1) {
+      ArrayUtils.remove(this.items, this.items[existingIndex]);
+      this.onItemRemovedEvent(key);
+    }
 
     // Add the item to the list
     if (sortedInsert) {
@@ -162,6 +189,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
       this.items.push(normalizedItem);
     }
     this.onItemAddedEvent(key);
+    this.onItemsChangedEvent();
   }
 
   /**
@@ -174,6 +202,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     if (index > -1) {
       ArrayUtils.remove(this.items, this.items[index]);
       this.onItemRemovedEvent(key);
+      this.onItemsChangedEvent();
       return true;
     }
 
@@ -239,18 +268,16 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
       normalizedItems.sort(this.config.comparator);
     }
 
+    const itemsChanged = this.haveItemsChanged(this.items, normalizedItems);
     const currentKeys = new Set(this.items.map(item => item.key));
     const nextKeys = new Set(normalizedItems.map(item => item.key));
 
-    // When a comparator is configured, items may be reordered on every sync. Treat the sync
-    // as a full rebuild so subscribers (e.g. DOM renderers) can reflect the new sorted order.
-    // Without a comparator, use a minimal diff (only add/remove changed items).
     const removedKeys = this.items
-      .filter(item => this.config.comparator || !nextKeys.has(item.key))
+      .filter(item => !nextKeys.has(item.key))
       .map(item => item.key);
 
     const addedKeys = normalizedItems
-      .filter(item => this.config.comparator || !currentKeys.has(item.key))
+      .filter(item => !currentKeys.has(item.key))
       .map(item => item.key);
 
     this.items = normalizedItems;
@@ -265,12 +292,19 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     for (const key of addedKeys) {
       this.onItemAddedEvent(key);
     }
+    if (itemsChanged) {
+      this.onItemsChangedEvent();
+    }
   }
 
   /**
    * Removes all items from this selector.
    */
   clearItems() {
+    if (this.items.length === 0) {
+      return;
+    }
+
     // local copy for iteration after clear
     const items = this.items;
     // clear items
@@ -283,6 +317,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
     for (const item of items) {
       this.onItemRemovedEvent(item.key);
     }
+    this.onItemsChangedEvent();
   }
 
   /**
@@ -299,6 +334,10 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
 
   protected onItemRemovedEvent(key: string) {
     this.listSelectorEvents.onItemRemoved.dispatch(this, key);
+  }
+
+  protected onItemsChangedEvent() {
+    this.listSelectorEvents.onItemsChanged.dispatch(this);
   }
 
   protected onItemSelectedEvent(key: string) {
@@ -340,6 +379,18 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
    */
   get onItemRemoved(): Event<ListSelector<Config>, string> {
     return this.listSelectorEvents.onItemRemoved.getEvent();
+  }
+
+  /**
+   * Gets the event that is fired when the effective items collection changes.
+   *
+   * Use this to react to list-wide changes such as additions, removals, reordering, or
+   * item property updates that should trigger a rebuild from {@link getItems()}.
+   *
+   * @returns {Event<ListSelector<Config>, NoArgs>}
+   */
+  get onItemsChanged(): Event<ListSelector<Config>, NoArgs> {
+    return this.listSelectorEvents.onItemsChanged.getEvent();
   }
 
   /**

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -2,7 +2,7 @@ import { Component, ComponentConfig } from '../Component';
 import { EventDispatcher, Event } from '../../EventDispatcher';
 import { NoArgs } from '../../EventDispatcher';
 import { ArrayUtils } from '../../utils/ArrayUtils';
-import { LocalizableText } from '../../localization/i18n';
+import { i18n, LocalizableText } from '../../localization/i18n';
 
 /**
  * A map of items (key/value -> label} for a {@link ListSelector} in a {@link ListSelectorConfig}.
@@ -129,7 +129,7 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
 
       if (
         previousItem.key !== nextItem.key ||
-        previousItem.label !== nextItem.label ||
+        i18n.performLocalization(previousItem.label) !== i18n.performLocalization(nextItem.label) ||
         previousItem.sortedInsert !== nextItem.sortedInsert ||
         previousItem.ariaLabel !== nextItem.ariaLabel
       ) {

--- a/src/ts/components/lists/ListSelector.ts
+++ b/src/ts/components/lists/ListSelector.ts
@@ -64,6 +64,14 @@ export interface ListSelectorConfig extends ComponentConfig {
   items?: ListItem[];
   filter?: ListItemFilter;
   translator?: ListItemLabelTranslator;
+  /**
+   * Optional comparator to control the display order of list items.
+   *
+   * Requires a custom UI. The default {@link UIFactory} presets do not expose this option.
+   * 
+   * Note: For subtitle UIs, the built-in `Off` option is pinned at the top regardless of the
+   * comparator result.
+   */
   comparator?: ListItemComparator;
 }
 
@@ -130,7 +138,6 @@ export abstract class ListSelector<Config extends ListSelectorConfig> extends Co
       if (
         previousItem.key !== nextItem.key ||
         i18n.performLocalization(previousItem.label) !== i18n.performLocalization(nextItem.label) ||
-        previousItem.sortedInsert !== nextItem.sortedInsert ||
         previousItem.ariaLabel !== nextItem.ariaLabel
       ) {
         return true;

--- a/src/ts/components/lists/SubtitleListBox.ts
+++ b/src/ts/components/lists/SubtitleListBox.ts
@@ -19,7 +19,7 @@ export class SubtitleListBox extends ListBox {
   constructor(title?: LocalizableText);
   constructor(config?: SubtitleListBoxConfig);
   constructor(configOrTitle: LocalizableText | SubtitleListBoxConfig = {}) {
-    const config =
+    const config: SubtitleListBoxConfig =
       typeof configOrTitle === 'string' || typeof configOrTitle === 'function'
         ? { title: configOrTitle }
         : configOrTitle;
@@ -27,8 +27,7 @@ export class SubtitleListBox extends ListBox {
     super({
       ...config,
       listSelector: new SubtitleSelectBox(config),
-      title: config.title,
-    } as ListBoxConfig);
+    });
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/lists/SubtitleListBox.ts
+++ b/src/ts/components/lists/SubtitleListBox.ts
@@ -4,11 +4,8 @@ import { SubtitleSwitchHandler } from '../../utils/SubtitleUtils';
 import { PlayerAPI } from 'bitmovin-player';
 import { SubtitleSelectBox } from '../settings/SubtitleSelectBox';
 import { LocalizableText } from '../../localization/i18n';
-import { ListSelectorConfig } from './ListSelector';
 
-export interface SubtitleListBoxConfig extends ListSelectorConfig {
-  title?: LocalizableText;
-}
+export interface SubtitleListBoxConfig extends Omit<ListBoxConfig, 'listSelector'> {}
 
 /**
  * A element that is similar to a select box where the user can select a subtitle
@@ -19,7 +16,14 @@ export interface SubtitleListBoxConfig extends ListSelectorConfig {
  * @category Components
  */
 export class SubtitleListBox extends ListBox {
-  constructor(config: SubtitleListBoxConfig = {}) {
+  constructor(title?: LocalizableText);
+  constructor(config?: SubtitleListBoxConfig);
+  constructor(configOrTitle: LocalizableText | SubtitleListBoxConfig = {}) {
+    const config =
+      typeof configOrTitle === 'string' || typeof configOrTitle === 'function'
+        ? { title: configOrTitle }
+        : configOrTitle;
+
     super({
       ...config,
       listSelector: new SubtitleSelectBox(config),

--- a/src/ts/components/lists/SubtitleListBox.ts
+++ b/src/ts/components/lists/SubtitleListBox.ts
@@ -8,7 +8,7 @@ import { LocalizableText } from '../../localization/i18n';
 export interface SubtitleListBoxConfig extends Omit<ListBoxConfig, 'listSelector'> {}
 
 /**
- * A element that is similar to a select box where the user can select a subtitle
+ * An element that is similar to a select box where the user can select a subtitle
  *
  * When a comparator is configured, the built-in "Off" option remains fixed at the top
  * and is not reordered together with the subtitle tracks.

--- a/src/ts/components/lists/SubtitleListBox.ts
+++ b/src/ts/components/lists/SubtitleListBox.ts
@@ -13,6 +13,9 @@ export interface SubtitleListBoxConfig extends ListSelectorConfig {
 /**
  * A element that is similar to a select box where the user can select a subtitle
  *
+ * When a comparator is configured, the built-in "Off" option remains fixed at the top
+ * and is not reordered together with the subtitle tracks.
+ *
  * @category Components
  */
 export class SubtitleListBox extends ListBox {

--- a/src/ts/components/lists/SubtitleListBox.ts
+++ b/src/ts/components/lists/SubtitleListBox.ts
@@ -4,6 +4,11 @@ import { SubtitleSwitchHandler } from '../../utils/SubtitleUtils';
 import { PlayerAPI } from 'bitmovin-player';
 import { SubtitleSelectBox } from '../settings/SubtitleSelectBox';
 import { LocalizableText } from '../../localization/i18n';
+import { ListSelectorConfig } from './ListSelector';
+
+export interface SubtitleListBoxConfig extends ListSelectorConfig {
+  title?: LocalizableText;
+}
 
 /**
  * A element that is similar to a select box where the user can select a subtitle
@@ -11,11 +16,12 @@ import { LocalizableText } from '../../localization/i18n';
  * @category Components
  */
 export class SubtitleListBox extends ListBox {
-  constructor(title?: LocalizableText) {
+  constructor(config: SubtitleListBoxConfig = {}) {
     super({
-      listSelector: new SubtitleSelectBox(),
-      title: title,
-    });
+      ...config,
+      listSelector: new SubtitleSelectBox(config),
+      title: config.title,
+    } as ListBoxConfig);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/settings/SelectBox.ts
+++ b/src/ts/components/settings/SelectBox.ts
@@ -126,13 +126,8 @@ export class SelectBox extends ListSelector<ListSelectorConfig> {
     }
   }
 
-  protected onItemAddedEvent(value: string) {
-    super.onItemAddedEvent(value);
-    this.updateDomItems(this.selectedItem);
-  }
-
-  protected onItemRemovedEvent(value: string) {
-    super.onItemRemovedEvent(value);
+  protected onItemsChangedEvent() {
+    super.onItemsChangedEvent();
     this.updateDomItems(this.selectedItem);
   }
 

--- a/src/ts/components/settings/SubtitleSelectBox.ts
+++ b/src/ts/components/settings/SubtitleSelectBox.ts
@@ -17,6 +17,12 @@ export class SubtitleSelectBox extends SelectBox {
   constructor(config: ListSelectorConfig = {}) {
     const comparator = config.comparator
       ? (itemA: ListItem, itemB: ListItem) => {
+          if (
+            itemA.key === SubtitleSwitchHandler.SUBTITLES_OFF_KEY &&
+            itemB.key === SubtitleSwitchHandler.SUBTITLES_OFF_KEY
+          ) {
+            return 0;
+          }
           if (itemA.key === SubtitleSwitchHandler.SUBTITLES_OFF_KEY) {
             return -1;
           }

--- a/src/ts/components/settings/SubtitleSelectBox.ts
+++ b/src/ts/components/settings/SubtitleSelectBox.ts
@@ -8,6 +8,9 @@ import { i18n } from '../../localization/i18n';
 /**
  * A select box providing a selection between available subtitle and caption tracks.
  *
+ * When a comparator is configured, the built-in "Off" option remains fixed at the top
+ * and is not reordered together with the subtitle tracks.
+ *
  * @category Components
  */
 export class SubtitleSelectBox extends SelectBox {

--- a/src/ts/components/settings/SubtitleSelectBox.ts
+++ b/src/ts/components/settings/SubtitleSelectBox.ts
@@ -17,10 +17,10 @@ export class SubtitleSelectBox extends SelectBox {
   constructor(config: ListSelectorConfig = {}) {
     const comparator = config.comparator
       ? (itemA: ListItem, itemB: ListItem) => {
-          if (itemA.key === 'null') {
+          if (itemA.key === SubtitleSwitchHandler.SUBTITLES_OFF_KEY) {
             return -1;
           }
-          if (itemB.key === 'null') {
+          if (itemB.key === SubtitleSwitchHandler.SUBTITLES_OFF_KEY) {
             return 1;
           }
           return config.comparator(itemA, itemB);

--- a/src/ts/components/settings/SubtitleSelectBox.ts
+++ b/src/ts/components/settings/SubtitleSelectBox.ts
@@ -1,5 +1,5 @@
 import { SelectBox } from './SelectBox';
-import { ListSelectorConfig } from '../lists/ListSelector';
+import { ListItem, ListSelectorConfig } from '../lists/ListSelector';
 import { UIInstanceManager } from '../../UIManager';
 import { SubtitleSwitchHandler } from '../../utils/SubtitleUtils';
 import { PlayerAPI } from 'bitmovin-player';
@@ -12,10 +12,28 @@ import { i18n } from '../../localization/i18n';
  */
 export class SubtitleSelectBox extends SelectBox {
   constructor(config: ListSelectorConfig = {}) {
-    super(config);
+    const comparator = config.comparator
+      ? (itemA: ListItem, itemB: ListItem) => {
+          if (itemA.key === 'null') {
+            return -1;
+          }
+          if (itemB.key === 'null') {
+            return 1;
+          }
+          return config.comparator(itemA, itemB);
+        }
+      : undefined;
+
+    super({
+      ...config,
+      comparator,
+    });
 
     this.config = this.mergeConfig(
-      config,
+      {
+        ...config,
+        comparator,
+      },
       {
         cssClasses: ['ui-subtitleselectbox'],
         ariaLabel: i18n.getLocalizer('subtitle.select'),

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -117,8 +117,8 @@ export { WindowColorSelectBox } from './components/settings/subtitlesettings/Win
 export { WindowOpacitySelectBox } from './components/settings/subtitlesettings/WindowOpacitySelectBox';
 export { SubtitleSettingsResetButton } from './components/settings/subtitlesettings/SubtitleSettingsResetButton';
 export { ListBox, ListBoxConfig } from './components/lists/ListBox';
-export { SubtitleListBox } from './components/lists/SubtitleListBox';
-export { AudioTrackListBox } from './components/lists/AudioTrackListBox';
+export { SubtitleListBox, SubtitleListBoxConfig } from './components/lists/SubtitleListBox';
+export { AudioTrackListBox, AudioTrackListBoxConfig } from './components/lists/AudioTrackListBox';
 export { SettingsPanelPage, SettingsPanelPageConfig } from './components/settings/SettingsPanelPage';
 export { SettingsPanelPageBackButton } from './components/settings/SettingsPanelPageBackButton';
 export { SettingsPanelPageOpenButton } from './components/settings/SettingsPanelPageOpenButton';

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -137,6 +137,7 @@ export {
   ListSelector,
   ListSelectorConfig,
   ListItem,
+  ListItemComparator,
   ListItemFilter,
   ListItemLabelTranslator,
 } from './components/lists/ListSelector';

--- a/src/ts/utils/AudioTrackUtils.ts
+++ b/src/ts/utils/AudioTrackUtils.ts
@@ -66,16 +66,12 @@ export class AudioTrackSwitchHandler {
 
   private refreshAudioTracks = () => {
     const previouslySelectedAudioTrack = this.listElement.getSelectedItem();
-    const comparator = this.uimanager.getConfig().audioTrackComparator;
-    const audioTracks = comparator
-      ? this.player.getAvailableAudio().slice().sort(comparator)
-      : this.player.getAvailableAudio();
     const audioTrackToListItem = (audioTrack: AudioTrack): ListItem => {
       return { key: audioTrack.id, label: audioTrack.label };
     };
 
     this.listElement.clearItems();
-    this.listElement.synchronizeItems(audioTracks.map(audioTrackToListItem));
+    this.listElement.synchronizeItems(this.player.getAvailableAudio().map(audioTrackToListItem));
     if (this.player.getAudio()) {
       this.selectCurrentAudioTrack();
     } else if (previouslySelectedAudioTrack && this.listElement.hasItem(previouslySelectedAudioTrack)) {

--- a/src/ts/utils/AudioTrackUtils.ts
+++ b/src/ts/utils/AudioTrackUtils.ts
@@ -48,20 +48,26 @@ export class AudioTrackSwitchHandler {
     return this.listElement.getConfig().comparator != null;
   }
 
+  private audioTrackToListItem(audioTrack: AudioTrack): ListItem {
+    return { key: audioTrack.id, label: audioTrack.label };
+  }
+
   private addAudioTrack = (event: AudioTrackEvent) => {
-    const audioTrack = event.track;
+    const addedAudioTrack = event.track;
 
     if (!this.hasComparator()) {
-      if (!this.listElement.hasItem(audioTrack.id)) {
-        this.listElement.addItem(audioTrack.id, i18n.getLocalizer(audioTrack.label), true);
+      if (!this.listElement.hasItem(addedAudioTrack.id)) {
+        this.listElement.addItem(addedAudioTrack.id, i18n.getLocalizer(addedAudioTrack.label), true);
       }
       return;
     }
 
-    const audioTracks = this.player.getAvailableAudio();
-    const mergedTracks = audioTracks.some(track => track.id === audioTrack.id) ? audioTracks : [...audioTracks, audioTrack];
+    const availableAudioTracks = this.player.getAvailableAudio();
+    const mergedTracks = availableAudioTracks.some(track => track.id === addedAudioTrack.id)
+      ? availableAudioTracks
+      : [...availableAudioTracks, addedAudioTrack];
 
-    this.listElement.synchronizeItems(mergedTracks.map(track => ({ key: track.id, label: track.label })));
+    this.listElement.synchronizeItems(mergedTracks.map(audioTrack => this.audioTrackToListItem(audioTrack)));
     this.selectCurrentAudioTrack();
   };
 
@@ -83,11 +89,10 @@ export class AudioTrackSwitchHandler {
 
   private refreshAudioTracks = () => {
     const previouslySelectedAudioTrack = this.listElement.getSelectedItem();
-    const audioTrackToListItem = (audioTrack: AudioTrack): ListItem => {
-      return { key: audioTrack.id, label: audioTrack.label };
-    };
 
-    this.listElement.synchronizeItems(this.player.getAvailableAudio().map(audioTrackToListItem));
+    this.listElement.synchronizeItems(
+      this.player.getAvailableAudio().map(audioTrack => this.audioTrackToListItem(audioTrack)),
+    );
     if (this.player.getAudio()) {
       this.selectCurrentAudioTrack();
     } else if (previouslySelectedAudioTrack && this.listElement.hasItem(previouslySelectedAudioTrack)) {

--- a/src/ts/utils/AudioTrackUtils.ts
+++ b/src/ts/utils/AudioTrackUtils.ts
@@ -45,7 +45,7 @@ export class AudioTrackSwitchHandler {
   }
 
   private hasComparator(): boolean {
-    return typeof this.listElement.getConfig === 'function' && this.listElement.getConfig().comparator != null;
+    return this.listElement.getConfig().comparator != null;
   }
 
   private addAudioTrack = (event: AudioTrackEvent) => {

--- a/src/ts/utils/AudioTrackUtils.ts
+++ b/src/ts/utils/AudioTrackUtils.ts
@@ -65,6 +65,7 @@ export class AudioTrackSwitchHandler {
   };
 
   private refreshAudioTracks = () => {
+    const previouslySelectedAudioTrack = this.listElement.getSelectedItem();
     const comparator = this.uimanager.getConfig().audioTrackComparator;
     const audioTracks = comparator
       ? this.player.getAvailableAudio().slice().sort(comparator)
@@ -75,6 +76,10 @@ export class AudioTrackSwitchHandler {
 
     this.listElement.clearItems();
     this.listElement.synchronizeItems(audioTracks.map(audioTrackToListItem));
-    this.selectCurrentAudioTrack();
+    if (this.player.getAudio()) {
+      this.selectCurrentAudioTrack();
+    } else if (previouslySelectedAudioTrack && this.listElement.hasItem(previouslySelectedAudioTrack)) {
+      this.listElement.selectItem(previouslySelectedAudioTrack);
+    }
   };
 }

--- a/src/ts/utils/AudioTrackUtils.ts
+++ b/src/ts/utils/AudioTrackUtils.ts
@@ -70,11 +70,12 @@ export class AudioTrackSwitchHandler {
       return { key: audioTrack.id, label: audioTrack.label };
     };
 
-    this.listElement.clearItems();
     this.listElement.synchronizeItems(this.player.getAvailableAudio().map(audioTrackToListItem));
     if (this.player.getAudio()) {
       this.selectCurrentAudioTrack();
     } else if (previouslySelectedAudioTrack && this.listElement.hasItem(previouslySelectedAudioTrack)) {
+      // HLS streams don't always report the selected audio track via getAudio() after a refresh.
+      // If getAudio() is unavailable, restore the previously selected track if it still exists.
       this.listElement.selectItem(previouslySelectedAudioTrack);
     }
   };

--- a/src/ts/utils/AudioTrackUtils.ts
+++ b/src/ts/utils/AudioTrackUtils.ts
@@ -44,11 +44,8 @@ export class AudioTrackSwitchHandler {
     this.uimanager.getConfig().events.onUpdated.subscribe(this.refreshAudioTracks);
   }
 
-  private addAudioTrack = (event: AudioTrackEvent) => {
-    const audioTrack = event.track;
-    if (!this.listElement.hasItem(audioTrack.id)) {
-      this.listElement.addItem(audioTrack.id, i18n.getLocalizer(audioTrack.label), true);
-    }
+  private addAudioTrack = (_event: AudioTrackEvent) => {
+    this.refreshAudioTracks();
   };
 
   private removeAudioTrack = (event: AudioTrackEvent) => {
@@ -68,11 +65,15 @@ export class AudioTrackSwitchHandler {
   };
 
   private refreshAudioTracks = () => {
-    const audioTracks = this.player.getAvailableAudio();
+    const comparator = this.uimanager.getConfig().audioTrackComparator;
+    const audioTracks = comparator
+      ? this.player.getAvailableAudio().slice().sort(comparator)
+      : this.player.getAvailableAudio();
     const audioTrackToListItem = (audioTrack: AudioTrack): ListItem => {
       return { key: audioTrack.id, label: audioTrack.label };
     };
 
+    this.listElement.clearItems();
     this.listElement.synchronizeItems(audioTracks.map(audioTrackToListItem));
     this.selectCurrentAudioTrack();
   };

--- a/src/ts/utils/AudioTrackUtils.ts
+++ b/src/ts/utils/AudioTrackUtils.ts
@@ -44,8 +44,25 @@ export class AudioTrackSwitchHandler {
     this.uimanager.getConfig().events.onUpdated.subscribe(this.refreshAudioTracks);
   }
 
-  private addAudioTrack = (_event: AudioTrackEvent) => {
-    this.refreshAudioTracks();
+  private hasComparator(): boolean {
+    return typeof this.listElement.getConfig === 'function' && this.listElement.getConfig().comparator != null;
+  }
+
+  private addAudioTrack = (event: AudioTrackEvent) => {
+    const audioTrack = event.track;
+
+    if (!this.hasComparator()) {
+      if (!this.listElement.hasItem(audioTrack.id)) {
+        this.listElement.addItem(audioTrack.id, i18n.getLocalizer(audioTrack.label), true);
+      }
+      return;
+    }
+
+    const audioTracks = this.player.getAvailableAudio();
+    const mergedTracks = audioTracks.some(track => track.id === audioTrack.id) ? audioTracks : [...audioTracks, audioTrack];
+
+    this.listElement.synchronizeItems(mergedTracks.map(track => ({ key: track.id, label: track.label })));
+    this.selectCurrentAudioTrack();
   };
 
   private removeAudioTrack = (event: AudioTrackEvent) => {

--- a/src/ts/utils/SubtitleUtils.ts
+++ b/src/ts/utils/SubtitleUtils.ts
@@ -60,6 +60,10 @@ export class SubtitleSwitchHandler {
     return this.listElement.getConfig().comparator != null;
   }
 
+  private subtitleToListItem(subtitle: SubtitleTrack): ListItem {
+    return { key: subtitle.id, label: subtitle.label };
+  }
+
   private onSubtitleEnabled = (event: SubtitleEvent) => {
     this.selectCurrentSubtitle();
 
@@ -73,17 +77,19 @@ export class SubtitleSwitchHandler {
   };
 
   private addSubtitle = (event: SubtitleEvent) => {
-    const subtitle = event.subtitle;
+    const addedSubtitle = event.subtitle;
 
     if (!this.hasComparator()) {
-      if (!this.listElement.hasItem(subtitle.id)) {
-        this.listElement.addItem(subtitle.id, subtitle.label);
+      if (!this.listElement.hasItem(addedSubtitle.id)) {
+        this.listElement.addItem(addedSubtitle.id, addedSubtitle.label);
       }
       return;
     }
 
-    const subtitles = this.player.subtitles.list();
-    const mergedSubtitles = subtitles.some(track => track.id === subtitle.id) ? subtitles : [...subtitles, subtitle];
+    const availableSubtitles = this.player.subtitles.list();
+    const mergedSubtitles = availableSubtitles.some(track => track.id === addedSubtitle.id)
+      ? availableSubtitles
+      : [...availableSubtitles, addedSubtitle];
     const offListItem: ListItem = {
       key: SubtitleSwitchHandler.SUBTITLES_OFF_KEY,
       label: i18n.getLocalizer('off'),
@@ -91,7 +97,7 @@ export class SubtitleSwitchHandler {
 
     this.listElement.synchronizeItems([
       offListItem,
-      ...mergedSubtitles.map(track => ({ key: track.id, label: track.label })),
+      ...mergedSubtitles.map(subtitle => this.subtitleToListItem(subtitle)),
     ]);
     this.selectCurrentSubtitle();
   };
@@ -133,11 +139,10 @@ export class SubtitleSwitchHandler {
       label: i18n.getLocalizer('off'),
     };
 
-    const subtitleToListItem = (subtitle: SubtitleTrack): ListItem => {
-      return { key: subtitle.id, label: subtitle.label };
-    };
-
-    this.listElement.synchronizeItems([offListItem, ...this.player.subtitles.list().map(subtitleToListItem)]);
+    this.listElement.synchronizeItems([
+      offListItem,
+      ...this.player.subtitles.list().map(subtitle => this.subtitleToListItem(subtitle)),
+    ]);
     this.selectCurrentSubtitle();
   };
 }

--- a/src/ts/utils/SubtitleUtils.ts
+++ b/src/ts/utils/SubtitleUtils.ts
@@ -56,6 +56,10 @@ export class SubtitleSwitchHandler {
     this.uimanager.getConfig().events.onUpdated.subscribe(this.refreshSubtitles);
   }
 
+  private hasComparator(): boolean {
+    return typeof this.listElement.getConfig === 'function' && this.listElement.getConfig().comparator != null;
+  }
+
   private onSubtitleEnabled = (event: SubtitleEvent) => {
     this.selectCurrentSubtitle();
 
@@ -68,8 +72,28 @@ export class SubtitleSwitchHandler {
     }
   };
 
-  private addSubtitle = (_event: SubtitleEvent) => {
-    this.refreshSubtitles();
+  private addSubtitle = (event: SubtitleEvent) => {
+    const subtitle = event.subtitle;
+
+    if (!this.hasComparator()) {
+      if (!this.listElement.hasItem(subtitle.id)) {
+        this.listElement.addItem(subtitle.id, subtitle.label);
+      }
+      return;
+    }
+
+    const subtitles = this.player.subtitles.list();
+    const mergedSubtitles = subtitles.some(track => track.id === subtitle.id) ? subtitles : [...subtitles, subtitle];
+    const offListItem: ListItem = {
+      key: SubtitleSwitchHandler.SUBTITLES_OFF_KEY,
+      label: i18n.getLocalizer('off'),
+    };
+
+    this.listElement.synchronizeItems([
+      offListItem,
+      ...mergedSubtitles.map(track => ({ key: track.id, label: track.label })),
+    ]);
+    this.selectCurrentSubtitle();
   };
 
   private removeSubtitle = (event: SubtitleEvent) => {

--- a/src/ts/utils/SubtitleUtils.ts
+++ b/src/ts/utils/SubtitleUtils.ts
@@ -68,11 +68,8 @@ export class SubtitleSwitchHandler {
     }
   };
 
-  private addSubtitle = (event: SubtitleEvent) => {
-    const subtitle = event.subtitle;
-    if (!this.listElement.hasItem(subtitle.id)) {
-      this.listElement.addItem(subtitle.id, subtitle.label);
-    }
+  private addSubtitle = (_event: SubtitleEvent) => {
+    this.refreshSubtitles();
   };
 
   private removeSubtitle = (event: SubtitleEvent) => {
@@ -112,11 +109,15 @@ export class SubtitleSwitchHandler {
       label: i18n.getLocalizer('off'),
     };
 
-    const subtitles = this.player.subtitles.list();
+    const comparator = this.uimanager.getConfig().subtitleComparator;
+    const subtitles = comparator
+      ? this.player.subtitles.list().slice().sort(comparator)
+      : this.player.subtitles.list();
     const subtitleToListItem = (subtitle: SubtitleTrack): ListItem => {
       return { key: subtitle.id, label: subtitle.label };
     };
 
+    this.listElement.clearItems();
     this.listElement.synchronizeItems([offListItem, ...subtitles.map(subtitleToListItem)]);
     this.selectCurrentSubtitle();
   };

--- a/src/ts/utils/SubtitleUtils.ts
+++ b/src/ts/utils/SubtitleUtils.ts
@@ -109,16 +109,12 @@ export class SubtitleSwitchHandler {
       label: i18n.getLocalizer('off'),
     };
 
-    const comparator = this.uimanager.getConfig().subtitleComparator;
-    const subtitles = comparator
-      ? this.player.subtitles.list().slice().sort(comparator)
-      : this.player.subtitles.list();
     const subtitleToListItem = (subtitle: SubtitleTrack): ListItem => {
       return { key: subtitle.id, label: subtitle.label };
     };
 
     this.listElement.clearItems();
-    this.listElement.synchronizeItems([offListItem, ...subtitles.map(subtitleToListItem)]);
+    this.listElement.synchronizeItems([offListItem, ...this.player.subtitles.list().map(subtitleToListItem)]);
     this.selectCurrentSubtitle();
   };
 }

--- a/src/ts/utils/SubtitleUtils.ts
+++ b/src/ts/utils/SubtitleUtils.ts
@@ -57,7 +57,7 @@ export class SubtitleSwitchHandler {
   }
 
   private hasComparator(): boolean {
-    return typeof this.listElement.getConfig === 'function' && this.listElement.getConfig().comparator != null;
+    return this.listElement.getConfig().comparator != null;
   }
 
   private onSubtitleEnabled = (event: SubtitleEvent) => {

--- a/src/ts/utils/SubtitleUtils.ts
+++ b/src/ts/utils/SubtitleUtils.ts
@@ -11,7 +11,7 @@ import { i18n } from '../localization/i18n';
  * @category Utils
  */
 export class SubtitleSwitchHandler {
-  private static SUBTITLES_OFF_KEY: string = 'null';
+  static readonly SUBTITLES_OFF_KEY: string = 'null';
 
   private player: PlayerAPI;
   private listElement: ListSelector<ListSelectorConfig>;
@@ -113,7 +113,6 @@ export class SubtitleSwitchHandler {
       return { key: subtitle.id, label: subtitle.label };
     };
 
-    this.listElement.clearItems();
     this.listElement.synchronizeItems([offListItem, ...this.player.subtitles.list().map(subtitleToListItem)]);
     this.selectCurrentSubtitle();
   };


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Currently there's no way to control the tracks ordering. For some devices, like iOS, tracks might not be ordered alphabetically due to asynchronous loading and addition of tracks.

This PR address this issue by introducing a comparator function for list selectors, allowing integrators to define the display order for audio and subtitle tracks.

### Changes

- Adds an optional comparator callback to `ListSelector`, allowing to customize the display order of its elements

- Adds `ListSelector.onItemsChanged` which fires when the effective item collection changes, including reordering and item updates, so UI consumers can rebuild from the current list state
<!-- Adds `ListSelector.onItemsChanged` to signal whenever the items in the collection change so that UI consumers can get the new list rendered. Without this, we don't have an event to fire on re-sort changes (firing an existing `onItemRemoved`/`onItemAdded` is bad semantically for this scenario) -->

- Extend `AudioTrackListBox` and `SubtitleListBox` to accept config objects (in addition to title-only), so that `comparator`, `filter`, and `translator` can be passed through

 - Keeps the built-in `Off` subtitle option pinned to the top when a subtitle comparator is used

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
