### PR TITLE
Subtitle window coloring not applying for non-region WebVTT cues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed subtitle window coloring not applying
+
 ## [4.11.0] - 2026-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed subtitle window coloring for non-region WebVTT cues
+- Subtitle window coloring for non-region WebVTT cues
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Subtitle window coloring for non-region WebVTT cues
+- Subtitle window coloring was not applied for non-region WebVTT cues
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed subtitle window coloring not applying
+- Fixed subtitle window coloring for non-region WebVTT cues
 
 ## [4.11.0] - 2026-04-03
 

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -7,6 +7,7 @@ import {
   SubtitleRegionContainerManager,
 } from '../../../src/ts/components/overlays/SubtitleOverlay';
 import { DOM } from '../../../src/ts/DOM';
+import { VttUtils } from '../../../src/ts/utils/VttUtils';
 
 let playerMock: jest.Mocked<TestingPlayerAPI>;
 let uiInstanceManagerMock: UIInstanceManager;
@@ -216,7 +217,27 @@ describe('SubtitleOverlay', () => {
       expect(getLabelCssClasses(removeLabelSpy, 0, 0)).toEqual(['subtitle-vtt-cue']);
     });
 
-    it.todo('moves updated VTT cues into a different container when the region assignment changes');
+    it('moves updated VTT cues into the correct container when the region assignment changes', () => {
+      const overlaySize = { width: 640, height: 360 };
+      const setVttRegionStylesSpy = jest.spyOn(VttUtils, 'setVttRegionStyles');
+      jest.spyOn(subtitleOverlay, 'removeComponent');
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue({
+        ...MockHelper.generateDOMMock(),
+        size: jest.fn().mockReturnValue(overlaySize),
+      } as any);
+
+      const previousCueEvent = createSubtitleCueEvent({ vtt: createVttProps() });
+      const updatedCueEvent = createSubtitleCueEvent({
+        vtt: createVttProps({ region: { id: 'region-1' } }),
+      });
+
+      playerMock.eventEmitter.fireEvent({ ...previousCueEvent, type: playerMock.exports.PlayerEvent.CueEnter } as any);
+      playerMock.eventEmitter.fireEvent({ ...updatedCueEvent, type: playerMock.exports.PlayerEvent.CueUpdate } as any);
+
+      expect(Object.keys((subtitleRegionContainerManagerMock as any).subtitleRegionContainers)).toEqual(['region-1']);
+      expect(setVttRegionStylesSpy).toHaveBeenCalledWith(expect.anything(), updatedCueEvent.vtt.region, overlaySize);
+      expect(subtitleOverlay.removeComponent).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -2,6 +2,7 @@ import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
 import { UIInstanceManager } from '../../../src/ts/UIManager';
 import {
   SubtitleOverlay,
+  SubtitleLabel,
   SubtitleRegionContainer,
   SubtitleRegionContainerManager,
 } from '../../../src/ts/components/overlays/SubtitleOverlay';
@@ -108,4 +109,80 @@ describe('SubtitleOverlay', () => {
       expect(subtitleOverlay['cea608FontSizeFactor']).toBe(expectedFactor);
     });
   });
+
+  describe('WebVTT container behavior', () => {
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
+      uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+
+      subtitleOverlay = new SubtitleOverlay();
+      subtitleOverlay.configure(playerMock, uiInstanceManagerMock);
+      subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
+    });
+
+    it('marks non-region VTT labels as cue boxes', () => {
+      const label = subtitleOverlay.generateLabel(createSubtitleCueEvent({ vtt: createVttProps() }));
+
+      expect((label as any).config.cssClasses).toEqual(['subtitle-vtt-cue']);
+    });
+
+    it('does not mark VTT region labels as cue boxes', () => {
+      const label = subtitleOverlay.generateLabel(
+        createSubtitleCueEvent({ vtt: createVttProps({ region: { id: 'region-1' } }) }),
+      );
+
+      expect((label as any).config.cssClasses).toEqual([]);
+    });
+
+    it('creates a non-region VTT container that stays in normal flow and marks it as a cue container', () => {
+      const regionContainerDom = MockHelper.generateDOMMock();
+      jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(regionContainerDom);
+      const addComponentSpy = jest.spyOn(subtitleOverlay, 'addComponent');
+
+      const label = new SubtitleLabel({
+        text: 'Test Subtitle',
+        vtt: createVttProps(),
+      });
+
+      subtitleRegionContainerManagerMock.addLabel(label);
+
+      expect(Object.keys((subtitleRegionContainerManagerMock as any).subtitleRegionContainers)).toContain('vtt');
+      expect(addComponentSpy).toHaveBeenCalledTimes(1);
+      expect(regionContainerDom.css).toHaveBeenCalledWith('position', 'static');
+    });
+
+    it('creates a VTT region container with region-specific classes', () => {
+      const regionContainerDom = MockHelper.generateDOMMock();
+      jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(regionContainerDom);
+      const addComponentSpy = jest.spyOn(subtitleOverlay, 'addComponent');
+
+      const label = new SubtitleLabel({
+        text: 'Test Subtitle',
+        vtt: createVttProps({ region: { id: 'region-1' } }),
+      });
+
+      subtitleRegionContainerManagerMock.addLabel(label);
+
+      expect(Object.keys((subtitleRegionContainerManagerMock as any).subtitleRegionContainers)).toContain('region-1');
+      expect(addComponentSpy).toHaveBeenCalledTimes(1);
+      expect(regionContainerDom.css).toHaveBeenCalledWith('position', 'static');
+    });
+  });
 });
