### PR TITLE
Fix `APINotAvailableError` on UI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Inline `<i>`/`<em>`, `<b>`/`<strong>`, and `<u>` tags in subtitle cue text (e.g. CEA-608 italics) were rendered without their semantic styling
+- Player APIs called after the player was already destroyed
 
 ## [4.12.0] - 2026-04-30
 

--- a/src/ts/components/UIContainer.ts
+++ b/src/ts/components/UIContainer.ts
@@ -65,7 +65,6 @@ export class UIContainer extends Container<UIContainerConfig> {
   private static readonly CONTROLS_HIDDEN = 'controls-hidden';
 
   private uiHideTimeout: Timeout;
-  private isReleased: boolean = false;
   private playerStateChange: EventDispatcher<UIContainer, PlayerUtils.PlayerState>;
 
   private userInteractionEventSource: DOM;
@@ -157,9 +156,6 @@ export class UIContainer extends Container<UIContainerConfig> {
     };
 
     this.showUi = () => {
-      if (this.isReleased) {
-        return;
-      }
       isHideUiPending = false;
 
       if (!isUiShown) {
@@ -174,9 +170,6 @@ export class UIContainer extends Container<UIContainerConfig> {
     };
 
     this.hideUi = (force: boolean = false) => {
-      if (this.isReleased) {
-        return;
-      }
       // Hide the UI only if it is shown, and if not casting
       if (isUiShown && !player.isCasting()) {
         if (force) {
@@ -505,7 +498,8 @@ export class UIContainer extends Container<UIContainerConfig> {
   }
 
   release(): void {
-    this.isReleased = true;
+    // Hide the UI to make sure hideUi becomes a no-op and avoid race conditions with the hide timeout while releasing
+    this.hideUi(true);
 
     // Explicitly unsubscribe user interaction event handlers because they could be attached to an external element
     // that isn't owned by the UI and therefore not removed on release.

--- a/src/ts/components/UIContainer.ts
+++ b/src/ts/components/UIContainer.ts
@@ -7,7 +7,7 @@ import { CancelEventArgs, Event as UiEvent, EventDispatcher } from '../EventDisp
 import { PlayerAPI, PlayerResizedEvent } from 'bitmovin-player';
 import { i18n } from '../localization/i18n';
 import { Button, ButtonConfig } from './buttons/Button';
-import { TouchControlOverlay, TouchControlOverlayConfig } from './overlays/TouchControlOverlay';
+import { TouchControlOverlay } from './overlays/TouchControlOverlay';
 import { Component, ComponentConfig } from './Component';
 import { SettingsPanel } from './settings/SettingsPanel';
 
@@ -65,6 +65,7 @@ export class UIContainer extends Container<UIContainerConfig> {
   private static readonly CONTROLS_HIDDEN = 'controls-hidden';
 
   private uiHideTimeout: Timeout;
+  private isReleased: boolean = false;
   private playerStateChange: EventDispatcher<UIContainer, PlayerUtils.PlayerState>;
 
   private userInteractionEventSource: DOM;
@@ -156,6 +157,9 @@ export class UIContainer extends Container<UIContainerConfig> {
     };
 
     this.showUi = () => {
+      if (this.isReleased) {
+        return;
+      }
       isHideUiPending = false;
 
       if (!isUiShown) {
@@ -170,6 +174,9 @@ export class UIContainer extends Container<UIContainerConfig> {
     };
 
     this.hideUi = (force: boolean = false) => {
+      if (this.isReleased) {
+        return;
+      }
       // Hide the UI only if it is shown, and if not casting
       if (isUiShown && !player.isCasting()) {
         if (force) {
@@ -498,6 +505,8 @@ export class UIContainer extends Container<UIContainerConfig> {
   }
 
   release(): void {
+    this.isReleased = true;
+
     // Explicitly unsubscribe user interaction event handlers because they could be attached to an external element
     // that isn't owned by the UI and therefore not removed on release.
     if (this.userInteractionEvents) {


### PR DESCRIPTION
## Description

Fixes a race condition where `player.isCasting()` (and other player API calls inside `hideUi`/`showUi` closures) could be called after the player was already destroyed.

### Root cause

`UIContainer` creates a `Timeout` that calls `hideUi` after `hideDelay` ms. When the timeout's delay elapses, the callback is placed in the JS macrotask queue. If the player is destroyed and `release()` is called in the same execution context, `clearTimeout` is a no-op because the timer has already fired. The callback is already queued and will execute after `release()` returns, hitting the destroyed player's API.

### This fix

Call `hideUi` at the very top of `release()`, causing the next `hideUi` to become a no-op, hence blocking all player API calls after the player has been torn down.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry