### PR TITLE
Ensure spy implementations do not persist into subsequent tests globally

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
 
-  // Restore prototype spy implementations
+  // Automatically restore prototype spy implementations back to their original value between every test
   restoreAllMocks: true,
 
   // The directory where Jest should output its coverage files

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   clearMocks: true,
 
   // Automatically restore prototype spy implementations back to their original value between every test
-  restoreAllMocks: true,
+  restoreMocks: true,
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,9 @@ module.exports = {
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
 
+  // Restore prototype spy implementations
+  restoreAllMocks: true,
+
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

In our global Jest config, we already have `clearMocks: true`, which clears call history but doesn't restore original implementations; [restoreAllMocks](https://jestjs.io/docs/jest-object#jestrestoreallmocks) fills that gap for `jest.spyOn` calls.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry - no need, dev experience change only
