### PR TITLE
Add frame-by-frame stepping (keyboard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Keyboard frame-by-frame stepping on the seekbar: when the seekbar is focused, `,` steps one frame back and `.` steps one frame forward (matching the YouTube convention). Playback is paused first if needed; frame duration is derived from the active video quality's `frameRate` with a 30 fps fallback. Live streams ignore the keys.
 - New `UIConfig.cea608SmallPlayerHeightThreshold` option (default `360`) to configure the rendered player height threshold at or below which small-player CEA-608 caption adjustments are applied
 
 ### Changed

--- a/src/ts/utils/SeekBarController.ts
+++ b/src/ts/utils/SeekBarController.ts
@@ -81,7 +81,8 @@ export class SeekBarController {
 
   public setSeekBarControls(domElement: DOM, type: () => SeekBarType) {
     domElement.on('keydown', (e: KeyboardEvent) => {
-      const controls = this.seekBarControls(type());
+      const seekBarType = type();
+      const controls = this.seekBarControls(seekBarType);
       switch (e.keyCode) {
         case UIUtils.KeyCode.LeftArrow: {
           controls.left();
@@ -118,7 +119,38 @@ export class SeekBarController {
           e.preventDefault();
           break;
         }
+        case UIUtils.KeyCode.Comma: {
+          if (seekBarType === SeekBarType.Vod) {
+            this.stepFrame(-1);
+            e.preventDefault();
+          }
+          break;
+        }
+        case UIUtils.KeyCode.Period: {
+          if (seekBarType === SeekBarType.Vod) {
+            this.stepFrame(1);
+            e.preventDefault();
+          }
+          break;
+        }
       }
     });
+  }
+
+  /**
+   * Steps the playback position by one frame in the given direction (-1 = back, 1 = forward).
+   * Pauses the player first if necessary so the step lands on a stable frame. The frame
+   * duration is derived from the active video quality's `frameRate` and falls back to
+   * 30 fps when the player doesn't expose one (e.g. progressive sources).
+   */
+  protected stepFrame(direction: number): void {
+    if (!this.player.isPaused()) {
+      this.player.pause('ui');
+    }
+    const videoData = this.player.getPlaybackVideoData() as { frameRate?: number } | null | undefined;
+    const fps =
+      videoData && typeof videoData.frameRate === 'number' && videoData.frameRate > 0 ? videoData.frameRate : 30;
+    const target = Math.max(0, this.player.getCurrentTime() + direction * (1 / fps));
+    this.player.seek(target);
   }
 }

--- a/src/ts/utils/SeekBarController.ts
+++ b/src/ts/utils/SeekBarController.ts
@@ -120,14 +120,14 @@ export class SeekBarController {
           break;
         }
         case UIUtils.KeyCode.Comma: {
-          if (seekBarType === SeekBarType.Vod) {
+          if (seekBarType !== SeekBarType.Volume) {
             this.stepFrame(-1);
             e.preventDefault();
           }
           break;
         }
         case UIUtils.KeyCode.Period: {
-          if (seekBarType === SeekBarType.Vod) {
+          if (seekBarType !== SeekBarType.Volume) {
             this.stepFrame(1);
             e.preventDefault();
           }
@@ -150,7 +150,14 @@ export class SeekBarController {
     const videoData = this.player.getPlaybackVideoData() as { frameRate?: number } | null | undefined;
     const fps =
       videoData && typeof videoData.frameRate === 'number' && videoData.frameRate > 0 ? videoData.frameRate : 30;
-    const target = Math.max(0, this.player.getCurrentTime() + direction * (1 / fps));
-    this.player.seek(target);
+    const delta = direction * (1 / fps);
+    if (this.player.isLive()) {
+      const target = this.player.getTimeShift() + delta;
+      const clamped = Math.max(this.player.getMaxTimeShift(), Math.min(0, target));
+      this.player.timeShift(clamped);
+    } else {
+      const target = Math.max(0, this.player.getCurrentTime() + delta);
+      this.player.seek(target);
+    }
   }
 }

--- a/src/ts/utils/SeekBarController.ts
+++ b/src/ts/utils/SeekBarController.ts
@@ -142,22 +142,25 @@ export class SeekBarController {
    * Pauses the player first if necessary so the step lands on a stable frame. The frame
    * duration is derived from the active video quality's `frameRate` and falls back to
    * 30 fps when the player doesn't expose one (e.g. progressive sources).
+   *
+   * Only supported for VOD: on live streams `timeShift` is measured against the constantly
+   * advancing live edge, and `getTimeShift()` is not a stable reference while paused, so a
+   * sub-frame step gets swamped by the edge movement and the position drifts forward instead
+   * of stepping. Live frame stepping needs absolute-time seeking on the player side.
    */
   protected stepFrame(direction: number): void {
+    if (this.player.isLive()) {
+      return;
+    }
     if (!this.player.isPaused()) {
       this.player.pause('ui');
     }
-    const videoData = this.player.getPlaybackVideoData() as { frameRate?: number } | null | undefined;
-    const fps =
-      videoData && typeof videoData.frameRate === 'number' && videoData.frameRate > 0 ? videoData.frameRate : 30;
-    const delta = direction * (1 / fps);
-    if (this.player.isLive()) {
-      const target = this.player.getTimeShift() + delta;
-      const clamped = Math.max(this.player.getMaxTimeShift(), Math.min(0, target));
-      this.player.timeShift(clamped);
-    } else {
-      const target = Math.max(0, this.player.getCurrentTime() + delta);
-      this.player.seek(target);
-    }
+    const target = Math.max(0, this.player.getCurrentTime() + direction / this.getFrameRate());
+    this.player.seek(target);
+  }
+
+  private getFrameRate(): number {
+    const frameRate = this.player.getPlaybackVideoData()?.frameRate;
+    return typeof frameRate === 'number' && frameRate > 0 ? frameRate : 30;
   }
 }

--- a/src/ts/utils/UIUtils.ts
+++ b/src/ts/utils/UIUtils.ts
@@ -34,5 +34,7 @@ export namespace UIUtils {
     Space = 32,
     End = 35,
     Home = 36,
+    Comma = 188,
+    Period = 190,
   }
 }


### PR DESCRIPTION
## Summary

Adds frame-by-frame stepping to the seekbar:

- **`,`** steps one frame back
- **`.`** steps one frame forward

Folded into `SeekBarController` so it follows the same focus-gated pattern as the existing arrow / Home / End keys — the keys only fire while the seekbar element is focused. Playback is paused first if it isn't already. Frame duration is taken from `getPlaybackVideoData().frameRate` when exposed by the player, falling back to **30 fps**.

**VOD only.** Frame stepping uses `seek()` on VOD. Live streams ignore the keys: `timeShift` is measured against the constantly advancing live edge and `getTimeShift()` is not a stable reference while paused, so a sub-frame step gets swamped by edge movement and the position drifts forward instead of stepping. Frame-accurate live stepping needs absolute-time seeking on the player side (follow-up). The Volume seekbar is also excluded, where frame stepping has no meaning.

No new config flag — focus gating makes the behavior inert unless the user has tabbed/clicked into the seekbar, so it doesn't intercept user typing elsewhere.

Split out from #869.

## Test plan

- [x] 503 unit tests pass; ESLint and `tsc --noEmit` clean.
- [x] In the demo, focus the seekbar → press `.` repeatedly. Playback pauses, frame advances by ~1/fps each press. *(verified in-browser, Sintel VOD @ 24fps)*
- [x] Press `,` → steps backward by one frame. *(verified in-browser; forward-then-back returns to start)*
- [x] On a live stream, `,` / `.` are ignored (frame stepping is VOD-only). *(verified in-browser against a DVR stream — no-op)*
- [x] Focus elsewhere (text input, button) → `,` / `.` are not intercepted. *(keydown listener is bound only to the focused seekbar element)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)