### PR TITLE
a11y: fix SettingsToggleButton ARIA and honor prefers-reduced-motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Support for the `prefers-reduced-motion` accessibility setting: all UI animations and transitions are collapsed to ~1 ms when the user has set the OS-level `prefers-reduced-motion: reduce` preference (animation / transition end events still fire so dependent UI logic continues to work)
+- Support for the `prefers-reduced-motion` accessibility setting: UI animations and transitions are disabled when the user has set the OS-level `prefers-reduced-motion: reduce` preference
 - New `UIConfig.cea608SmallPlayerHeightThreshold` option (default `360`) to configure the rendered player height threshold at or below which small-player CEA-608 caption adjustments are applied
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Support for the `prefers-reduced-motion` accessibility setting: all UI animations and transitions are collapsed to ~1 ms when the user has set the OS-level `prefers-reduced-motion: reduce` preference (animation / transition end events still fire so dependent UI logic continues to work)
 - New `UIConfig.cea608SmallPlayerHeightThreshold` option (default `360`) to configure the rendered player height threshold at or below which small-player CEA-608 caption adjustments are applied
 
 ### Changed
 
 - CEA-608 captions on players with a rendered height at or below 360 CSS pixels (configurable via `cea608SmallPlayerHeightThreshold`) now stay readable by using a centered 80% safe area and avoiding control-bar pushup that can crowd caption rows on small players
-- The settings toggle button now exposes valid ARIA semantics for assistive technologies: it relies on the implicit `<button>` role (the previous custom `role="pop-up button"` is not a valid ARIA role), advertises the popup via `aria-haspopup="menu"`, links the panel via `aria-controls`, and reflects open / closed state in `aria-expanded`
-- All UI animations and transitions are collapsed to ~1 ms when the user has set the OS-level `prefers-reduced-motion: reduce` preference (animation / transition end events still fire so dependent UI logic continues to work)
 
 ### Fixed
 
+- Wrong ARIA semantics on the `SettingsToggleButton`: it now relies on the native `<button>` role (the previous custom `role="pop-up button"` is not a valid ARIA role), advertises the popup via `aria-haspopup="menu"`, links the panel via `aria-controls`, and reflects open / closed state in `aria-expanded`
 - CEA-608 captions could keep stale sizing after CEA subtitle rendering was disabled and re-enabled, causing captions to appear incorrectly scaled or positioned
 
 ## [4.13.0] - 2026-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - CEA-608 captions on players with a rendered height at or below 360 CSS pixels (configurable via `cea608SmallPlayerHeightThreshold`) now stay readable by using a centered 80% safe area and avoiding control-bar pushup that can crowd caption rows on small players
+- The settings toggle button now exposes valid ARIA semantics for assistive technologies: it relies on the implicit `<button>` role (the previous custom `role="pop-up button"` is not a valid ARIA role), advertises the popup via `aria-haspopup="menu"`, links the panel via `aria-controls`, and reflects open / closed state in `aria-expanded`
+- All UI animations and transitions are collapsed to ~1 ms when the user has set the OS-level `prefers-reduced-motion: reduce` preference (animation / transition end events still fire so dependent UI logic continues to work)
 
 ### Fixed
 

--- a/spec/components/settings/SettingsToggleButton.spec.ts
+++ b/spec/components/settings/SettingsToggleButton.spec.ts
@@ -51,11 +51,35 @@ describe('SettingsToggleButton', () => {
 
       attrSpy.mockClear();
 
-      (panel['componentEvents'].onShow as { dispatch: (s: unknown) => void }).dispatch(panel);
-      expect(attrSpy).toHaveBeenCalledWith('aria-expanded', 'true');
-
-      (panel['componentEvents'].onHide as { dispatch: (s: unknown) => void }).dispatch(panel);
+      // Drive the show/hide events via the public Container API rather than reaching
+      // into the private `componentEvents` field. Component.hidden starts unset, so the
+      // first `hide()` flips it from falsy → true (firing onHide), and `show()` then
+      // flips it back to false (firing onShow).
+      panel.hide();
       expect(attrSpy).toHaveBeenCalledWith('aria-expanded', 'false');
+
+      panel.show();
+      expect(attrSpy).toHaveBeenCalledWith('aria-expanded', 'true');
+    });
+
+    it('refreshes aria-controls / aria-owns when the panel active page changes', () => {
+      const secondPage = new SettingsPanelPage({});
+      panel = new SettingsPanel({
+        components: [new SettingsPanelPage({}), secondPage],
+        hidden: true,
+      });
+      const button = new SettingsToggleButton({ settingsPanel: panel });
+      const playerMock = MockHelper.getPlayerMock();
+      const uiManagerMock = MockHelper.getUiInstanceManagerMock();
+      panel.configure(playerMock, uiManagerMock);
+      button.configure(playerMock, uiManagerMock);
+
+      attrSpy.mockClear();
+
+      panel.setActivePage(secondPage);
+      const newId = secondPage.getConfig().id;
+      expect(attrSpy).toHaveBeenCalledWith('aria-controls', newId);
+      expect(attrSpy).toHaveBeenCalledWith('aria-owns', newId);
     });
   });
 });

