### PR TITLE
Add timeline marker namespace API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `UIManager.recommendations` namespace for dynamically updating recommendation items for the `RecommendationOverlay`
+- `UIManager.timelineMarkers` namespace for dynamically updating `TimelineMarker`s for the seek bar
 
 ### Internal
 
 - Webpack dev server uses automatic port selection starting from `9000`, allowing multiple local checkouts to run concurrently
+
+### Deprecated
+
+- `UIManager.getTimelineMarkers`, `UIManager.addTimelineMarker`, and `UIManager.removeTimelineMarker` in favor of the new `UIManager.timelineMarkers` namespace.
 
 ## [4.14.0] - 2026-05-14
 

--- a/spec/UIManager.spec.ts
+++ b/spec/UIManager.spec.ts
@@ -11,7 +11,7 @@ import { MockHelper, TestingPlayerAPI } from './helper/MockHelper';
 import { MobileV3PlayerEvent } from '../src/ts/utils/MobileV3PlayerAPI';
 import { UIContainer } from '../src/ts/components/UIContainer';
 import { Container } from '../src/ts/components/Container';
-import { RecommendationConfig } from '../src/ts/UIConfig';
+import { RecommendationConfig, TimelineMarker } from '../src/ts/UIConfig';
 
 jest.mock('../src/ts/DOM');
 
