### PR TITLE
Add support to add/remove recommendations at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `UIManager.getRecommendations`, `UIManager.addRecommendation`, and `UIManager.removeRecommendation` for dynamically updating recommendation items for the `RecommendationOverlay`
+- `UIManager.recommendations` API for dynamically updating recommendation items for the `RecommendationOverlay`
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `UIManager.getRecommendations`, `UIManager.addRecommendation`, and `UIManager.removeRecommendation` for dynamically updating recommendation items for the `RecommendationOverlay`
+
 ## [4.14.0] - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `UIManager.recommendations` API for dynamically updating recommendation items for the `RecommendationOverlay`
+- `UIManager.recommendations` namespace for dynamically updating recommendation items for the `RecommendationOverlay`
 
 ### Internal
 

--- a/spec/UIManager.spec.ts
+++ b/spec/UIManager.spec.ts
@@ -214,36 +214,36 @@ describe('UIManager', () => {
       const onUpdatedSpy = jest.fn();
       (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
 
-      uiManager.addRecommendation(recommendation);
+      uiManager.recommendations.add(recommendation);
 
-      expect(uiManager.getRecommendations()).toEqual([recommendation]);
+      expect(uiManager.recommendations.list()).toEqual([recommendation]);
       expect(onUpdatedSpy).toHaveBeenCalledWith(uiManager, null);
     });
 
     it('removes recommendations by reference and dispatches config update', () => {
       const recommendation = createRecommendation('recommendation-1');
-      uiManager.addRecommendation(recommendation);
+      uiManager.recommendations.add(recommendation);
       const onUpdatedSpy = jest.fn();
       (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
 
-      const removed = uiManager.removeRecommendation(recommendation);
+      const removed = uiManager.recommendations.remove(recommendation);
 
       expect(removed).toBe(true);
-      expect(uiManager.getRecommendations()).toEqual([]);
+      expect(uiManager.recommendations.list()).toEqual([]);
       expect(onUpdatedSpy).toHaveBeenCalledWith(uiManager, null);
     });
 
     it('does not dispatch config update when the recommendation is not present', () => {
       const recommendation = createRecommendation('recommendation-1');
       const otherRecommendation = createRecommendation('recommendation-2');
-      uiManager.addRecommendation(recommendation);
+      uiManager.recommendations.add(recommendation);
       const onUpdatedSpy = jest.fn();
       (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
 
-      const removed = uiManager.removeRecommendation(otherRecommendation);
+      const removed = uiManager.recommendations.remove(otherRecommendation);
 
       expect(removed).toBe(false);
-      expect(uiManager.getRecommendations()).toEqual([recommendation]);
+      expect(uiManager.recommendations.list()).toEqual([recommendation]);
       expect(onUpdatedSpy).not.toHaveBeenCalled();
     });
   });

--- a/spec/UIManager.spec.ts
+++ b/spec/UIManager.spec.ts
@@ -11,6 +11,7 @@ import { MockHelper, TestingPlayerAPI } from './helper/MockHelper';
 import { MobileV3PlayerEvent } from '../src/ts/utils/MobileV3PlayerAPI';
 import { UIContainer } from '../src/ts/components/UIContainer';
 import { Container } from '../src/ts/components/Container';
+import { RecommendationConfig } from '../src/ts/UIConfig';
 
 jest.mock('../src/ts/DOM');
 
@@ -187,6 +188,63 @@ describe('UIManager', () => {
       const uiManager = new UIManager(playerMock, [uiVariant]);
 
       expect(uiManager.activeUi).toBeInstanceOf(UIInstanceManager);
+    });
+  });
+
+  describe('recommendations', () => {
+    const createRecommendation = (title: string): RecommendationConfig => ({
+      title,
+      resource: {
+        url: `https://example.com/${title}`,
+      },
+    });
+
+    let playerMock: TestingPlayerAPI;
+    let uiManager: UIManager;
+
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock();
+      uiManager = new UIManager(playerMock, [{ ui: new UIContainer({ components: [new Container({})] }) }], {
+        metadata: { recommendations: [] },
+      });
+    });
+
+    it('adds recommendations and dispatches config update', () => {
+      const recommendation = createRecommendation('recommendation-1');
+      const onUpdatedSpy = jest.fn();
+      (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
+
+      uiManager.addRecommendation(recommendation);
+
+      expect(uiManager.getRecommendations()).toEqual([recommendation]);
+      expect(onUpdatedSpy).toHaveBeenCalledWith(uiManager, null);
+    });
+
+    it('removes recommendations by reference and dispatches config update', () => {
+      const recommendation = createRecommendation('recommendation-1');
+      uiManager.addRecommendation(recommendation);
+      const onUpdatedSpy = jest.fn();
+      (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
+
+      const removed = uiManager.removeRecommendation(recommendation);
+
+      expect(removed).toBe(true);
+      expect(uiManager.getRecommendations()).toEqual([]);
+      expect(onUpdatedSpy).toHaveBeenCalledWith(uiManager, null);
+    });
+
+    it('does not dispatch config update when the recommendation is not present', () => {
+      const recommendation = createRecommendation('recommendation-1');
+      const otherRecommendation = createRecommendation('recommendation-2');
+      uiManager.addRecommendation(recommendation);
+      const onUpdatedSpy = jest.fn();
+      (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
+
+      const removed = uiManager.removeRecommendation(otherRecommendation);
+
+      expect(removed).toBe(false);
+      expect(uiManager.getRecommendations()).toEqual([recommendation]);
+      expect(onUpdatedSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/spec/UIManager.spec.ts
+++ b/spec/UIManager.spec.ts
@@ -11,7 +11,7 @@ import { MockHelper, TestingPlayerAPI } from './helper/MockHelper';
 import { MobileV3PlayerEvent } from '../src/ts/utils/MobileV3PlayerAPI';
 import { UIContainer } from '../src/ts/components/UIContainer';
 import { Container } from '../src/ts/components/Container';
-import { RecommendationConfig } from '../src/ts/UIConfig';
+import { RecommendationConfig, TimelineMarker } from '../src/ts/UIConfig';
 
 jest.mock('../src/ts/DOM');
 
@@ -245,6 +245,96 @@ describe('UIManager', () => {
       expect(removed).toBe(false);
       expect(uiManager.recommendations.list()).toEqual([recommendation]);
       expect(onUpdatedSpy).not.toHaveBeenCalled();
+    });
+
+    it('clears dynamically added recommendations on source load and restores UI config recommendations', () => {
+      const configuredRecommendation = createRecommendation('configured-recommendation');
+      const dynamicRecommendation = createRecommendation('dynamic-recommendation');
+      const configuredRecommendations = [configuredRecommendation];
+
+      uiManager = new UIManager(playerMock, [{ ui: new UIContainer({ components: [new Container({})] }) }], {
+        metadata: { recommendations: configuredRecommendations },
+      });
+
+      uiManager.recommendations.add(dynamicRecommendation);
+      expect(uiManager.recommendations.list()).toEqual([configuredRecommendation, dynamicRecommendation]);
+      expect(configuredRecommendations).toEqual([configuredRecommendation]);
+
+      playerMock.eventEmitter.fireSourceLoadedEvent();
+
+      expect(uiManager.recommendations.list()).toEqual([configuredRecommendation]);
+    });
+
+    it('clears dynamically added recommendations on source load and restores source recommendations', () => {
+      const configuredRecommendation = createRecommendation('configured-recommendation');
+      const sourceRecommendation = createRecommendation('source-recommendation');
+      const dynamicRecommendation = createRecommendation('dynamic-recommendation');
+      const sourceRecommendations = [sourceRecommendation];
+      (playerMock.getSource as jest.Mock).mockReturnValue({ recommendations: sourceRecommendations });
+
+      uiManager = new UIManager(playerMock, [{ ui: new UIContainer({ components: [new Container({})] }) }], {
+        metadata: { recommendations: [configuredRecommendation] },
+      });
+
+      uiManager.recommendations.add(dynamicRecommendation);
+      expect(uiManager.recommendations.list()).toEqual([sourceRecommendation, dynamicRecommendation]);
+      expect(sourceRecommendations).toEqual([sourceRecommendation]);
+
+      playerMock.eventEmitter.fireSourceLoadedEvent();
+
+      expect(uiManager.recommendations.list()).toEqual([sourceRecommendation]);
+    });
+
+    it('preserves functions in source recommendation resources when rebuilding the config', () => {
+      const preprocessHttpRequest = jest.fn();
+      const sourceRecommendation: RecommendationConfig = {
+        title: 'source-recommendation',
+        resource: {
+          dash: 'https://example.com/manifest.mpd',
+          network: { preprocessHttpRequest },
+        } as any,
+      };
+      (playerMock.getSource as jest.Mock).mockReturnValue({ recommendations: [sourceRecommendation] });
+
+      uiManager = new UIManager(playerMock, [{ ui: new UIContainer({ components: [new Container({})] }) }]);
+
+      playerMock.eventEmitter.fireSourceLoadedEvent();
+
+      const [recommendation] = uiManager.recommendations.list();
+      expect(recommendation).toBe(sourceRecommendation);
+      expect((recommendation.resource as any).network.preprocessHttpRequest).toBe(preprocessHttpRequest);
+    });
+  });
+
+  describe('timeline markers', () => {
+    const createTimelineMarker = (time: number): TimelineMarker => ({ time });
+
+    let playerMock: TestingPlayerAPI;
+    let uiManager: UIManager;
+
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock();
+      uiManager = new UIManager(playerMock, [{ ui: new UIContainer({ components: [new Container({})] }) }], {
+        metadata: { markers: [] },
+      });
+    });
+
+    it('clears dynamically added markers on source load and restores UI config markers', () => {
+      const configuredMarker = createTimelineMarker(1);
+      const dynamicMarker = createTimelineMarker(2);
+      const configuredMarkers = [configuredMarker];
+
+      uiManager = new UIManager(playerMock, [{ ui: new UIContainer({ components: [new Container({})] }) }], {
+        metadata: { markers: configuredMarkers },
+      });
+
+      uiManager.addTimelineMarker(dynamicMarker);
+      expect(uiManager.getTimelineMarkers()).toEqual([configuredMarker, dynamicMarker]);
+      expect(configuredMarkers).toEqual([configuredMarker]);
+
+      playerMock.eventEmitter.fireSourceLoadedEvent();
+
+      expect(uiManager.getTimelineMarkers()).toEqual([configuredMarker]);
     });
   });
 

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -88,10 +88,37 @@ export interface UIConfig {
    * HTMLElement object. By default, the player container will be used ({@link PlayerAPI#getContainer}).
    */
   container?: string | HTMLElement;
+  /**
+   * Specifies UI metadata displayed or used by UI components.
+   */
   metadata?: {
+    /**
+     * Title displayed by {@link MetadataLabel} components configured for title content.
+     *
+     * Values provided via the {@link SourceConfig} `title` override this value.
+     */
     title?: string;
+    /**
+     * Description displayed by {@link MetadataLabel} components configured for description content.
+     *
+     * Values provided via the {@link SourceConfig} `description` override this value.
+     */
     description?: string;
+    /**
+     * Timeline markers rendered on components such as the {@link SeekBar}.
+     *
+     * Values provided via the {@link SourceConfig} `markers` override this array.
+     * Use {@link UIManager.addTimelineMarker} and {@link UIManager.removeTimelineMarker} to update timeline markers
+     * after the UI has been initialized or a Source was loaded.
+     */
     markers?: TimelineMarker[];
+    /**
+     * Recommendations displayed by the {@link RecommendationOverlay} after playback of the current source has ended.
+     *
+     * Values provided via the {@link SourceConfig} `recommendations` override this array.
+     * Use {@link UIManager.recommendations} to update recommendations after the UI has been initialized or
+     * a Source was loaded.
+     */
     recommendations?: RecommendationConfig[];
   };
   /**

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -262,7 +262,7 @@ export class UIManager {
      */
     const updateConfig = () => {
       const playerSourceConfig = player.getSource() || {};
-      this.config.metadata = JSON.parse(JSON.stringify(uiconfig.metadata || {}));
+      this.config.metadata = { ...uiconfig.metadata };
 
       // Extract the UI-related config properties from the source config
       const playerSourceUiConfig: UIConfig = {
@@ -280,9 +280,10 @@ export class UIManager {
       // lifetime of the player instance.
       this.config.metadata.title = playerSourceUiConfig.metadata.title || uiconfig.metadata.title;
       this.config.metadata.description = playerSourceUiConfig.metadata.description || uiconfig.metadata.description;
-      this.config.metadata.markers = playerSourceUiConfig.metadata.markers || uiconfig.metadata.markers || [];
-      this.config.metadata.recommendations =
-        playerSourceUiConfig.metadata.recommendations || uiconfig.metadata.recommendations || [];
+      this.config.metadata.markers = [...(playerSourceUiConfig.metadata.markers || uiconfig.metadata.markers || [])];
+      this.config.metadata.recommendations = [
+        ...(playerSourceUiConfig.metadata.recommendations || uiconfig.metadata.recommendations || []),
+      ];
 
       StorageUtils.setStorageApiDisabled(uiconfig);
     };

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -7,7 +7,7 @@ import { NoArgs, EventDispatcher, CancelEventArgs } from './EventDispatcher';
 import { UIUtils } from './utils/UIUtils';
 import { ArrayUtils } from './utils/ArrayUtils';
 import { BrowserUtils } from './utils/BrowserUtils';
-import { TimelineMarker, UIConfig } from './UIConfig';
+import { RecommendationConfig, TimelineMarker, UIConfig } from './UIConfig';
 import { PlayerAPI, PlayerEventCallback, PlayerEventBase, PlayerEvent, AdEvent, LinearAd } from 'bitmovin-player';
 import { VolumeController } from './utils/VolumeController';
 import { i18n, CustomVocabulary, Vocabularies, I18n, LanguageChangedArgument } from './localization/i18n';
@@ -674,6 +674,35 @@ export class UIManager {
    */
   removeTimelineMarker(timelineMarker: TimelineMarker): boolean {
     if (ArrayUtils.remove(this.config.metadata.markers, timelineMarker) === timelineMarker) {
+      this.config.events.onUpdated.dispatch(this);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Returns the list of all added recommendations in display order.
+   */
+  getRecommendations(): RecommendationConfig[] {
+    return this.config.metadata.recommendations;
+  }
+
+  /**
+   * Adds a recommendation.
+   */
+  addRecommendation(recommendation: RecommendationConfig): void {
+    this.config.metadata.recommendations.push(recommendation);
+    this.config.events.onUpdated.dispatch(this);
+  }
+
+  /**
+   * Removes a recommendation (by reference) and returns `true` if the recommendation has
+   * been part of the recommendations and successfully removed, or `false` if the recommendation
+   * could not be found and thus not removed.
+   */
+  removeRecommendation(recommendation: RecommendationConfig): boolean {
+    if (ArrayUtils.remove(this.config.metadata.recommendations, recommendation) === recommendation) {
       this.config.events.onUpdated.dispatch(this);
       return true;
     }

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -689,7 +689,7 @@ export class UIManager {
   }
 
   /**
-   * Adds a recommendation.
+   * Adds a recommendation which will be displayed in the {@link RecommendationOverlay}.
    */
   addRecommendation(recommendation: RecommendationConfig): void {
     this.config.metadata.recommendations.push(recommendation);

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -71,6 +71,10 @@ export interface InternalUIConfig extends UIConfig {
 export interface RecommendationsApi {
   /**
    * Adds a recommendation which will be displayed in the {@link RecommendationOverlay}.
+   *
+   * Note:
+   * - Does not check for duplicated recommendations.
+   * - Dynamically added recommendations will be cleared when a new source is loaded into the Player.
    */
   add(recommendation: RecommendationConfig): void;
 

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -248,7 +248,7 @@ export class UIManager {
         return false;
       },
       list: (): RecommendationConfig[] => {
-        return this.config.metadata.recommendations;
+        return [...this.config.metadata.recommendations];
       },
     };
 

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -66,6 +66,28 @@ export interface InternalUIConfig extends UIConfig {
 }
 
 /**
+ * API for managing recommendations displayed by the {@link RecommendationOverlay}.
+ */
+export interface RecommendationsApi {
+  /**
+   * Adds a recommendation which will be displayed in the {@link RecommendationOverlay}.
+   */
+  add(recommendation: RecommendationConfig): void;
+
+  /**
+   * Removes a recommendation by reference and returns `true` if the recommendation has
+   * been part of the recommendations and successfully removed, or `false` if the recommendation
+   * could not be found and thus not removed.
+   */
+  remove(recommendation: RecommendationConfig): boolean;
+
+  /**
+   * Returns the list of all added recommendations in display order.
+   */
+  list(): RecommendationConfig[];
+}
+
+/**
  * The context that will be passed to a {@link UIConditionResolver} to determine if it's conditions fulfil the context.
  */
 export interface UIConditionContext {
@@ -147,6 +169,7 @@ export class UIManager {
   private focusVisibilityTracker: FocusVisibilityTracker;
   private subtitleSettingsManager: SubtitleSettingsManager;
   private shadowDomManager: ShadowDomManager;
+  private recommendationsApi: RecommendationsApi;
 
   private events = {
     onUiVariantResolve: new EventDispatcher<UIManager, UIConditionContext>(),
@@ -209,6 +232,24 @@ export class UIManager {
       },
       volumeController: new VolumeController(this.managerPlayerWrapper.getPlayer()),
       adBreakTracker: new AdBreakTracker(this.managerPlayerWrapper.getPlayer()),
+    };
+
+    this.recommendationsApi = {
+      add: (recommendation: RecommendationConfig): void => {
+        this.config.metadata.recommendations.push(recommendation);
+        this.config.events.onUpdated.dispatch(this);
+      },
+      remove: (recommendation: RecommendationConfig): boolean => {
+        if (ArrayUtils.remove(this.config.metadata.recommendations, recommendation) === recommendation) {
+          this.config.events.onUpdated.dispatch(this);
+          return true;
+        }
+
+        return false;
+      },
+      list: (): RecommendationConfig[] => {
+        return this.config.metadata.recommendations;
+      },
     };
 
     /**
@@ -653,6 +694,13 @@ export class UIManager {
   }
 
   /**
+   * API for managing recommendations displayed by the {@link RecommendationOverlay}.
+   */
+  get recommendations(): RecommendationsApi {
+    return this.recommendationsApi;
+  }
+
+  /**
    * Returns the list of all added markers in undefined order.
    */
   getTimelineMarkers(): TimelineMarker[] {
@@ -674,35 +722,6 @@ export class UIManager {
    */
   removeTimelineMarker(timelineMarker: TimelineMarker): boolean {
     if (ArrayUtils.remove(this.config.metadata.markers, timelineMarker) === timelineMarker) {
-      this.config.events.onUpdated.dispatch(this);
-      return true;
-    }
-
-    return false;
-  }
-
-  /**
-   * Returns the list of all added recommendations in display order.
-   */
-  getRecommendations(): RecommendationConfig[] {
-    return this.config.metadata.recommendations;
-  }
-
-  /**
-   * Adds a recommendation which will be displayed in the {@link RecommendationOverlay}.
-   */
-  addRecommendation(recommendation: RecommendationConfig): void {
-    this.config.metadata.recommendations.push(recommendation);
-    this.config.events.onUpdated.dispatch(this);
-  }
-
-  /**
-   * Removes a recommendation (by reference) and returns `true` if the recommendation has
-   * been part of the recommendations and successfully removed, or `false` if the recommendation
-   * could not be found and thus not removed.
-   */
-  removeRecommendation(recommendation: RecommendationConfig): boolean {
-    if (ArrayUtils.remove(this.config.metadata.recommendations, recommendation) === recommendation) {
       this.config.events.onUpdated.dispatch(this);
       return true;
     }

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -86,7 +86,7 @@ export interface RecommendationsApi {
   remove(recommendation: RecommendationConfig): boolean;
 
   /**
-   * Returns the list of all added recommendations in display order.
+   * Returns the list of all added recommendations in insertion order.
    */
   list(): RecommendationConfig[];
 }


### PR DESCRIPTION
## Description

Currently, it's only possible to specify the recommendations statically before loading a source. Recommendation data can now be updated after source load. This lets applications fetch recommendations during playback and inject them into the UI before or after playback finishes, without reloading the source.

## Changes
`UIManager.recommendations` exposes a small API for dynamically managing recommendation items:

- `add(recommendation)`
- `remove(recommendation)`
- `list()`

## Manual Testing

Open the demo page and use the browser console:

```js
const recommendation = {
  title: 'Recommendation 1: The best video ever',
  resource: {
    dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
    poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
  },
  duration: 10.4,
};

uiManager.recommendations.add(recommendation);
uiManager.recommendations.remove(recommendation);
```

## Checklist (for PR submitter and reviewers)

- [x] `CHANGELOG` entry