--- a/spec/components/settings/SettingsToggleButton.spec.ts
+++ b/spec/components/settings/SettingsToggleButton.spec.ts
@@ -28,18 +28,19 @@ describe('SettingsToggleButton', () => {
       expect(button.getConfig().role).toBe('button');
     });
 
-    it('sets aria-haspopup, aria-controls, aria-owns, and aria-expanded on the DOM element', () => {
+    it('sets aria-haspopup, aria-controls, and aria-expanded on the DOM element', () => {
       new SettingsToggleButton({ settingsPanel: panel });
       const calls = attrSpy.mock.calls.map(([name, value]: [string, string]) => `${name}=${value}`);
       const panelId = panel.getActivePage().getConfig().id;
       expect(calls).toEqual(
-        expect.arrayContaining([
-          'aria-haspopup=menu',
-          `aria-controls=${panelId}`,
-          `aria-owns=${panelId}`,
-          'aria-expanded=false',
-        ]),
+        expect.arrayContaining(['aria-haspopup=menu', `aria-controls=${panelId}`, 'aria-expanded=false']),
       );
+    });
+
+    it('does not set aria-owns (avoids iOS VoiceOver double-announcement when paired with aria-controls)', () => {
+      new SettingsToggleButton({ settingsPanel: panel });
+      const names = attrSpy.mock.calls.map(([name]: [string]) => name);
+      expect(names).not.toContain('aria-owns');
     });
 
     it('flips aria-expanded when the panel show / hide events fire', () => {
@@ -62,7 +63,7 @@ describe('SettingsToggleButton', () => {
       expect(attrSpy).toHaveBeenCalledWith('aria-expanded', 'true');
     });
 
-    it('refreshes aria-controls / aria-owns when the panel active page changes', () => {
+    it('refreshes aria-controls when the panel active page changes', () => {
       const secondPage = new SettingsPanelPage({});
       panel = new SettingsPanel({
         components: [new SettingsPanelPage({}), secondPage],
@@ -79,7 +80,6 @@ describe('SettingsToggleButton', () => {
       panel.setActivePage(secondPage);
       const newId = secondPage.getConfig().id;
       expect(attrSpy).toHaveBeenCalledWith('aria-controls', newId);
-      expect(attrSpy).toHaveBeenCalledWith('aria-owns', newId);
     });
   });
 });

--- a/spec/components/settings/SettingsToggleButton.spec.ts
+++ b/spec/components/settings/SettingsToggleButton.spec.ts
@@ -1,0 +1,61 @@
+import { DOM } from '../../../src/ts/DOM';
+import { SettingsPanel, SettingsPanelConfig } from '../../../src/ts/components/settings/SettingsPanel';
+import { SettingsPanelPage } from '../../../src/ts/components/settings/SettingsPanelPage';
+import { SettingsToggleButton } from '../../../src/ts/components/settings/SettingsToggleButton';
+import { MockHelper } from '../../helper/MockHelper';
+
+describe('SettingsToggleButton', () => {
+  describe('ARIA wiring', () => {
+    let panel: SettingsPanel<SettingsPanelConfig>;
+    let attrSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // Spy on DOM.attr *before* constructing the button so we capture the calls
+      // emitted from the constructor. DOM is auto-mocked via the MockHelper, so its
+      // prototype methods are jest spies/stubs that we can query.
+      attrSpy = jest.spyOn(DOM.prototype, 'attr');
+      panel = new SettingsPanel({ components: [new SettingsPanelPage({})], hidden: true });
+    });
+
+    afterEach(() => {
+      attrSpy.mockRestore();
+    });
+
+    it('does not configure the invalid `pop-up button` role', () => {
+      const button = new SettingsToggleButton({ settingsPanel: panel });
+      // Inherits the valid native button role from the Button base class instead of the
+      // previously-used invalid "pop-up button" string.
+      expect(button.getConfig().role).toBe('button');
+    });
+
+    it('sets aria-haspopup, aria-controls, aria-owns, and aria-expanded on the DOM element', () => {
+      new SettingsToggleButton({ settingsPanel: panel });
+      const calls = attrSpy.mock.calls.map(([name, value]: [string, string]) => `${name}=${value}`);
+      const panelId = panel.getActivePage().getConfig().id;
+      expect(calls).toEqual(
+        expect.arrayContaining([
+          'aria-haspopup=menu',
+          `aria-controls=${panelId}`,
+          `aria-owns=${panelId}`,
+          'aria-expanded=false',
+        ]),
+      );
+    });
+
+    it('flips aria-expanded when the panel show / hide events fire', () => {
+      const button = new SettingsToggleButton({ settingsPanel: panel });
+      const playerMock = MockHelper.getPlayerMock();
+      const uiManagerMock = MockHelper.getUiInstanceManagerMock();
+      panel.configure(playerMock, uiManagerMock);
+      button.configure(playerMock, uiManagerMock);
+
+      attrSpy.mockClear();
+
+      (panel['componentEvents'].onShow as { dispatch: (s: unknown) => void }).dispatch(panel);
+      expect(attrSpy).toHaveBeenCalledWith('aria-expanded', 'true');
+
+      (panel['componentEvents'].onHide as { dispatch: (s: unknown) => void }).dispatch(panel);
+      expect(attrSpy).toHaveBeenCalledWith('aria-expanded', 'false');
+    });
+  });
+});

--- a/src/scss/bitmovinplayer-ui.scss
+++ b/src/scss/bitmovinplayer-ui.scss
@@ -54,18 +54,18 @@
 @import 'small-screen';
 @import 'tv';
 
-// Honor the user's OS-level "reduce motion" preference. We collapse
-// transitions and animations to ~0 ms (rather than removing them) so
-// `transitionend` / `animationend` listeners that the UI depends on
-// still fire.
+// Honor the user's OS-level "reduce motion" preference. Disable transitions
+// and animations outright — overriding only durations breaks our show/hide
+// transitions, which depend on `visibility 0s` to flip instantly when a
+// component becomes visible (with a non-zero duration, visibility uses
+// discrete interpolation and stays hidden for one frame, causing a visible
+// pop). `SubtitleOverlay.awaitTransitionEnd` already short-circuits when
+// `transition-property` is `none`, so no listeners are stranded.
 @media (prefers-reduced-motion: reduce) {
   .#{$prefix}-ui-uicontainer,
   .#{$prefix}-ui-uicontainer * {
-    animation-duration: 1ms !important;
-    animation-delay: 0ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 1ms !important;
-    transition-delay: 0ms !important;
+    animation: none !important;
+    transition: none !important;
     scroll-behavior: auto !important;
   }
 }

--- a/src/scss/bitmovinplayer-ui.scss
+++ b/src/scss/bitmovinplayer-ui.scss
@@ -62,8 +62,10 @@
   .#{$prefix}-ui-uicontainer,
   .#{$prefix}-ui-uicontainer * {
     animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 1ms !important;
+    transition-delay: 0ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/src/scss/bitmovinplayer-ui.scss
+++ b/src/scss/bitmovinplayer-ui.scss
@@ -54,6 +54,20 @@
 @import 'small-screen';
 @import 'tv';
 
+// Honor the user's OS-level "reduce motion" preference. We collapse
+// transitions and animations to ~0 ms (rather than removing them) so
+// `transitionend` / `animationend` listeners that the UI depends on
+// still fire.
+@media (prefers-reduced-motion: reduce) {
+  .#{$prefix}-ui-uicontainer,
+  .#{$prefix}-ui-uicontainer * {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 // sass-lint:disable nesting-depth
 .#{$prefix}-ui-uicontainer {
   color: $color-primary;

--- a/src/ts/components/settings/SettingsToggleButton.ts
+++ b/src/ts/components/settings/SettingsToggleButton.ts
@@ -39,25 +39,39 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
       throw new Error('Required SettingsPanel is missing');
     }
 
+    // Setting both ariaLabels on the parent ToggleButton suppresses its default
+    // `aria-pressed` attribute (see the ToggleButtonConfig.ariaLabel doc) so we don't end
+    // up announcing both pressed/unpressed *and* expanded/collapsed for the same widget.
+    // Using the same localizer for both states keeps the announced name stable.
+    const settingsLabel = i18n.getLocalizer('settings');
     this.config = this.mergeConfig(
       config,
       {
         cssClass: 'ui-settingstogglebutton',
-        text: i18n.getLocalizer('settings'),
+        text: settingsLabel,
+        onAriaLabel: settingsLabel,
+        offAriaLabel: settingsLabel,
         settingsPanel: null,
         autoHideWhenNoActiveSettings: true,
       },
       <SettingsToggleButtonConfig>this.config,
     );
 
-    // The element is a native <button>; inherits role=button implicitly.
-    // aria-haspopup="menu" advertises that activation reveals a menu, and aria-controls /
-    // aria-owns points consumers (screen readers) at the controlled panel id.
-    const settingsPanelId = config.settingsPanel.getActivePage().getConfig().id;
+    // The element renders as a native `<button>` (with the explicit `role="button"`
+    // inherited from the Button base). aria-haspopup="menu" advertises that activation
+    // reveals a menu, and aria-controls / aria-owns point assistive tech at the panel id.
+    // Both are updated whenever the panel's active page changes (see `configure`).
     this.getDomElement().attr('aria-haspopup', 'menu');
+    this.updateAriaPanelIdRefs();
+    this.getDomElement().attr('aria-expanded', 'false');
+  }
+
+  private updateAriaPanelIdRefs(): void {
+    const settingsPanel = this.getConfig().settingsPanel;
+    if (!settingsPanel) return;
+    const settingsPanelId = settingsPanel.getActivePage().getConfig().id;
     this.getDomElement().attr('aria-controls', settingsPanelId);
     this.getDomElement().attr('aria-owns', settingsPanelId);
-    this.getDomElement().attr('aria-expanded', 'false');
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
@@ -86,6 +100,14 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
       this.off();
       this.getDomElement().attr('aria-expanded', 'false');
     });
+
+    // Keep aria-controls / aria-owns pointing at the *currently* active page id —
+    // the user may navigate into sub-pages while the panel is open.
+    settingsPanel.onActivePageChanged.subscribe(() => this.updateAriaPanelIdRefs());
+
+    // Sync aria-expanded with the panel's current visibility in case the panel was
+    // already shown before `configure()` ran (`hidden: false`, manual `show()`, etc.).
+    this.getDomElement().attr('aria-expanded', settingsPanel.isShown() ? 'true' : 'false');
 
     // Ensure that only one `SettingPanel` is visible at once
     // Keep track of shown SettingsPanels

--- a/src/ts/components/settings/SettingsToggleButton.ts
+++ b/src/ts/components/settings/SettingsToggleButton.ts
@@ -46,20 +46,18 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
         text: i18n.getLocalizer('settings'),
         settingsPanel: null,
         autoHideWhenNoActiveSettings: true,
-        role: 'pop-up button',
       },
       <SettingsToggleButtonConfig>this.config,
     );
 
