### PR TITLE
Enable automatic webpack dev server ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Internal
+
+- Webpack dev server uses automatic port selection starting from `9000`, allowing multiple local checkouts to run concurrently
+
 ## [4.14.0] - 2026-05-14
 
 ### Added

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,8 @@ const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
 const OUTPUT_ROOT_DIRECTORY = 'dist';
+const DEV_SERVER_BASE_PORT = 9000;
+process.env.WEBPACK_DEV_SERVER_BASE_PORT = process.env.WEBPACK_DEV_SERVER_BASE_PORT || String(DEV_SERVER_BASE_PORT);
 
 // You can customize the output names and css prefix by passing environment variables to the build script, e.g.:
 // ```
@@ -144,7 +146,7 @@ module.exports = (env, { mode }) => {
       static: {
         directory: path.join(__dirname, OUTPUT_ROOT_DIRECTORY),
       },
-      port: 9000,
+      port: 'auto',
       hot: true,
       client: {
         overlay: {


### PR DESCRIPTION
## Description
Enables webpack-dev-server automatic port selection while keeping `9000` as the base port. This allows multiple local checkouts to run dev servers concurrently without `EADDRINUSE` conflicts on port `9000`.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry