### PR TITLE
Fix VTT background color applies color to window instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed subtitle window coloring for non-region WebVTT cues
-- Fix WebVTT subtitle background color applies window color instead
+- WebVTT subtitle background color applies styling to window color instead
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Subtitle window coloring was not applied for non-region WebVTT cues
-- WebVTT subtitle background color applies styling to window color instead
+- WebVTT subtitle background color is applied to the window instead of the text background
 
 ## [4.11.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed subtitle window coloring for non-region WebVTT cues
+- Fix WebVTT subtitle background color applies window color instead
 
 ## [4.11.0] - 2026-04-03
 

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -220,6 +220,7 @@ describe('SubtitleOverlay', () => {
     it('moves updated VTT cues into the correct container when the region assignment changes', () => {
       const overlaySize = { width: 640, height: 360 };
       const setVttRegionStylesSpy = jest.spyOn(VttUtils, 'setVttRegionStyles');
+      const updateComponentsSpy = jest.spyOn(subtitleOverlay, 'updateComponents');
       jest.spyOn(subtitleOverlay, 'removeComponent');
       jest.spyOn(subtitleOverlay, 'getDomElement').mockReturnValue({
         ...MockHelper.generateDOMMock(),
@@ -237,6 +238,7 @@ describe('SubtitleOverlay', () => {
       expect(Object.keys((subtitleRegionContainerManagerMock as any).subtitleRegionContainers)).toEqual(['region-1']);
       expect(setVttRegionStylesSpy).toHaveBeenCalledWith(expect.anything(), updatedCueEvent.vtt.region, overlaySize);
       expect(subtitleOverlay.removeComponent).toHaveBeenCalledTimes(1);
+      expect(updateComponentsSpy).toHaveBeenCalled();
     });
   });
 });

--- a/spec/components/settings/subtitlesettings/SubtitleOverlaySettingsStyles.spec.ts
+++ b/spec/components/settings/subtitlesettings/SubtitleOverlaySettingsStyles.spec.ts
@@ -3,8 +3,8 @@ import path = require('path');
 
 describe('Subtitle overlay settings styles', () => {
   const stylesPath = path.resolve(
-    __dirname,
-    '../../../../src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss',
+    process.cwd(),
+    'src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss',
   );
   const styles = fs.readFileSync(stylesPath, 'utf8');
 

--- a/spec/components/settings/subtitlesettings/SubtitleOverlaySettingsStyles.spec.ts
+++ b/spec/components/settings/subtitlesettings/SubtitleOverlaySettingsStyles.spec.ts
@@ -1,0 +1,19 @@
+import fs = require('fs');
+import path = require('path');
+
+describe('Subtitle overlay settings styles', () => {
+  const stylesPath = path.resolve(
+    __dirname,
+    '../../../../src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss',
+  );
+  const styles = fs.readFileSync(stylesPath, 'utf8');
+
+  it('keeps WebVTT background color on a different visual layer than window color', () => {
+    expect(styles).toContain(
+      '.#{$prefix}-subtitle-region-container:not(.#{$prefix}-subtitle-vtt-region-container):not(.#{$prefix}-subtitle-vtt-cue-container)',
+    );
+    expect(styles).toContain('.#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-region-container');
+    expect(styles).toContain('.#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-cue-container');
+    expect(styles).toContain('.#{$prefix}-ui-label-text');
+  });
+});

--- a/src/scss/components/overlays/_subtitle-overlay.scss
+++ b/src/scss/components/overlays/_subtitle-overlay.scss
@@ -63,6 +63,24 @@
       }
     }
 
+    .#{$prefix}-ui-subtitle-label.#{$prefix}-subtitle-vtt-cue,
+    .#{$prefix}-subtitle-vtt-region-container .#{$prefix}-ui-subtitle-label {
+      .#{$prefix}-ui-label-text {
+        max-width: 100%;
+        width: fit-content;
+      }
+
+      &[style*='text-align: center'] .#{$prefix}-ui-label-text {
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      &[style*='text-align: right'] .#{$prefix}-ui-label-text,
+      &[style*='text-align: end'] .#{$prefix}-ui-label-text {
+        margin-left: auto;
+      }
+    }
+
     // Move the subtitle up above the controlbar when it appears to avoid them overlapping
     &.#{$prefix}-controlbar-visible {
       bottom: 5em;

--- a/src/scss/components/overlays/_subtitle-overlay.scss
+++ b/src/scss/components/overlays/_subtitle-overlay.scss
@@ -75,9 +75,16 @@
         margin-right: auto;
       }
 
-      &[style*='text-align: right'] .#{$prefix}-ui-label-text,
-      &[style*='text-align: end'] .#{$prefix}-ui-label-text {
-        margin-left: auto;
+      &[style*='text-align: right'] .#{$prefix}-ui-label-text {  
+        margin-left: auto;  
+      }
+
+      &[style*='text-align: end'] .#{$prefix}-ui-label-text {  
+        margin-inline-start: auto;
+      }
+
+      &[style*='text-align: start'] .#{$prefix}-ui-label-text {  
+        margin-inline-end: auto;  
       }
     }
 

--- a/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
+++ b/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
@@ -56,9 +56,18 @@
   @each $color-name, $color-value in $colors {
     @each $opacity-name, $opacity-value in $opacities {
       &.#{$prefix}-bgcolor-#{$color-name}#{$opacity-name} {
-        .#{$prefix}-subtitle-region-container {
+        .#{$prefix}-subtitle-region-container:not(.#{$prefix}-subtitle-vtt-region-container):not(.#{$prefix}-subtitle-vtt-cue-container) {
           .#{$prefix}-ui-subtitle-label {
             background-color: transparentize($color-value, 1 - $opacity-value);
+          }
+        }
+
+        .#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-region-container,
+        .#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-cue-container {
+          .#{$prefix}-ui-subtitle-label {
+            .#{$prefix}-ui-label-text {
+              background-color: transparentize($color-value, 1 - $opacity-value);
+            }
           }
         }
       }

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -93,6 +93,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
       if (labelToReplace) {
         this.subtitleContainerManager.replaceLabel(labelToReplace, label, this.getDomElement().size());
+        this.updateComponents();
       }
 
       if (uimanager.getConfig().forceSubtitlesIntoViewContainer) {


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Applying background color to VTT subtitles applies to color to the window instead.

## Changes

window color was applied to the generic subtitle container, which is not the visible cue box for plain WebVTT cues.

This branch adds separate VTT cue/container classes and applies window color to the actual cue box when there is no WebVTT region.

Additionally, it fixes cue updates when a WebVTT cue changes container type.


## Testing Instructions

On demo page, ensure that:
- For VTT: background color applies to background color (color behind text) and window color to window color (color whole row)
- For CEA: background color and window color still works as expected



## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