-    /**
-     * WCAG20 standard defines which popup menu (element id) is owned by the button
-     */
-    this.getDomElement().attr('aria-owns', config.settingsPanel.getActivePage().getConfig().id);
-
-    /**
-     * WCAG20 standard defines that a button has a popup menu bound to it
-     */
-    this.getDomElement().attr('aria-haspopup', 'true');
+    // The element is a native <button>; inherits role=button implicitly.
+    // aria-haspopup="menu" advertises that activation reveals a menu, and aria-controls /
+    // aria-owns points consumers (screen readers) at the controlled panel id.
+    const settingsPanelId = config.settingsPanel.getActivePage().getConfig().id;
+    this.getDomElement().attr('aria-haspopup', 'menu');
+    this.getDomElement().attr('aria-controls', settingsPanelId);
+    this.getDomElement().attr('aria-owns', settingsPanelId);
+    this.getDomElement().attr('aria-expanded', 'false');
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
@@ -81,10 +79,12 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
     settingsPanel.onShow.subscribe(() => {
       // Set toggle status to on when the settings panel shows
       this.on();
+      this.getDomElement().attr('aria-expanded', 'true');
     });
     settingsPanel.onHide.subscribe(() => {
       // Set toggle status to off when the settings panel hides
       this.off();
+      this.getDomElement().attr('aria-expanded', 'false');
     });
 
     // Ensure that only one `SettingPanel` is visible at once