@@ -245,6 +245,72 @@ describe('UIManager', () => {
       expect(removed).toBe(false);
       expect(uiManager.recommendations.list()).toEqual([recommendation]);
       expect(onUpdatedSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('timelineMarkers', () => {
+    const createTimelineMarker = (time: number): TimelineMarker => ({
+      time,
+      title: `marker-${time}`,
+    });
+
+    let playerMock: TestingPlayerAPI;
+    let uiManager: UIManager;
+
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock();
+      uiManager = new UIManager(playerMock, [{ ui: new UIContainer({ components: [new Container({})] }) }], {
+        metadata: { markers: [] },
+      });
+    });
+
+    it('adds timeline markers and dispatches config update', () => {
+      const timelineMarker = createTimelineMarker(10);
+      const onUpdatedSpy = jest.fn();
+      (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
+
+      uiManager.timelineMarkers.add(timelineMarker);
+
+      expect(uiManager.timelineMarkers.list()).toEqual([timelineMarker]);
+      expect(onUpdatedSpy).toHaveBeenCalledWith(uiManager, null);
+    });
+
+    it('removes timeline markers by reference and dispatches config update', () => {
+      const timelineMarker = createTimelineMarker(10);
+      uiManager.timelineMarkers.add(timelineMarker);
+      const onUpdatedSpy = jest.fn();
+      (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
+
+      const removed = uiManager.timelineMarkers.remove(timelineMarker);
+
+      expect(removed).toBe(true);
+      expect(uiManager.timelineMarkers.list()).toEqual([]);
+      expect(onUpdatedSpy).toHaveBeenCalledWith(uiManager, null);
+    });
+
+    it('does not dispatch config update when the timeline marker is not present', () => {
+      const timelineMarker = createTimelineMarker(10);
+      const otherTimelineMarker = createTimelineMarker(20);
+      uiManager.timelineMarkers.add(timelineMarker);
+      const onUpdatedSpy = jest.fn();
+      (uiManager.getConfig() as InternalUIConfig).events.onUpdated.subscribe(onUpdatedSpy);
+
+      const removed = uiManager.timelineMarkers.remove(otherTimelineMarker);
+
+      expect(removed).toBe(false);
+      expect(uiManager.timelineMarkers.list()).toEqual([timelineMarker]);
+      expect(onUpdatedSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps deprecated timeline marker APIs backed by the timelineMarkers namespace', () => {
+      const timelineMarker = createTimelineMarker(10);
+
+      uiManager.addTimelineMarker(timelineMarker);
+
+      expect(uiManager.getTimelineMarkers()).toBe(uiManager.timelineMarkers.list());
+      expect(uiManager.timelineMarkers.list()).toEqual([timelineMarker]);
+      expect(uiManager.removeTimelineMarker(timelineMarker)).toBe(true);
+      expect(uiManager.timelineMarkers.list()).toEqual([]);
     });
   });
 

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -88,6 +88,28 @@ export interface RecommendationsApi {
 }
 
 /**
+ * API for managing markers displayed on the playback timeline.
+ */
+export interface TimelineMarkersApi {
+  /**
+   * Adds a marker to the timeline. Does not check for duplicates/overlaps at the `time`.
+   */
+  add(timelineMarker: TimelineMarker): void;
+
+  /**
+   * Removes a marker from the timeline by reference and returns `true` if the marker has
+   * been part of the timeline and successfully removed, or `false` if the marker could not
+   * be found and thus not removed.
+   */
+  remove(timelineMarker: TimelineMarker): boolean;
+
+  /**
+   * Returns the list of all added timeline markers in undefined order.
+   */
+  list(): TimelineMarker[];
+}
+
+/**
  * The context that will be passed to a {@link UIConditionResolver} to determine if it's conditions fulfil the context.
  */
 export interface UIConditionContext {
@@ -170,6 +192,7 @@ export class UIManager {
   private subtitleSettingsManager: SubtitleSettingsManager;
   private shadowDomManager: ShadowDomManager;
   private recommendationsApi: RecommendationsApi;
+  private timelineMarkersApi: TimelineMarkersApi;
 
   private events = {
     onUiVariantResolve: new EventDispatcher<UIManager, UIConditionContext>(),
@@ -249,6 +272,24 @@ export class UIManager {
       },
       list: (): RecommendationConfig[] => {
         return this.config.metadata.recommendations;
+      },
+    };
+
+    this.timelineMarkersApi = {
+      add: (timelineMarker: TimelineMarker): void => {
+        this.config.metadata.markers.push(timelineMarker);
+        this.config.events.onUpdated.dispatch(this);
+      },
+      remove: (timelineMarker: TimelineMarker): boolean => {
+        if (ArrayUtils.remove(this.config.metadata.markers, timelineMarker) === timelineMarker) {
+          this.config.events.onUpdated.dispatch(this);
+          return true;
+        }
+
+        return false;
+      },
+      list: (): TimelineMarker[] => {
+        return this.config.metadata.markers;
       },
     };
 
@@ -701,32 +742,39 @@ export class UIManager {
   }
 
   /**
+   * API for managing markers displayed on the playback timeline.
+   */
+  get timelineMarkers(): TimelineMarkersApi {
+    return this.timelineMarkersApi;
+  }
+
+  /**
    * Returns the list of all added markers in undefined order.
+   *
+   * @deprecated Use {@link TimelineMarkersApi.list} instead.
    */
   getTimelineMarkers(): TimelineMarker[] {
-    return this.config.metadata.markers;
+    return this.timelineMarkers.list();
   }
 
   /**
    * Adds a marker to the timeline. Does not check for duplicates/overlaps at the `time`.
+   *
+   * @deprecated Use {@link TimelineMarkersApi.add} instead.
    */
   addTimelineMarker(timelineMarker: TimelineMarker): void {
-    this.config.metadata.markers.push(timelineMarker);
-    this.config.events.onUpdated.dispatch(this);
+    this.timelineMarkers.add(timelineMarker);
   }
 
   /**
    * Removes a marker from the timeline (by reference) and returns `true` if the marker has
    * been part of the timeline and successfully removed, or `false` if the marker could not
    * be found and thus not removed.
+   *
+   * @deprecated Use {@link TimelineMarkersApi.remove} instead.
    */
   removeTimelineMarker(timelineMarker: TimelineMarker): boolean {
-    if (ArrayUtils.remove(this.config.metadata.markers, timelineMarker) === timelineMarker) {
-      this.config.events.onUpdated.dispatch(this);
-      return true;
-    }
-
-    return false;
+    return this.timelineMarkers.remove(timelineMarker);
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `UIManager.timelineMarkers` with `add`, `remove`, and `list`, matching the `recommendations` namespace shape
- Deprecate `getTimelineMarkers`, `addTimelineMarker`, and `removeTimelineMarker` with exact replacement links
- Add focused `UIManager` coverage and update the changelog

## Tests

- `npm test -- UIManager.spec.ts --runInBand`
- `npm run lint-ts`
- `npx tsc --noEmit --project tsconfig.json`
