### PR TITLE
Add UIConfig.defaultUiComponentConfigs for default-layout components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - New `SubtitleOverlayConfig.enableCea608CaptionFormatting` option (defaults to `true`) to opt out of CEA-608-specific text formatting (monospaced font, uppercase transform, character letter-spacing). CEA-608 row/column positioning is still applied.
+- `UIConfig.defaultUiComponentConfigs` to enable and configure individual components in the default UI layouts without building a custom UI. Initial support covers `quickSeekBackwardButton`, `quickSeekForwardButton`, and `watermark`. Each entry accepts an `enable` flag plus the underlying component config (e.g. `seekSeconds` for the quick-seek buttons).
+
+### Deprecated
+
+- `UIConfig.includeWatermark` in favor of `UIConfig.defaultUiComponentConfigs.watermark.enable`.
 
 ### Fixed
 

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -279,7 +279,20 @@
           //       ],
         },
         //    seekbarSnappingRange: 0,
-        includeWatermark: true,
+
+        defaultUiComponentConfigs: {
+          quickSeekBackwardButton: {
+            enable: true,
+            seekSeconds: -10,
+          },
+          quickSeekForwardButton: {
+            enable: true,
+            seekSeconds: 10,
+          },
+          watermark: {
+            enable: false,
+          },
+        },
       };
 
       var player;

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -217,7 +217,7 @@ export interface ComponentConfigs {
   /**
    * Enable the watermark in the default layout.
    */
-  watermark: WithEnable<WatermarkConfig>;
+  watermark?: WithEnable<WatermarkConfig>;
 }
 
 export interface ShadowDomConfig {

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -1,6 +1,7 @@
 import { ErrorMessageMap, ErrorMessageTranslator } from './components/overlays/ErrorMessageOverlay';
 import { SourceConfig } from 'bitmovin-player';
 import { LocalizationConfig } from './UIManager';
+import { QuickSeekButtonConfig, WatermarkConfig } from './main';
 
 /**
  * A link to an external recommended video that can be shown in the {@link RecommendationOverlay} after the
@@ -164,6 +165,8 @@ export interface UIConfig {
    */
   ecoMode?: boolean;
   /**
+   * @deprecated Use {@link UIConfig.defaultUiComponentConfigs} instead.
+   *
    * Specifies if the Watermark element should be included in the UI.
    * Per default, the Watermark shows the Bitmovin Logo.
    *
@@ -186,6 +189,35 @@ export interface UIConfig {
    * Allows setting a {@link LocalizationConfig} to specify language details of the UI.
    */
   localization?: LocalizationConfig;
+  /**
+   * Allows configuring and/or enabling different components in the default layouts without creating a custom UI.
+   */
+  defaultUiComponentConfigs?: ComponentConfigs;
+}
+
+/**
+ * Extends specific ComponentConfig interfaces with a property to enable the config in the default layout.
+ */
+export type WithEnable<T> = T & {
+  /**
+   * Enable the component in the default UI layout, if the UI variant layout contains that component.
+   */
+  enable?: boolean;
+};
+
+export interface ComponentConfigs {
+  /**
+   * Enable and configure the quick seek back button in the default layout.
+   */
+  quickSeekBackwardButton?: WithEnable<QuickSeekButtonConfig>;
+  /**
+   * Enable and configure the quick seek forward button in the default layout.
+   */
+  quickSeekForwardButton?: WithEnable<QuickSeekButtonConfig>;
+  /**
+   * Enable the watermark in the default layout.
+   */
+  watermark: WithEnable<WatermarkConfig>;
 }
 
 export interface ShadowDomConfig {

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -208,10 +208,20 @@ export type WithEnable<T> = T & {
 export interface ComponentConfigs {
   /**
    * Enable and configure the quick seek back button in the default layout.
+   *
+   * The configured `seekSeconds` value is automatically applied as a backward seek for this button, i.e. it will be a
+   * negative number.
+   *
+   * Omitting `seekSeconds` or setting it to `0` while enabling it will use the default `seekSeconds` value.
    */
   quickSeekBackwardButton?: WithEnable<QuickSeekButtonConfig>;
   /**
    * Enable and configure the quick seek forward button in the default layout.
+   *
+   * The configured `seekSeconds` value is automatically applied as a forward seek for this button, i.e. it will be an
+   * absolute, positive number.
+   *
+   * Omitting `seekSeconds` or setting it to `0` while enabling it will use the default `seekSeconds` value.
    */
   quickSeekForwardButton?: WithEnable<QuickSeekButtonConfig>;
   /**

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -165,7 +165,7 @@ export interface UIConfig {
    */
   ecoMode?: boolean;
   /**
-   * @deprecated Use {@link UIConfig.defaultUiComponentConfigs} instead.
+   * @deprecated Use {@link UIConfig.defaultUiComponentConfigs}.watermark.enable instead.
    *
    * Specifies if the Watermark element should be included in the UI.
    * Per default, the Watermark shows the Bitmovin Logo.

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -791,10 +791,9 @@ export namespace UIFactory {
   }
 
   function configureConditionalComponents(config: UIConfig) {
+    const watermarkEnabled = config.defaultUiComponentConfigs?.watermark?.enable ?? config.includeWatermark;
     const watermark = [
-      config.includeWatermark || config.defaultUiComponentConfigs?.watermark?.enable
-        ? new Watermark(config.defaultUiComponentConfigs?.watermark || {})
-        : null,
+      watermarkEnabled ? new Watermark(config.defaultUiComponentConfigs?.watermark || {}) : null,
     ].filter(e => e);
 
     const quickseekBack = [];

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -55,6 +55,7 @@ import { AdMessageLabel } from './components/ads/AdMessageLabel';
 import { FocusableContainer } from './spatialnavigation/FocusableContainer';
 import { BrowserUtils } from './utils/BrowserUtils';
 import { RecommendationOverlayNavigationGroup } from './spatialnavigation/RecommendationOverlayNavigationGroup';
+import { QuickSeekButton } from './components/buttons/QuickSeekButton';
 
 /**
  * Provides factory methods to create Bitmovin provided UIs.
@@ -93,7 +94,7 @@ export namespace UIFactory {
           },
         },
         {
-          ui: UIFactory.defaultLayouts.smallScreen(),
+          ui: UIFactory.defaultLayouts.smallScreen(config),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi && context.documentWidth < smallScreenSwitchWidth;
           },
@@ -105,7 +106,7 @@ export namespace UIFactory {
           },
         },
         {
-          ...UIFactory.defaultLayouts.tv(),
+          ...UIFactory.defaultLayouts.tv(config),
           condition: (context: UIConditionContext) => {
             return context.isTv && !context.isAd && !context.adRequiresUi;
           },
@@ -149,7 +150,7 @@ export namespace UIFactory {
           },
         },
         {
-          ui: UIFactory.defaultLayouts.smallScreen(),
+          ui: UIFactory.defaultLayouts.smallScreen(config),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -192,7 +193,7 @@ export namespace UIFactory {
           },
         },
         {
-          ...UIFactory.defaultLayouts.tv(),
+          ...UIFactory.defaultLayouts.tv(config),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
@@ -248,6 +249,9 @@ export namespace UIFactory {
       const subtitleOverlay = new SubtitleOverlay();
 
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode === true);
+
+      const conditionalComponents = configureConditionalComponents(config);
+
       const controlBar = new ControlBar({
         components: [
           new Container({
@@ -267,6 +271,8 @@ export namespace UIFactory {
           new Container({
             components: [
               new PlaybackToggleButton(),
+              ...conditionalComponents.quickSeekBackwardButtons,
+              ...conditionalComponents.quickSeekForwardButtons,
               new VolumeToggleButton(),
               new VolumeSlider(),
               new Spacer(),
@@ -282,8 +288,6 @@ export namespace UIFactory {
         ],
       });
 
-      const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
-
       return new UIContainer({
         components: [
           subtitleOverlay,
@@ -293,7 +297,7 @@ export namespace UIFactory {
           controlBar,
           new TitleBar(),
           new RecommendationOverlay(),
-          ...conditionalComponents,
+          ...conditionalComponents.watermark,
           new DismissClickOverlay({ target: settingsPanel }),
           settingsPanel,
           new ErrorMessageOverlay(),
@@ -359,10 +363,12 @@ export namespace UIFactory {
       });
     }
 
-    export function smallScreen(): UIContainer {
+    export function smallScreen(config: UIConfig = {}): UIContainer {
       const subtitleOverlay = new SubtitleOverlay();
 
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
+
+      const conditionalComponents = configureConditionalComponents(config);
 
       const controlBar = new ControlBar({
         components: [
@@ -383,6 +389,8 @@ export namespace UIFactory {
           new Container({
             components: [
               new PlaybackToggleButton(),
+              ...conditionalComponents.quickSeekBackwardButtons,
+              ...conditionalComponents.quickSeekForwardButtons,
               new VolumeToggleButton(),
               new VolumeSlider(),
               new Spacer(),
@@ -485,6 +493,8 @@ export namespace UIFactory {
     }
 
     export function castReceiver(config: UIConfig = {}): UIContainer {
+      const conditionalComponents = configureConditionalComponents(config);
+
       const controlBar = new ControlBar({
         components: [
           new Container({
@@ -504,8 +514,6 @@ export namespace UIFactory {
         ],
       });
 
-      const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
-
       return new CastUIContainer({
         components: [
           new SubtitleOverlay(),
@@ -513,7 +521,7 @@ export namespace UIFactory {
           new PlaybackToggleOverlay(),
           controlBar,
           new TitleBar({ keepHiddenWithoutMetadata: true }),
-          ...conditionalComponents,
+          ...conditionalComponents.watermark,
           new ErrorMessageOverlay(),
         ],
         cssClasses: ['ui-cast-receiver'],
@@ -525,10 +533,12 @@ export namespace UIFactory {
       });
     }
 
-    export function tv(): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
+    export function tv(config: UIConfig = {}): Pick<UIVariant, 'ui' | 'spatialNavigation'> {
       const seekBar = new SeekBar({ label: new SeekBarLabel() });
       const subtitleOverlay = new SubtitleOverlay();
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, 5000);
+
+      const conditionalComponents = configureConditionalComponents(config);
 
       const subtitleListBox = new SubtitleListBox({ title: i18n.getLocalizer('settings.subtitles') });
       const subtitleListBoxOpenButton = new SettingsToggleButton({
@@ -563,6 +573,8 @@ export namespace UIFactory {
       const bottomControlBar = new Container({
         components: [
           playbackToggleButton,
+          ...conditionalComponents.quickSeekBackwardButtons,
+          ...conditionalComponents.quickSeekForwardButtons,
           new Spacer(),
           subtitleListBoxOpenButton,
           audioListBoxToggleButton,
@@ -776,5 +788,35 @@ export namespace UIFactory {
     settingsPanel.addComponent(subtitleSettingsPanelPage);
 
     return settingsPanel;
+  }
+
+  function configureConditionalComponents(config: UIConfig) {
+    const watermark = [
+      config.includeWatermark || config.defaultUiComponentConfigs?.watermark?.enable
+        ? new Watermark(config.defaultUiComponentConfigs?.watermark || {})
+        : null,
+    ].filter(e => e);
+
+    const quickseekBack = [];
+    if (config.defaultUiComponentConfigs?.quickSeekBackwardButton?.enable) {
+      config.defaultUiComponentConfigs.quickSeekBackwardButton.seekSeconds = -Math.abs(
+        config.defaultUiComponentConfigs.quickSeekBackwardButton.seekSeconds || 10,
+      );
+      quickseekBack.push(new QuickSeekButton(config.defaultUiComponentConfigs?.quickSeekBackwardButton));
+    }
+
+    const quickseekForward = [];
+    if (config.defaultUiComponentConfigs?.quickSeekForwardButton?.enable) {
+      config.defaultUiComponentConfigs.quickSeekForwardButton.seekSeconds = Math.abs(
+        config.defaultUiComponentConfigs.quickSeekForwardButton.seekSeconds || 10,
+      );
+      quickseekForward.push(new QuickSeekButton(config.defaultUiComponentConfigs?.quickSeekForwardButton));
+    }
+
+    return {
+      quickSeekBackwardButtons: quickseekBack,
+      quickSeekForwardButtons: quickseekForward,
+      watermark: watermark,
+    };
   }
 }


### PR DESCRIPTION
## Summary

- Adds `UIConfig.defaultUiComponentConfigs`, an opt-in map for enabling and configuring individual components in the default UI layouts without building a custom UI.
- Initial coverage: `quickSeekBackwardButton`, `quickSeekForwardButton`, and `watermark`. Each entry takes an `enable` flag plus the underlying component config (e.g. `seekSeconds` for the quick-seek buttons, which is auto-signed to match the direction).
- Wires the new config through `UIFactory.defaultLayouts.smallScreen`, `tv`, `castReceiver`, and the modern desktop layout via a new `configureConditionalComponents` helper.
- Deprecates `UIConfig.includeWatermark` in favor of `defaultUiComponentConfigs.watermark.enable`. The legacy flag still works.

## Test plan

- [x] Run the demo page (`src/html/index.html`) with `defaultUiComponentConfigs.quickSeek{Backward,Forward}Button.enable = true` and verify both buttons render and seek by the configured `seekSeconds` on desktop, small-screen, and TV layouts.
- [x] Verify `defaultUiComponentConfigs.watermark.enable = true` shows the watermark and `false` (or omitted) hides it.
- [x] Confirm the legacy `includeWatermark: true` path still renders the watermark for backward compatibility.
- [x] Confirm negative `seekSeconds` on the forward button (and positive on the backward button) is normalized to the correct sign.
- [x] `npm run build` / type-check passes.