--- a/src/ts/components/settings/SettingsToggleButton.ts
+++ b/src/ts/components/settings/SettingsToggleButton.ts
@@ -59,8 +59,11 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
 
     // The element renders as a native `<button>` (with the explicit `role="button"`
     // inherited from the Button base). aria-haspopup="menu" advertises that activation
-    // reveals a menu, and aria-controls / aria-owns point assistive tech at the panel id.
-    // Both are updated whenever the panel's active page changes (see `configure`).
+    // reveals a menu, and aria-controls points assistive tech at the panel id, which
+    // is refreshed whenever the panel's active page changes (see `configure`).
+    // We intentionally do not set aria-owns: when it points at the same element as
+    // aria-controls, iOS VoiceOver follows both relationships and announces the menu
+    // twice. The WAI-ARIA APG menu button pattern uses aria-controls alone.
     this.getDomElement().attr('aria-haspopup', 'menu');
     this.updateAriaPanelIdRefs();
     this.getDomElement().attr('aria-expanded', 'false');
@@ -71,7 +74,6 @@ export class SettingsToggleButton extends ToggleButton<SettingsToggleButtonConfi
     if (!settingsPanel) return;
     const settingsPanelId = settingsPanel.getActivePage().getConfig().id;
     this.getDomElement().attr('aria-controls', settingsPanelId);
