### PR TITLE
Add enableCea608CaptionFormatting config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- New `SubtitleOverlayConfig.enableCea608CaptionFormatting` option (defaults to `true`) to opt out of CEA-608-specific text formatting (monospaced font, uppercase transform, character letter-spacing). CEA-608 row/column positioning is still applied.
+
 ## [4.11.1] - 2026-04-23
 
 ### Fixed

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -118,6 +118,7 @@ describe('SubtitleOverlay', () => {
     // ever loses this field, these tests will fail.
     let RealSubtitleOverlay: typeof SubtitleOverlay;
     let RealSubtitleRegionContainer: typeof SubtitleRegionContainer;
+    let RealSubtitleLabel: typeof SubtitleLabel;
 
     beforeAll(() => {
       jest.isolateModules(() => {
@@ -126,6 +127,7 @@ describe('SubtitleOverlay', () => {
         const module = require('../../../src/ts/components/overlays/SubtitleOverlay');
         RealSubtitleOverlay = module.SubtitleOverlay;
         RealSubtitleRegionContainer = module.SubtitleRegionContainer;
+        RealSubtitleLabel = module.SubtitleLabel;
       });
     });
 
@@ -219,6 +221,54 @@ describe('SubtitleOverlay', () => {
 
       expect(overlayDom.removeClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
       expect(overlayDom.removeClass).toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
+    });
+
+    it.each([
+      {
+        label: 'does not re-apply letter-spacing on grid recalculation when formatting is disabled',
+        config: { enableCea608CaptionFormatting: false },
+        letterSpacingExpected: false,
+      },
+      {
+        label: 'does re-apply letter-spacing on grid recalculation when formatting is enabled (default)',
+        config: {},
+        letterSpacingExpected: true,
+      },
+    ])('$label', ({ config, letterSpacingExpected }) => {
+      // Regression: ensureCea608GridSizeUpdated runs on onShow/PlayerResized/ControlBar toggles
+      // and used to unconditionally write letter-spacing onto every active label, undoing the
+      // formatting opt-out for already-rendered cues. Root cause of the f1-stream bug.
+      const overlay = new RealSubtitleOverlay(config);
+      const overlayDom = MockHelper.generateDOMMock();
+      (overlayDom.width as jest.Mock).mockReturnValue(1280);
+      (overlayDom.height as jest.Mock).mockReturnValue(720);
+      (overlayDom.get as jest.Mock).mockReturnValue([{ style: { setProperty: jest.fn() } }]);
+      jest.spyOn(overlay, 'getDomElement').mockReturnValue(overlayDom);
+      jest.spyOn(overlay, 'updateComponents').mockImplementation(() => undefined);
+      jest.spyOn(RealSubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
+      jest.spyOn(RealSubtitleRegionContainer.prototype, 'updateComponents').mockImplementation(() => undefined);
+      // Labels use their DOM for measurements inside the grid calc (dummy label) and for
+      // style writes (the actual cue label). Non-zero width/height avoids NaN in the calc.
+      // Spy on the isolated-module's SubtitleLabel, not the outer import — otherwise the
+      // real code's `new SubtitleLabel()` creates instances whose prototype isn't the one
+      // we spied on.
+      const labelDom = MockHelper.generateDOMMock();
+      (labelDom.width as jest.Mock).mockReturnValue(10);
+      (labelDom.height as jest.Mock).mockReturnValue(20);
+      jest.spyOn(RealSubtitleLabel.prototype, 'getDomElement').mockReturnValue(labelDom);
+
+      overlay.configure(playerMock, uiInstanceManagerMock);
+      fireCea608CueEnter();
+      // Change overlay dimensions so the grid recalc doesn't bail on the unchanged-size check.
+      (overlayDom.width as jest.Mock).mockReturnValue(1920);
+      (overlayDom.height as jest.Mock).mockReturnValue(1080);
+      (labelDom.css as jest.Mock).mockClear();
+      (overlay as any).ensureCea608GridSizeUpdated();
+
+      const cssCalls = (labelDom.css as jest.Mock).mock.calls;
+      const writtenStyles = cssCalls.map((call: unknown[]) => call[0]).filter(arg => arg && typeof arg === 'object');
+      const hasLetterSpacingWrite = writtenStyles.some(style => 'letter-spacing' in (style as object));
+      expect(hasLetterSpacingWrite).toBe(letterSpacingExpected);
     });
   });
 

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -111,6 +111,89 @@ describe('SubtitleOverlay', () => {
     });
   });
 
+  describe('CEA 608 caption formatting config', () => {
+    let overlayDomMock: DOM;
+
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
+      uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+      overlayDomMock = MockHelper.generateDOMMock();
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    function fireCea608CueEnter() {
+      playerMock.eventEmitter.fireEvent({
+        subtitleId: 'subtitleId',
+        start: 0,
+        end: 10,
+        text: 'Test Subtitle',
+        position: { row: 5, column: 10 },
+        type: playerMock.exports.PlayerEvent.CueEnter,
+      } as any);
+    }
+
+    function setupOverlay(config: { enableCea608CaptionFormatting?: boolean } = {}): SubtitleOverlay {
+      const overlay = new SubtitleOverlay(config);
+      // Container is auto-mocked, so mergeConfig does nothing and this.config ends up undefined.
+      // Assign it explicitly (defaulting enableCea608CaptionFormatting to true to mirror the real mergeConfig default).
+      (overlay as any).config = { enableCea608CaptionFormatting: true, ...config };
+      // prefixCss is auto-mocked to return undefined; make it return the raw class name
+      // so addClass/removeClass assertions can match on the suffix.
+      jest.spyOn(overlay as any, 'prefixCss').mockImplementation((cls: any) => cls);
+      overlay.configure(playerMock, uiInstanceManagerMock);
+      jest.spyOn(overlay, 'getDomElement').mockReturnValue(overlayDomMock);
+      jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
+      return overlay;
+    }
+
+    it('applies CEA-608 positioning and formatting classes when the config is not set (default behavior)', () => {
+      subtitleOverlay = setupOverlay();
+
+      fireCea608CueEnter();
+
+      expect(overlayDomMock.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
+      expect(overlayDomMock.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
+    });
+
+    it('applies CEA-608 positioning but not the formatting class when enableCea608CaptionFormatting is false', () => {
+      subtitleOverlay = setupOverlay({ enableCea608CaptionFormatting: false });
+
+      fireCea608CueEnter();
+
+      expect(overlayDomMock.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
+      expect(overlayDomMock.addClass).not.toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
+    });
+
+    it('does not set inline letter-spacing on the label when enableCea608CaptionFormatting is false', () => {
+      subtitleOverlay = setupOverlay({ enableCea608CaptionFormatting: false });
+      subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
+      const addLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'addLabel');
+
+      fireCea608CueEnter();
+
+      const label = addLabelSpy.mock.calls[0][0] as SubtitleLabel;
+      const labelCssCalls = (label.getDomElement().css as jest.Mock).mock.calls;
+      const styleArgs = labelCssCalls.map(call => call[0]).filter(arg => typeof arg === 'object');
+      const styleWithLetterSpacing = styleArgs.find(style => 'letter-spacing' in style);
+      expect(styleWithLetterSpacing).toBeUndefined();
+    });
+
+    it('sets inline letter-spacing on the label when the config is not set (default behavior)', () => {
+      subtitleOverlay = setupOverlay();
+      subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
+      const addLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'addLabel');
+
+      fireCea608CueEnter();
+
+      const label = addLabelSpy.mock.calls[0][0] as SubtitleLabel;
+      const labelCssCalls = (label.getDomElement().css as jest.Mock).mock.calls;
+      const styleArgs = labelCssCalls.map(call => call[0]).filter(arg => typeof arg === 'object');
+      const styleWithLetterSpacing = styleArgs.find(style => 'letter-spacing' in style);
+      expect(styleWithLetterSpacing).toBeDefined();
+    });
+  });
+
   describe('WebVTT container behavior', () => {
     beforeEach(() => {
       playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -137,14 +137,8 @@ describe('SubtitleOverlay', () => {
     afterEach(() => jest.restoreAllMocks());
 
     function fireCea608CueEnter() {
-      playerMock.eventEmitter.fireEvent({
-        subtitleId: 'subtitleId',
-        start: 0,
-        end: 10,
-        text: 'Test Subtitle',
-        position: { row: 5, column: 10 },
-        type: playerMock.exports.PlayerEvent.CueEnter,
-      } as any);
+      // position triggers the CEA-608 code path in SubtitleOverlay (see isCea608SubtitleCue)
+      playerMock.eventEmitter.fireSubtitleCueEnterEvent({ position: { row: 5, column: 10 } });
     }
 
     function setupOverlay(config: { enableCea608CaptionFormatting?: boolean } = {}): {
@@ -160,16 +154,22 @@ describe('SubtitleOverlay', () => {
       const overlayDom = MockHelper.generateDOMMock();
       jest.spyOn(overlay, 'getDomElement').mockReturnValue(overlayDom);
       jest.spyOn(RealSubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
-      // updateComponents touches innerContainerElement which isn't set up under the mocked DOM.
+      // updateComponents on both the overlay and its region containers touches DOM plumbing
+      // (innerContainerElement, child .remove()) that isn't set up under the mocked DOM.
+      jest.spyOn(overlay, 'updateComponents').mockImplementation(() => undefined);
       jest.spyOn(RealSubtitleRegionContainer.prototype, 'updateComponents').mockImplementation(() => undefined);
       return { overlay, overlayDom };
     }
 
-    function getLetterSpacingStyle(addLabelSpy: jest.SpyInstance) {
+    function getLetterSpacingStyle(addLabelSpy: jest.SpyInstance): unknown {
       const label = addLabelSpy.mock.calls[0][0] as SubtitleLabel;
       const labelCssCalls = (label.getDomElement().css as jest.Mock).mock.calls;
-      const styleArgs = labelCssCalls.map(call => call[0]).filter(arg => typeof arg === 'object');
-      return styleArgs.find(style => 'letter-spacing' in style);
+      // The CEA-608 cue path calls css() exactly once with a style object. If a future
+      // change adds another call (or switches to the css(name, value) form), fail loudly
+      // here rather than silently filtering it out.
+      expect(labelCssCalls).toHaveLength(1);
+      const style = labelCssCalls[0][0] as Record<string, string>;
+      return style['letter-spacing'];
     }
 
     it('applies CEA-608 positioning and formatting classes when the config is not set (default behavior)', () => {
@@ -206,6 +206,19 @@ describe('SubtitleOverlay', () => {
       fireCea608CueEnter();
 
       expect(getLetterSpacingStyle(addLabelSpy)).toBeDefined();
+    });
+
+    it('removes both CEA-608 classes on reset, even when the formatting class was never added', () => {
+      // When the formatting class is disabled it's never added, but the reset path still
+      // calls removeClass on it. Guard against a future refactor that makes the removal
+      // conditional and accidentally leaves stale classes on the overlay.
+      const { overlayDom } = setupOverlay({ enableCea608CaptionFormatting: false });
+
+      fireCea608CueEnter();
+      playerMock.eventEmitter.fireSourceUnloadedEvent();
+
+      expect(overlayDom.removeClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
+      expect(overlayDom.removeClass).toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
     });
   });
 

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -112,12 +112,26 @@ describe('SubtitleOverlay', () => {
   });
 
   describe('CEA 608 caption formatting config', () => {
-    let overlayDomMock: DOM;
+    // This block uses the real Container implementation (via jest.isolateModules + jest.unmock)
+    // so that the SubtitleOverlay constructor's mergeConfig call actually runs. That means the
+    // "default is true" contract is exercised end-to-end — if the mergeConfig defaults object
+    // ever loses this field, these tests will fail.
+    let RealSubtitleOverlay: typeof SubtitleOverlay;
+    let RealSubtitleRegionContainer: typeof SubtitleRegionContainer;
+
+    beforeAll(() => {
+      jest.isolateModules(() => {
+        jest.unmock('../../../src/ts/components/Container');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const module = require('../../../src/ts/components/overlays/SubtitleOverlay');
+        RealSubtitleOverlay = module.SubtitleOverlay;
+        RealSubtitleRegionContainer = module.SubtitleRegionContainer;
+      });
+    });
 
     beforeEach(() => {
       playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
       uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
-      overlayDomMock = MockHelper.generateDOMMock();
     });
 
     afterEach(() => jest.restoreAllMocks());
@@ -133,64 +147,65 @@ describe('SubtitleOverlay', () => {
       } as any);
     }
 
-    function setupOverlay(config: { enableCea608CaptionFormatting?: boolean } = {}): SubtitleOverlay {
-      const overlay = new SubtitleOverlay(config);
-      // Container is auto-mocked, so mergeConfig does nothing and this.config ends up undefined.
-      // Assign it explicitly (defaulting enableCea608CaptionFormatting to true to mirror the real mergeConfig default).
-      (overlay as any).config = { enableCea608CaptionFormatting: true, ...config };
-      // prefixCss is auto-mocked to return undefined; make it return the raw class name
-      // so addClass/removeClass assertions can match on the suffix.
-      jest.spyOn(overlay as any, 'prefixCss').mockImplementation((cls: any) => cls);
+    function setupOverlay(config: { enableCea608CaptionFormatting?: boolean } = {}): {
+      overlay: SubtitleOverlay;
+      overlayDom: jest.Mocked<DOM>;
+    } {
+      const overlay = new RealSubtitleOverlay(config);
       overlay.configure(playerMock, uiInstanceManagerMock);
-      jest.spyOn(overlay, 'getDomElement').mockReturnValue(overlayDomMock);
-      jest.spyOn(SubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
-      return overlay;
+      // The real CEA-608 grid-size calculation reads pixel dimensions off the DOM, which are
+      // unavailable under jsdom without a real layout. Stub it out: the tests only care about
+      // the class-toggling and letter-spacing decisions, not the computed grid values.
+      (overlay as any).ensureCea608GridSizeUpdated = (): void => undefined;
+      const overlayDom = MockHelper.generateDOMMock();
+      jest.spyOn(overlay, 'getDomElement').mockReturnValue(overlayDom);
+      jest.spyOn(RealSubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
+      // updateComponents touches innerContainerElement which isn't set up under the mocked DOM.
+      jest.spyOn(RealSubtitleRegionContainer.prototype, 'updateComponents').mockImplementation(() => undefined);
+      return { overlay, overlayDom };
+    }
+
+    function getLetterSpacingStyle(addLabelSpy: jest.SpyInstance) {
+      const label = addLabelSpy.mock.calls[0][0] as SubtitleLabel;
+      const labelCssCalls = (label.getDomElement().css as jest.Mock).mock.calls;
+      const styleArgs = labelCssCalls.map(call => call[0]).filter(arg => typeof arg === 'object');
+      return styleArgs.find(style => 'letter-spacing' in style);
     }
 
     it('applies CEA-608 positioning and formatting classes when the config is not set (default behavior)', () => {
-      subtitleOverlay = setupOverlay();
+      const { overlayDom } = setupOverlay();
 
       fireCea608CueEnter();
 
-      expect(overlayDomMock.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
-      expect(overlayDomMock.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
+      expect(overlayDom.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
+      expect(overlayDom.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
     });
 
     it('applies CEA-608 positioning but not the formatting class when enableCea608CaptionFormatting is false', () => {
-      subtitleOverlay = setupOverlay({ enableCea608CaptionFormatting: false });
+      const { overlayDom } = setupOverlay({ enableCea608CaptionFormatting: false });
 
       fireCea608CueEnter();
 
-      expect(overlayDomMock.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
-      expect(overlayDomMock.addClass).not.toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
+      expect(overlayDom.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
+      expect(overlayDom.addClass).not.toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
     });
 
     it('does not set inline letter-spacing on the label when enableCea608CaptionFormatting is false', () => {
-      subtitleOverlay = setupOverlay({ enableCea608CaptionFormatting: false });
-      subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
-      const addLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'addLabel');
+      const { overlay } = setupOverlay({ enableCea608CaptionFormatting: false });
+      const addLabelSpy = jest.spyOn((overlay as any).subtitleContainerManager, 'addLabel');
 
       fireCea608CueEnter();
 
-      const label = addLabelSpy.mock.calls[0][0] as SubtitleLabel;
-      const labelCssCalls = (label.getDomElement().css as jest.Mock).mock.calls;
-      const styleArgs = labelCssCalls.map(call => call[0]).filter(arg => typeof arg === 'object');
-      const styleWithLetterSpacing = styleArgs.find(style => 'letter-spacing' in style);
-      expect(styleWithLetterSpacing).toBeUndefined();
+      expect(getLetterSpacingStyle(addLabelSpy)).toBeUndefined();
     });
 
     it('sets inline letter-spacing on the label when the config is not set (default behavior)', () => {
-      subtitleOverlay = setupOverlay();
-      subtitleRegionContainerManagerMock = (subtitleOverlay as any).subtitleContainerManager;
-      const addLabelSpy = jest.spyOn(subtitleRegionContainerManagerMock, 'addLabel');
+      const { overlay } = setupOverlay();
+      const addLabelSpy = jest.spyOn((overlay as any).subtitleContainerManager, 'addLabel');
 
       fireCea608CueEnter();
 
-      const label = addLabelSpy.mock.calls[0][0] as SubtitleLabel;
-      const labelCssCalls = (label.getDomElement().css as jest.Mock).mock.calls;
-      const styleArgs = labelCssCalls.map(call => call[0]).filter(arg => typeof arg === 'object');
-      const styleWithLetterSpacing = styleArgs.find(style => 'letter-spacing' in style);
-      expect(styleWithLetterSpacing).toBeDefined();
+      expect(getLetterSpacingStyle(addLabelSpy)).toBeDefined();
     });
   });
 

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -326,14 +326,14 @@ export class PlayerEventEmitter {
     } as SubtitleEvent);
   }
 
-  fireSubtitleCueEnterEvent(overrides: Partial<SubtitleCueEvent> = {}): void {
+  fireSubtitleCueEnterEvent(overrides: Omit<Partial<SubtitleCueEvent>, 'type'> = {}): void {
     this.fireEvent<SubtitleCueEvent>({
       subtitleId: 'subtitleId',
       start: 0,
       end: 10,
       text: 'Test Subtitle',
-      type: PlayerEvent.CueEnter,
       ...overrides,
+      type: PlayerEvent.CueEnter,
     } as SubtitleCueEvent);
   }
 

--- a/spec/helper/PlayerEventEmitter.ts
+++ b/spec/helper/PlayerEventEmitter.ts
@@ -326,13 +326,14 @@ export class PlayerEventEmitter {
     } as SubtitleEvent);
   }
 
-  fireSubtitleCueEnterEvent(): void {
+  fireSubtitleCueEnterEvent(overrides: Partial<SubtitleCueEvent> = {}): void {
     this.fireEvent<SubtitleCueEvent>({
       subtitleId: 'subtitleId',
       start: 0,
       end: 10,
       text: 'Test Subtitle',
       type: PlayerEvent.CueEnter,
+      ...overrides,
     } as SubtitleCueEvent);
   }
 

--- a/src/scss/components/overlays/_subtitle-overlay-cea608.scss
+++ b/src/scss/components/overlays/_subtitle-overlay-cea608.scss
@@ -26,9 +26,7 @@
 
     .#{$prefix}-ui-subtitle-label {
       display: inline-block;
-      font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace;
       position: absolute;
-      text-transform: uppercase;
       white-space: nowrap;
 
       // center vertically
@@ -40,6 +38,13 @@
         content: normal;
         white-space: normal;
       }
+    }
+  }
+
+  &.#{$prefix}-cea608-formatting {
+    .#{$prefix}-ui-subtitle-label {
+      font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace;
+      text-transform: uppercase;
     }
   }
 }

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -486,7 +486,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
     });
 
     player.on(player.exports.PlayerEvent.SourceUnloaded, reset);
-    player.on(player.exports.PlayerEvent.SubtitleEnable, reset);
+    player.on(player.exports.PlayerEvent.SubtitleEnabled, reset);
     player.on(player.exports.PlayerEvent.SubtitleDisabled, reset);
   }
 

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -402,11 +402,14 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
 
       // Update font-size of all active subtitle labels
       const updateLabel = (label: SubtitleLabel) => {
-        label.getDomElement().css({
+        const labelCss: Record<string, string> = {
           'font-size': `${fontSize}px`,
           'line-height': `${rowHeight - windowMargin}px`,
-          'letter-spacing': `${fontLetterSpacing}px`,
-        });
+        };
+        if (this.isCea608FormattingEnabled()) {
+          labelCss['letter-spacing'] = `${fontLetterSpacing}px`;
+        }
+        label.getDomElement().css(labelCss);
 
         label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
       };
@@ -441,12 +444,10 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
         return;
       }
 
-      const applyFormatting = this.config.enableCea608CaptionFormatting !== false;
-
       if (!this.cea608Enabled) {
         this.cea608Enabled = true;
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
-        if (applyFormatting) {
+        if (this.isCea608FormattingEnabled()) {
           this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608_FORMATTING));
         }
       }
@@ -462,7 +463,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
         'font-size': `${fontSize}px`,
         'line-height': `${rowHeight - windowMargin}px`,
       };
-      if (applyFormatting) {
+      if (this.isCea608FormattingEnabled()) {
         labelCss['letter-spacing'] = `${fontLetterSpacing}px`;
       }
       label.getDomElement().css(labelCss);
@@ -504,6 +505,10 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
       this.subtitleContainerManager.removeLabel(this.previewSubtitle);
       this.updateComponents();
     }
+  }
+
+  private isCea608FormattingEnabled(): boolean {
+    return this.config.enableCea608CaptionFormatting !== false;
   }
 }
 

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -18,12 +18,23 @@ interface SubtitleCropDetectionResult {
   left: boolean;
 }
 
+export interface SubtitleOverlayConfig extends ContainerConfig {
+  /**
+   * Controls whether CEA-608 caption-specific text formatting (monospaced font, uppercase transform,
+   * and character letter-spacing) is applied. The CEA-608 grid-based row/column positioning is
+   * always preserved so captions still render at their authored on-screen positions.
+   *
+   * Defaults to `true` (CEA-608 text formatting is applied, matching historical behavior).
+   */
+  enableCea608CaptionFormatting?: boolean;
+}
+
 /**
  * Overlays the player to display subtitles.
  *
  * @category Components
  */
-export class SubtitleOverlay extends Container<ContainerConfig> {
+export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
   private subtitleManager: ActiveSubtitleManager;
   private previewSubtitleActive: boolean;
   private previewSubtitle: SubtitleLabel;
@@ -33,6 +44,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
 
   private static readonly CLASS_CONTROLBAR_VISIBLE = 'controlbar-visible';
   private static readonly CLASS_CEA_608 = 'cea608';
+  private static readonly CLASS_CEA_608_FORMATTING = 'cea608-formatting';
   private static readonly CEA608_NUM_ROWS = 15;
   private static readonly CEA608_NUM_COLUMNS = 32;
   private static readonly CEA608_COLUMN_OFFSET = 100 / SubtitleOverlay.CEA608_NUM_COLUMNS;
@@ -42,7 +54,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
   private cea608FontSizeFactor = 1;
   private ensureCea608GridSizeUpdated: () => void;
 
-  constructor(config: ContainerConfig = {}) {
+  constructor(config: SubtitleOverlayConfig = {}) {
     super(config);
 
     this.previewSubtitleActive = false;
@@ -52,6 +64,7 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
       config,
       {
         cssClass: 'ui-subtitle-overlay',
+        enableCea608CaptionFormatting: true,
       },
       this.config,
     );
@@ -428,9 +441,14 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         return;
       }
 
+      const applyFormatting = this.config.enableCea608CaptionFormatting !== false;
+
       if (!this.cea608Enabled) {
         this.cea608Enabled = true;
         this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
+        if (applyFormatting) {
+          this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608_FORMATTING));
+        }
       }
 
       let leftOffset = event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET + '%';
@@ -439,18 +457,22 @@ export class SubtitleOverlay extends Container<ContainerConfig> {
         leftOffset = SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET;
       }
 
-      label.getDomElement().css({
+      const labelCss: Record<string, string> = {
         left: leftOffset,
         'font-size': `${fontSize}px`,
-        'letter-spacing': `${fontLetterSpacing}px`,
         'line-height': `${rowHeight - windowMargin}px`,
-      });
+      };
+      if (applyFormatting) {
+        labelCss['letter-spacing'] = `${fontLetterSpacing}px`;
+      }
+      label.getDomElement().css(labelCss);
 
       label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
     });
 
     const reset = () => {
       this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
+      this.getDomElement().removeClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608_FORMATTING));
       this.cea608Enabled = false;
     };
 

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -81,7 +81,7 @@ export {
 export { RecommendationOverlay } from './components/overlays/RecommendationOverlay';
 export { RecommendationItem, RecommendationItemConfig } from './components/RecommendationItem';
 export { SeekBarLabel, SeekBarLabelConfig } from './components/seekbar/SeekBarLabel';
-export { SubtitleOverlay } from './components/overlays/SubtitleOverlay';
+export { SubtitleOverlay, SubtitleOverlayConfig } from './components/overlays/SubtitleOverlay';
 export { SubtitleSelectBox } from './components/settings/SubtitleSelectBox';
 export { TitleBar, TitleBarConfig } from './components/TitleBar';
 export { VolumeControlButton, VolumeControlButtonConfig } from './components/buttons/VolumeControlButton';


### PR DESCRIPTION
## Summary

- Adds `SubtitleOverlayConfig.enableCea608CaptionFormatting` (defaults to `true`) to opt out of CEA-608-specific text formatting — monospaced font, uppercase transform, and per-character letter-spacing. CEA-608 grid-based row/column positioning is preserved regardless.
- Splits the CSS: `.bmpui-cea608` now carries only grid/positioning rules; a new `.bmpui-cea608-formatting` class carries the font-family and uppercase. The formatting class is only applied when the option is enabled.

## Test plan

- [x] New unit tests for the CEA-608 formatting config:
  - Default behavior: `.bmpui-cea608` and `.bmpui-cea608-formatting` both applied; inline `letter-spacing` set.
  - Opt-out: `.bmpui-cea608` applied, `.bmpui-cea608-formatting` not; no inline `letter-spacing`.
  - Reset path: both classes removed on reset even when the formatting class was never added.
  - Grid recalc path: `letter-spacing` is or isn't re-applied based on the config.
- [x] Tests exercise the real `Container` implementation (via `jest.isolateModules` + `jest.unmock`) so the `mergeConfig` defaults contract is verified end-to-end. Mutation-tested by flipping the `mergeConfig` default from `true` to `false` — the two "default behavior" tests fail as expected.
- [x] Mutation-tested the grid-recalc fix by removing the `isCea608FormattingEnabled()` gate in `updateLabel` — the opt-out grid-recalc test fails as expected.
- [x] Manual verification against a real CEA-608 stream with the option set to `false`: positioning preserved, monospace/uppercase/letter-spacing not applied, behavior stable across player resizes and control-bar toggles.
