### PR TITLE
Restore inline italic/bold/underline styling in subtitle cues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [Unreleased]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Inline `<i>`/`<em>`, `<b>`/`<strong>`, and `<u>` tags in subtitle cue text (e.g. CEA-608 italics) were rendered without their semantic styling
+
 ## [4.11.1] - 2026-04-23
 
 ### Fixed

--- a/src/scss/components/overlays/_subtitle-overlay.scss
+++ b/src/scss/components/overlays/_subtitle-overlay.scss
@@ -29,6 +29,22 @@
       display: block;
     }
 
+    // Restore semantic inline formatting that `all: unset` above strips. Subtitle cues
+    // (CEA-608, WebVTT) use these tags to convey italic/bold/underlined text.
+    i,
+    em {
+      font-style: italic;
+    }
+
+    b,
+    strong {
+      font-weight: bold;
+    }
+
+    u {
+      text-decoration: underline;
+    }
+
     .#{$prefix}-subtitle-region-container {
       position: absolute;
 
@@ -75,16 +91,16 @@
         margin-right: auto;
       }
 
-      &[style*='text-align: right'] .#{$prefix}-ui-label-text {  
-        margin-left: auto;  
+      &[style*='text-align: right'] .#{$prefix}-ui-label-text {
+        margin-left: auto;
       }
 
-      &[style*='text-align: end'] .#{$prefix}-ui-label-text {  
+      &[style*='text-align: end'] .#{$prefix}-ui-label-text {
         margin-inline-start: auto;
       }
 
-      &[style*='text-align: start'] .#{$prefix}-ui-label-text {  
-        margin-inline-end: auto;  
+      &[style*='text-align: start'] .#{$prefix}-ui-label-text {
+        margin-inline-end: auto;
       }
     }
 

--- a/src/scss/components/overlays/_subtitle-overlay.scss
+++ b/src/scss/components/overlays/_subtitle-overlay.scss
@@ -38,7 +38,7 @@
 
     b,
     strong {
-      font-weight: bold;
+      font-weight: bolder;
     }
 
     u {


### PR DESCRIPTION
## Summary

- The subtitle overlay applies `* { all: unset; }` to every descendant as a defensive reset against host-app CSS bleed. That reset also strips the user-agent defaults from `<i>`/`<em>`/`<b>`/`<strong>`/`<u>`, which subtitle cues (CEA-608, WebVTT, TTML) rely on to convey italic/bold/underlined text — the tags ended up in the DOM but rendered upright and non-bold.
- Re-apply the semantic styling explicitly after the reset, scoped to the overlay.

## Test plan

- [x] Play a CEA-608 stream containing italic cues and confirm italics render slanted.
- [x] Play a WebVTT stream with `<b>` / `<u>` markup and confirm the styling renders.
- [x] Confirm no regression to other subtitle styling (font family, uppercase for CEA-608, color/background from user preferences).