-    this.getDomElement().attr('aria-owns', settingsPanelId);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {


### PR DESCRIPTION
## Summary

Two small accessibility fixes:

### 1. Fix invalid ARIA role on `SettingsToggleButton`

`SettingsToggleButton.ts` was setting `role="pop-up button"` on its `<button>` element. That value is not in the ARIA role registry — screen readers fell back to the default (`button`) and the popup relationship wasn't announced reliably.

The fix is to:

- Drop the custom `role` so the element keeps its implicit native `button` role.
- Set `aria-haspopup="menu"` (was `"true"` — `"menu"` is more specific and matches what the panel actually is).
- Add `aria-controls` pointing at the active panel-page id, refreshed on `onActivePageChanged` so it stays correct as the user navigates sub-pages.
- Add `aria-expanded`, initialized from the panel's current visibility and flipped on `onShow` / `onHide`.
- **Drop `aria-owns`**: when it points at the same element as `aria-controls`, iOS VoiceOver follows both relationships and announces the menu twice. The WAI-ARIA menu-button pattern uses `aria-controls` alone.
- Suppress the inherited `aria-pressed` (via matching on/off aria labels) so the button doesn't expose both `aria-pressed` and `aria-expanded`.

### 2. Honor `prefers-reduced-motion: reduce`

The UI had no `prefers-reduced-motion` support — the control bar fade, settings panel slide, buffering loader, huge play button "breathe" animation, etc. all ignored the user's OS preference.

Added a single global rule in `src/scss/bitmovinplayer-ui.scss` that disables every animation and transition inside `.bmpui-ui-uicontainer` (`animation: none` / `transition: none`) when the user has set `prefers-reduced-motion: reduce`. Disabling outright (rather than collapsing durations) avoids a glitch where `transition: visibility 0s <duration>` kept the settings panel on a discrete visibility delay and popped on open. `SubtitleOverlay.awaitTransitionEnd` already short-circuits when `transition-property` is `none`, so no listeners are stranded.

## Test plan

- [x] All 508 unit tests pass; ESLint and `tsc --noEmit` clean (ARIA wiring covered by 5 tests).
- [x] Open the demo player → inspect the settings cog → `aria-haspopup="menu"`, `aria-controls=<page-id>`, `aria-expanded="false"`, no `aria-owns`, no `aria-pressed`. *(verified in-browser)*
- [x] Open the settings panel → `aria-expanded` flips to `"true"`; close → flips back to `"false"`. *(open verified in-browser; close covered by unit test)*
- [x] Under `prefers-reduced-motion: reduce`, the settings panel opens with no glitch — computed `transition: none`, panel `visibility: visible` on the first frame. *(verified in-browser with the reduced-motion rule applied)*
- [x] Screen-reader-facing ARIA semantics verified structurally (native `button` role + `aria-haspopup="menu"` + `aria-expanded` collapsed/expanded). *(full VoiceOver/TalkBack pass not run in this environment)*

## Notes

I did not change color contrast (`#999` on `#111`) — that's a tokenized design call that touches the whole UI palette, worth its own PR with a designer in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)