+
+function createSubtitleCueEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    subtitleId: 'subtitleId',
+    start: 0,
+    end: 10,
+    text: 'Test Subtitle',
+    ...overrides,
+  } as any;
+}
+
+function createVttProps(overrides: Record<string, unknown> = {}) {
+  return {
+    region: null,
+    ...overrides,
+  } as any;
+}

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -120,10 +120,16 @@ describe('SubtitleOverlay', () => {
       subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
     });
 
+    it('does not mark non-VTT labels as cue boxes', () => {
+      const label = subtitleOverlay.generateLabel(createSubtitleCueEvent());
+
+      expect(label.getConfig().cssClasses).toEqual([]);
+    });
+
     it('marks non-region VTT labels as cue boxes', () => {
       const label = subtitleOverlay.generateLabel(createSubtitleCueEvent({ vtt: createVttProps() }));
 
-      expect((label as any).config.cssClasses).toEqual(['subtitle-vtt-cue']);
+      expect(label.getConfig().cssClasses).toEqual(['subtitle-vtt-cue']);
     });
 
     it('does not mark VTT region labels as cue boxes', () => {
@@ -131,13 +137,15 @@ describe('SubtitleOverlay', () => {
         createSubtitleCueEvent({ vtt: createVttProps({ region: { id: 'region-1' } }) }),
       );
 
-      expect((label as any).config.cssClasses).toEqual([]);
+      expect(label.getConfig().cssClasses).toEqual([]);
     });
 
     it('creates a non-region VTT container that stays in normal flow and marks it as a cue container', () => {
       const regionContainerDom = MockHelper.generateDOMMock();
       jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(regionContainerDom);
       const addComponentSpy = jest.spyOn(subtitleOverlay, 'addComponent');
+      const mergeConfigMock = (SubtitleRegionContainer.prototype as any).mergeConfig as jest.Mock;
+      mergeConfigMock.mockClear();
 
       const label = new SubtitleLabel({
         text: 'Test Subtitle',
@@ -148,6 +156,7 @@ describe('SubtitleOverlay', () => {
 
       expect(Object.keys((subtitleRegionContainerManagerMock as any).subtitleRegionContainers)).toContain('vtt');
       expect(addComponentSpy).toHaveBeenCalledTimes(1);
+      expect(getMergedCssClasses(mergeConfigMock)).toEqual(['subtitle-position-vtt', 'subtitle-vtt-cue-container']);
       expect(regionContainerDom.css).toHaveBeenCalledWith('position', 'static');
     });
 
@@ -155,6 +164,8 @@ describe('SubtitleOverlay', () => {
       const regionContainerDom = MockHelper.generateDOMMock();
       jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(regionContainerDom);
       const addComponentSpy = jest.spyOn(subtitleOverlay, 'addComponent');
+      const mergeConfigMock = (SubtitleRegionContainer.prototype as any).mergeConfig as jest.Mock;
+      mergeConfigMock.mockClear();
 
       const label = new SubtitleLabel({
         text: 'Test Subtitle',
@@ -165,10 +176,58 @@ describe('SubtitleOverlay', () => {
 
       expect(Object.keys((subtitleRegionContainerManagerMock as any).subtitleRegionContainers)).toContain('region-1');
       expect(addComponentSpy).toHaveBeenCalledTimes(1);
+      expect(getMergedCssClasses(mergeConfigMock)).toEqual([
+        'subtitle-position-vtt',
+        'subtitle-vtt-region-container',
+        'vtt-region-region-1',
+      ]);
       expect(regionContainerDom.css).toHaveBeenCalledWith('position', 'static');
     });
+
+    it('keeps non-VTT containers free of VTT-specific classes', () => {
+      const mergeConfigMock = (SubtitleRegionContainer.prototype as any).mergeConfig as jest.Mock;
+      mergeConfigMock.mockClear();
+
+      subtitleRegionContainerManagerMock.addLabel(new SubtitleLabel({ text: 'Test Subtitle', region: 'default' }));
+
+      expect(getMergedCssClasses(mergeConfigMock)).toEqual(['subtitle-position-default']);
+    });
+
+    it('preserves non-region VTT cue-box semantics on cue updates', () => {
+      const replaceLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'replaceLabel');
+      const cueEvent = createSubtitleCueEvent({ vtt: createVttProps() });
+
+      playerMock.eventEmitter.fireEvent({ ...cueEvent, type: playerMock.exports.PlayerEvent.CueEnter } as any);
+      playerMock.eventEmitter.fireEvent({ ...cueEvent, type: playerMock.exports.PlayerEvent.CueUpdate } as any);
+
+      expect(replaceLabelSpy).toHaveBeenCalledTimes(1);
+      expect(getLabelCssClasses(replaceLabelSpy, 0, 0)).toEqual(['subtitle-vtt-cue']);
+      expect(getLabelCssClasses(replaceLabelSpy, 0, 1)).toEqual(['subtitle-vtt-cue']);
+    });
+
+    it('removes non-region VTT labels from the cue container on cue exit', () => {
+      const removeLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'removeLabel');
+      const cueEvent = createSubtitleCueEvent({ vtt: createVttProps() });
+
+      playerMock.eventEmitter.fireEvent({ ...cueEvent, type: playerMock.exports.PlayerEvent.CueEnter } as any);
+      playerMock.eventEmitter.fireEvent({ ...cueEvent, type: playerMock.exports.PlayerEvent.CueExit } as any);
+
+      expect(removeLabelSpy).toHaveBeenCalledTimes(1);
+      expect(getLabelCssClasses(removeLabelSpy, 0, 0)).toEqual(['subtitle-vtt-cue']);
+    });
+
+    it.todo('moves updated VTT cues into a different container when the region assignment changes');
   });
 });
+
+function getMergedCssClasses(mergeConfigMock: jest.Mock): string[] {
+  return mergeConfigMock.mock.calls[0][0].cssClasses;
+}
+
+function getLabelCssClasses(spy: jest.SpyInstance, callIndex: number, argIndex: number): string[] {
+  const label = spy.mock.calls[callIndex][argIndex] as SubtitleLabel;
+  return label.getConfig().cssClasses;
+}
 
 function createSubtitleCueEvent(overrides: Record<string, unknown> = {}) {
   return {

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -121,6 +121,8 @@ describe('SubtitleOverlay', () => {
       subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
     });
 
+    afterEach(() => jest.restoreAllMocks());
+
     it('does not mark non-VTT labels as cue boxes', () => {
       const label = subtitleOverlay.generateLabel(createSubtitleCueEvent());
 
@@ -195,6 +197,11 @@ describe('SubtitleOverlay', () => {
     });
 
     it('preserves non-region VTT cue-box semantics on cue updates', () => {
+      jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue({
+        ...MockHelper.generateDOMMock(),
+        size: jest.fn().mockReturnValue({ width: 0, height: 0 }),
+      } as any);
       const replaceLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'replaceLabel');
       const cueEvent = createSubtitleCueEvent({ vtt: createVttProps() });
 
@@ -207,6 +214,11 @@ describe('SubtitleOverlay', () => {
     });
 
     it('removes non-region VTT labels from the cue container on cue exit', () => {
+      jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
+      jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue({
+        ...MockHelper.generateDOMMock(),
+        size: jest.fn().mockReturnValue({ width: 0, height: 0 }),
+      } as any);
       const removeLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'removeLabel');
       const cueEvent = createSubtitleCueEvent({ vtt: createVttProps() });
 
@@ -218,6 +230,7 @@ describe('SubtitleOverlay', () => {
     });
 
     it('moves updated VTT cues into the correct container when the region assignment changes', () => {
+      jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
       const overlaySize = { width: 640, height: 360 };
       const setVttRegionStylesSpy = jest.spyOn(VttUtils, 'setVttRegionStyles');
       jest.spyOn(subtitleOverlay, 'removeComponent');

--- a/src/scss/components/overlays/_subtitle-overlay.scss
+++ b/src/scss/components/overlays/_subtitle-overlay.scss
@@ -33,10 +33,12 @@
       position: absolute;
 
       &.#{$prefix}-subtitle-position-default {
+        align-items: center;
         bottom: 2em;
+        display: flex;
+        flex-direction: column;
         left: 3em;
         right: 3em;
-        top: initial;
       }
 
       &.#{$prefix}-subtitle-position-bottom > div {

--- a/src/scss/components/overlays/_subtitle-overlay.scss
+++ b/src/scss/components/overlays/_subtitle-overlay.scss
@@ -33,12 +33,10 @@
       position: absolute;
 
       &.#{$prefix}-subtitle-position-default {
-        align-items: center;
         bottom: 2em;
-        display: flex;
-        flex-direction: column;
         left: 3em;
         right: 3em;
+        top: initial;
       }
 
       &.#{$prefix}-subtitle-position-bottom > div {

--- a/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
+++ b/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
@@ -58,9 +58,7 @@
       &.#{$prefix}-bgcolor-#{$color-name}#{$opacity-name} {
         .#{$prefix}-subtitle-region-container {
           .#{$prefix}-ui-subtitle-label {
-            .#{$prefix}-ui-label-text {
-              background-color: transparentize($color-value, 1 - $opacity-value);
-            }
+            background-color: transparentize($color-value, 1 - $opacity-value);
           }
         }
       }

--- a/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
+++ b/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
@@ -58,7 +58,9 @@
       &.#{$prefix}-bgcolor-#{$color-name}#{$opacity-name} {
         .#{$prefix}-subtitle-region-container {
           .#{$prefix}-ui-subtitle-label {
-            background-color: transparentize($color-value, 1 - $opacity-value);
+            .#{$prefix}-ui-label-text {
+              background-color: transparentize($color-value, 1 - $opacity-value);
+            }
           }
         }
       }
@@ -69,8 +71,14 @@
   @each $color-name, $color-value in $colors {
     @each $opacity-name, $opacity-value in $opacities {
       &.#{$prefix}-windowcolor-#{$color-name}#{$opacity-name} {
-        .#{$prefix}-subtitle-region-container {
+        .#{$prefix}-subtitle-region-container:not(.#{$prefix}-subtitle-vtt-cue-container) {
           background-color: transparentize($color-value, 1 - $opacity-value);
+        }
+
+        .#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-cue-container {
+          .#{$prefix}-ui-subtitle-label.#{$prefix}-subtitle-vtt-cue {
+            background-color: transparentize($color-value, 1 - $opacity-value);
+          }
         }
       }
     }

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -92,7 +92,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       this.preprocessLabelEventCallback.dispatch(event, label);
 
       if (labelToReplace) {
-        this.subtitleContainerManager.replaceLabel(labelToReplace, label);
+        this.subtitleContainerManager.replaceLabel(labelToReplace, label, this.getDomElement().size());
       }
 
       if (uimanager.getConfig().forceSubtitlesIntoViewContainer) {
@@ -758,11 +758,9 @@ export class SubtitleRegionContainerManager {
     this.subtitleRegionContainers[regionContainerId].addLabel(label, overlaySize);
   }
 
-  replaceLabel(previousLabel: SubtitleLabel, newLabel: SubtitleLabel): void {
-    const { regionContainerId } = this.getRegion(previousLabel);
-
-    this.subtitleRegionContainers[regionContainerId].removeLabel(previousLabel);
-    this.subtitleRegionContainers[regionContainerId].addLabel(newLabel);
+  replaceLabel(previousLabel: SubtitleLabel, newLabel: SubtitleLabel, overlaySize?: Size): void {
+    this.removeLabel(previousLabel);
+    this.addLabel(newLabel, overlaySize);
   }
 
   /**

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -760,6 +760,15 @@ export class SubtitleRegionContainerManager {
   }
 
   replaceLabel(previousLabel: SubtitleLabel, newLabel: SubtitleLabel, overlaySize?: Size): void {
+    const previousRegion = this.getRegion(previousLabel);
+    const newRegion = this.getRegion(newLabel);
+
+    if (previousRegion.regionContainerId === newRegion.regionContainerId) {
+      const regionContainer = this.subtitleRegionContainers[previousRegion.regionContainerId];
+      regionContainer.removeLabel(previousLabel);
+      regionContainer.addLabel(newLabel, overlaySize);
+      return;
+    }
     this.removeLabel(previousLabel);
     this.addLabel(newLabel, overlaySize);
   }

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -230,6 +230,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       // Prefer the HTML subtitle text if set, else try generating a image tag as string from the image attribute,
       // else use the plain text
       text: event.html || ActiveSubtitleManager.generateImageTagText(event.image) || event.text,
+      cssClasses: event.vtt && !event.vtt.region ? ['subtitle-vtt-cue'] : [],
       vtt: event.vtt,
       region: region,
       regionStyle: event.regionStyle,
@@ -725,7 +726,10 @@ export class SubtitleRegionContainerManager {
     const cssClasses = [`subtitle-position-${regionName}`];
 
     if (label.vtt && label.vtt.region) {
+      cssClasses.push('subtitle-vtt-region-container');
       cssClasses.push(`vtt-region-${label.vtt.region.id}`);
+    } else if (label.vtt) {
+      cssClasses.push('subtitle-vtt-cue-container');
     }
 
     if (!this.subtitleRegionContainers[regionContainerId]) {
@@ -737,6 +741,10 @@ export class SubtitleRegionContainerManager {
 
       if (label.regionStyle) {
         regionContainer.getDomElement().attr('style', label.regionStyle);
+      }
+
+      if (label.vtt) {
+        regionContainer.getDomElement().css('position', 'static');
       }
 
       // getDomElement needs to be called at least once to ensure the component exists
@@ -814,38 +822,6 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
       }
 
       VttUtils.setVttCueBoxStyles(labelToAdd, overlaySize);
-
-      if (!labelToAdd.vtt.region) {
-        const labelEl = labelToAdd.getDomElement().get(0);
-        const containerDom = this.getDomElement();
-        const propsToMove = [
-          'position',
-          'bottom',
-          'top',
-          'left',
-          'right',
-          'width',
-          'height',
-          'writing-mode',
-          'transform',
-          'overflow',
-          'overflow-wrap',
-          'flex-flow',
-          'justify-content',
-        ];
-
-        for (const prop of propsToMove) {
-          (containerDom.get(0) as HTMLElement).style.removeProperty(prop);
-        }
-        for (const prop of propsToMove) {
-          const val = labelEl.style.getPropertyValue(prop);
-          if (val) {
-            containerDom.css(prop, val);
-            labelEl.style.removeProperty(prop);
-          }
-        }
-        containerDom.css('display', 'flex');
-      }
     }
 
     this.addComponent(labelToAdd);

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -739,10 +739,6 @@ export class SubtitleRegionContainerManager {
         regionContainer.getDomElement().attr('style', label.regionStyle);
       }
 
-      if (label.vtt) {
-        regionContainer.getDomElement().css('position', 'static');
-      }
-
       // getDomElement needs to be called at least once to ensure the component exists
       regionContainer.getDomElement();
 
@@ -818,6 +814,34 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
       }
 
       VttUtils.setVttCueBoxStyles(labelToAdd, overlaySize);
+
+      if (!labelToAdd.vtt.region) {
+        const labelEl = labelToAdd.getDomElement().get(0);
+        const containerDom = this.getDomElement();
+        const propsToMove = [
+          'position',
+          'bottom',
+          'top',
+          'left',
+          'right',
+          'width',
+          'height',
+          'writing-mode',
+          'transform',
+          'overflow',
+          'overflow-wrap',
+          'flex-flow',
+          'justify-content',
+        ];
+        for (const prop of propsToMove) {
+          const val = labelEl.style.getPropertyValue(prop);
+          if (val) {
+            containerDom.css(prop, val);
+            labelEl.style.removeProperty(prop);
+          }
+        }
+        containerDom.css('display', 'flex');
+      }
     }
 
     this.addComponent(labelToAdd);

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -833,6 +833,10 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
           'flex-flow',
           'justify-content',
         ];
+
+        for (const prop of propsToMove) {
+          (containerDom.get(0) as HTMLElement).style.removeProperty(prop);
+        }
         for (const prop of propsToMove) {
           const val = labelEl.style.getPropertyValue(prop);
           if (val) {

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -93,6 +93,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       if (labelToReplace) {
         this.subtitleContainerManager.replaceLabel(labelToReplace, label, this.getDomElement().size());
+        this.updateComponents();
       }
 
       if (uimanager.getConfig().forceSubtitlesIntoViewContainer) {


### PR DESCRIPTION
## Description
addresses https://bitmovin.atlassian.net/browse/PW-28067


- window color is always applied to `.subtitle-region-container`
- that works when the container is the visible window
- but for a non-region WebVTT cue, the visible box is the cue label after

## Changes

  This branch fixes that by splitting the cases:

  - CEA and WebVTT with region:
    keep window color on `.subtitle-region-container`
  - WebVTT without region:
    mark the wrapper as `.subtitle-vtt-cue-container`
    mark the label as `.subtitle-vtt-cue`
    apply window color to the cue label instead of the wrapper



## Testing Instructions

Use the demo app, and a styled stream like `aom-webvtt-styled-subtitles`.
And make sure CEA styling also works via the demo button showing test-patterns.

