### PR TITLE
Add custom context menu component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Desktop UI layouts show a player context menu with Bitmovin Player and UI version information
+- New `ContextMenu` component to show custom context menus on right-click.
+- Default `PlayerContextMenu` to access player information directly from the UI.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - New `ContextMenu` component to show custom context menus on right-click.
+- `UIInstanceManager.onActive` and `UIInstanceManager.onInactive` lifecycle events for UI variant status changes.
 - Default `PlayerContextMenu` to access player information directly from the UI.
 
 ## [4.15.0] - 2026-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Desktop UI layouts show a player context menu with Bitmovin Player and UI version information
+
 ### Internal
 
 - Webpack dev server uses automatic port selection starting from `9000`, allowing multiple local checkouts to run concurrently

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -246,6 +246,9 @@
         playback: {
           muted: true,
         },
+        logs: {
+          level: 'warn',
+        },
       };
 
       var uiConfig = {

--- a/src/scss/bitmovinplayer-ui.scss
+++ b/src/scss/bitmovinplayer-ui.scss
@@ -33,6 +33,7 @@
 @import 'components/overlays/error-message-overlay';
 @import 'components/title-bar';
 @import 'components/contextmenu/context-menu';
+@import 'components/contextmenu/player-context-menu';
 @import 'components/overlays/recommendation-overlay';
 @import 'components/overlays/click-overlay';
 @import 'components/overlays/click-to-dismiss-overlay';

--- a/src/scss/bitmovinplayer-ui.scss
+++ b/src/scss/bitmovinplayer-ui.scss
@@ -32,6 +32,7 @@
 @import 'components/overlays/cast-status-overlay';
 @import 'components/overlays/error-message-overlay';
 @import 'components/title-bar';
+@import 'components/contextmenu/context-menu';
 @import 'components/overlays/recommendation-overlay';
 @import 'components/overlays/click-overlay';
 @import 'components/overlays/click-to-dismiss-overlay';

--- a/src/scss/components/contextmenu/_context-menu.scss
+++ b/src/scss/components/contextmenu/_context-menu.scss
@@ -1,22 +1,13 @@
 @import '../../variables';
-@import '../../mixins';
 
 %ui-context-menu {
-  @extend %ui-container;
-  @include hidden-animated($animation-duration-short);
+  @extend %ui-settings-panel;
 
-  backdrop-filter: blur(10px);
-  background-color: transparentize($color-background-menu, 0.15);
-  border-radius: $border-radius;
-  box-shadow: 0 0 3px 0 transparentize($color: $color-black, $amount: 0.75);
-  color: $color-primary;
-  font-family: $font-family;
-  font-size: $font-size;
-  font-weight: $font-weight-medium;
+  bottom: unset;
+  max-height: unset;
   min-width: 14em;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
+  right: unset;
+  width: fit-content;
   z-index: 101;
 
   &.#{$prefix}-hidden {

--- a/src/scss/components/contextmenu/_context-menu.scss
+++ b/src/scss/components/contextmenu/_context-menu.scss
@@ -1,0 +1,29 @@
+@import '../../variables';
+@import '../../mixins';
+
+%ui-context-menu {
+  @extend %ui-container;
+  @include hidden-animated($animation-duration-short);
+
+  backdrop-filter: blur(10px);
+  background-color: transparentize($color-background-menu, 0.15);
+  border-radius: $border-radius;
+  box-shadow: 0 0 3px 0 transparentize($color: $color-black, $amount: 0.75);
+  color: $color-primary;
+  font-family: $font-family;
+  font-size: $font-size;
+  font-weight: $font-weight-medium;
+  min-width: 14em;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  z-index: 101;
+
+  &.#{$prefix}-hidden {
+    pointer-events: none;
+  }
+}
+
+.#{$prefix}-ui-context-menu {
+  @extend %ui-context-menu;
+}

--- a/src/scss/components/contextmenu/_player-context-menu.scss
+++ b/src/scss/components/contextmenu/_player-context-menu.scss
@@ -6,7 +6,30 @@
 }
 
 %ui-player-context-menu-info-item {
-  padding: 1rem;
+  // Unset normal SettingsPanelItem styles that don't apply to info items in the context menu
+  cursor: default;
+
+  * {
+    cursor: default;
+  }
+
+  &:active,
+  &:hover {
+    background-color: transparent;
+  }
+
+  > .#{$prefix}-container-wrapper {
+    display: block;
+  }
+
+  .#{$prefix}-ui-label {
+    display: block;
+    min-height: unset;
+  }
+
+  .#{$prefix}-ui-label-text {
+    white-space: normal;
+  }
 }
 
 .#{$prefix}-ui-player-context-menu {

--- a/src/scss/components/contextmenu/_player-context-menu.scss
+++ b/src/scss/components/contextmenu/_player-context-menu.scss
@@ -3,17 +3,22 @@
 %ui-player-context-menu-label {
   display: block;
   line-height: 1.2;
-  padding-left: 1rem;
-  padding-right: 1rem;
 }
 
-.#{$prefix}-ui-context-menu {
+%ui-player-context-menu-info-item {
+  padding: 1rem;
+}
+
+.#{$prefix}-ui-player-context-menu {
+  .#{$prefix}-ui-player-context-menu-info-item {
+    @extend %ui-player-context-menu-info-item;
+  }
+
   .#{$prefix}-ui-player-context-menu-header {
     @extend %ui-player-context-menu-label;
 
     color: $color-primary;
     font-weight: $font-weight-semi-bold;
-    padding-top: 0.9rem;
   }
 
   .#{$prefix}-ui-player-context-menu-subtitle {
@@ -29,14 +34,11 @@
 
     color: transparentize($color-primary, 0.15);
     font-family: monospace;
+    font-size: $font-size-small;
     padding-top: 0.15rem;
   }
 
   .#{$prefix}-ui-player-context-menu-subtitle + .#{$prefix}-ui-player-context-menu-info {
     padding-top: 0.45rem;
-  }
-
-  .#{$prefix}-ui-player-context-menu-info:last-child {
-    padding-bottom: 0.9rem;
   }
 }

--- a/src/scss/components/contextmenu/_player-context-menu.scss
+++ b/src/scss/components/contextmenu/_player-context-menu.scss
@@ -1,0 +1,42 @@
+@import '../../variables';
+
+%ui-player-context-menu-label {
+  display: block;
+  line-height: 1.2;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.#{$prefix}-ui-context-menu {
+  .#{$prefix}-ui-player-context-menu-header {
+    @extend %ui-player-context-menu-label;
+
+    color: $color-primary;
+    font-weight: $font-weight-semi-bold;
+    padding-top: 0.9rem;
+  }
+
+  .#{$prefix}-ui-player-context-menu-subtitle {
+    @extend %ui-player-context-menu-label;
+
+    color: $color-secondary;
+    font-size: $font-size-small;
+    padding-top: 0.15rem;
+  }
+
+  .#{$prefix}-ui-player-context-menu-info {
+    @extend %ui-player-context-menu-label;
+
+    color: transparentize($color-primary, 0.15);
+    font-family: monospace;
+    padding-top: 0.15rem;
+  }
+
+  .#{$prefix}-ui-player-context-menu-subtitle + .#{$prefix}-ui-player-context-menu-info {
+    padding-top: 0.45rem;
+  }
+
+  .#{$prefix}-ui-player-context-menu-info:last-child {
+    padding-bottom: 0.9rem;
+  }
+}

--- a/src/ts/DOM.ts
+++ b/src/ts/DOM.ts
@@ -529,6 +529,10 @@ export class DOM {
       const transitionHandler = (event: Event) => {
         const transitionEvent = event as TransitionEvent;
 
+        if (transitionEvent.target !== element) {
+          return;
+        }
+
         if (transitionEvent.propertyName !== propertyName) {
           return;
         }

--- a/src/ts/DOM.ts
+++ b/src/ts/DOM.ts
@@ -512,6 +512,38 @@ export class DOM {
   }
 
   /**
+   * Resolves when the next CSS transition on the first element finishes or is canceled.
+   * A transition property is required so unrelated or bubbling transitions do not resolve the promise too early.
+   * @param propertyName CSS transition property to wait for
+   * @returns {Promise<void>}
+   */
+  async waitForTransitionEnd(propertyName: string): Promise<void> {
+    const element = this.get(0);
+    const hasTransition = element && getComputedStyle(element).transitionProperty !== 'none';
+
+    if (!hasTransition) {
+      return;
+    }
+
+    return new Promise<void>(resolve => {
+      const transitionHandler = (event: Event) => {
+        const transitionEvent = event as TransitionEvent;
+
+        if (transitionEvent.propertyName !== propertyName) {
+          return;
+        }
+
+        this.off('transitionend', transitionHandler);
+        this.off('transitioncancel', transitionHandler);
+        resolve();
+      };
+
+      this.on('transitionend', transitionHandler);
+      this.on('transitioncancel', transitionHandler);
+    });
+  }
+
+  /**
    * Adds the specified class(es) to all elements.
    * @param className the class(es) to add, multiple classes separated by space
    * @returns {DOM}

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -26,6 +26,7 @@ import { SettingsToggleButton } from './components/settings/SettingsToggleButton
 import { FullscreenToggleButton } from './components/buttons/FullscreenToggleButton';
 import { UIContainer } from './components/UIContainer';
 import { BufferingOverlay } from './components/overlays/BufferingOverlay';
+import { PlayerContextMenu } from './components/contextmenu/PlayerContextMenu';
 import { PlaybackToggleOverlay } from './components/overlays/PlaybackToggleOverlay';
 import { CastStatusOverlay } from './components/overlays/CastStatusOverlay';
 import { TitleBar } from './components/TitleBar';
@@ -246,6 +247,7 @@ export namespace UIFactory {
 
     export function main(config: UIConfig = {}): UIContainer {
       const subtitleOverlay = new SubtitleOverlay();
+      const playerContextMenu = BrowserUtils.isMobile ? null : new PlayerContextMenu();
 
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, undefined, config.ecoMode === true);
       const controlBar = new ControlBar({
@@ -282,7 +284,11 @@ export namespace UIFactory {
         ],
       });
 
-      const conditionalComponents = [config.includeWatermark ? new Watermark() : null].filter(e => e);
+      const conditionalComponents = [
+        config.includeWatermark ? new Watermark() : null,
+        playerContextMenu ? new DismissClickOverlay({ target: playerContextMenu }) : null,
+        playerContextMenu,
+      ].filter(e => e);
 
       return new UIContainer({
         components: [
@@ -361,6 +367,7 @@ export namespace UIFactory {
 
     export function smallScreen(): UIContainer {
       const subtitleOverlay = new SubtitleOverlay();
+      const playerContextMenu = BrowserUtils.isMobile ? null : new PlayerContextMenu();
 
       const settingsPanel = buildDefaultSettingsPanel(subtitleOverlay, -1);
 
@@ -420,6 +427,7 @@ export namespace UIFactory {
           }),
           new DismissClickOverlay({ target: settingsPanel }),
           settingsPanel,
+          ...(playerContextMenu ? [new DismissClickOverlay({ target: playerContextMenu }), playerContextMenu] : []),
           new ErrorMessageOverlay(),
         ],
         cssClasses: ['ui-smallscreen'],

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -491,6 +491,7 @@ export class UIManager {
 
     // Hide the currently active UI variant
     if (this.currentUi) {
+      this.currentUi.onInactive.dispatch(this.currentUi.getUI());
       this.currentUi.getUI().hide();
     }
 
@@ -514,6 +515,7 @@ export class UIManager {
       onShow();
     }
     this.currentUi.getUI().show();
+    this.currentUi.onActive.dispatch(this.currentUi.getUI());
     this.events.onActiveUiChanged.dispatch(this, { previousUi, currentUi: nextUi });
   }
 
@@ -619,6 +621,11 @@ export class UIManager {
   release(): void {
     this.config.adBreakTracker.release();
 
+    if (this.currentUi) {
+      this.currentUi.onInactive.dispatch(this.currentUi.getUI());
+      this.currentUi = null;
+    }
+
     for (const uiInstanceManager of this.uiInstanceManagers) {
       this.releaseUi(uiInstanceManager);
     }
@@ -706,6 +713,8 @@ export class UIInstanceManager {
 
   private events = {
     onConfigured: new EventDispatcher<UIContainer, NoArgs>(),
+    onActive: new EventDispatcher<UIContainer, NoArgs>(),
+    onInactive: new EventDispatcher<UIContainer, NoArgs>(),
     onSeek: new EventDispatcher<SeekBar, NoArgs>(),
     onSeekPreview: new EventDispatcher<SeekBar, SeekPreviewArgs>(),
     onSeeked: new EventDispatcher<SeekBar, NoArgs>(),
@@ -758,6 +767,22 @@ export class UIInstanceManager {
    */
   get onConfigured(): EventDispatcher<UIContainer, NoArgs> {
     return this.events.onConfigured;
+  }
+
+  /**
+   * Fires when this UI instance becomes the active UI variant.
+   * @returns {EventDispatcher}
+   */
+  get onActive(): EventDispatcher<UIContainer, NoArgs> {
+    return this.events.onActive;
+  }
+
+  /**
+   * Fires when this UI instance stops being the active UI variant.
+   * @returns {EventDispatcher}
+   */
+  get onInactive(): EventDispatcher<UIContainer, NoArgs> {
+    return this.events.onInactive;
   }
 
   /**

--- a/src/ts/components/contextmenu/ContextMenu.ts
+++ b/src/ts/components/contextmenu/ContextMenu.ts
@@ -1,4 +1,4 @@
-import { Container, ContainerConfig } from '../Container';
+import { SettingsPanel, SettingsPanelConfig } from '../settings/SettingsPanel';
 import { UIInstanceManager } from '../../UIManager';
 import { PlayerAPI } from 'bitmovin-player';
 
@@ -7,7 +7,7 @@ import { PlayerAPI } from 'bitmovin-player';
  *
  * @category Configs
  */
-export interface ContextMenuConfig extends ContainerConfig {}
+export interface ContextMenuConfig extends SettingsPanelConfig {}
 
 /**
  * A floating context menu shown at the pointer position when the user opens the
@@ -15,7 +15,7 @@ export interface ContextMenuConfig extends ContainerConfig {}
  *
  * @category Components
  */
-export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> extends Container<Config> {
+export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> extends SettingsPanel<Config> {
   constructor(config: Config = {} as Config) {
     super(config);
 
@@ -23,6 +23,7 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
       config,
       {
         cssClass: 'ui-context-menu',
+        hideDelay: -1,
         hidden: true,
         role: 'menu',
       } as Config,
@@ -52,7 +53,7 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
 
       if (this.isShown()) {
         if (!this.isEventTargetInsideContextMenu(event)) {
-          this.hide();
+          this.hideAndReset();
         }
         // Let the browser handle a second contextmenu event while the custom menu is open,
         // so users can still access native actions like Inspect Element.
@@ -69,13 +70,13 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
 
     const documentKeyDownHandler = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && this.isShown()) {
-        this.hide();
+        this.hideAndReset();
       }
     };
 
     const documentClickHandler = (event: MouseEvent) => {
       if (this.isShown() && !this.isEventTargetInsideContextMenu(event)) {
-        this.hide();
+        this.hideAndReset();
       }
     };
 
@@ -93,11 +94,12 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
 
     const deactivateHandler = () => {
       detachDocumentHandlers();
-      this.hide();
+      this.hideAndReset();
     };
 
     uimanager.onActive.subscribe(attachDocumentHandlers);
     uimanager.onInactive.subscribe(deactivateHandler);
+    uimanager.onControlsHide.subscribe(() => this.hideAndReset());
   }
 
   release(): void {

--- a/src/ts/components/contextmenu/ContextMenu.ts
+++ b/src/ts/components/contextmenu/ContextMenu.ts
@@ -1,0 +1,149 @@
+import { Container, ContainerConfig } from '../Container';
+import { UIInstanceManager } from '../../UIManager';
+import { PlayerAPI } from 'bitmovin-player';
+
+/**
+ * Configuration interface for a generic {@link ContextMenu}.
+ *
+ * @category Configs
+ */
+export interface ContextMenuConfig extends ContainerConfig {}
+
+/**
+ * A floating context menu shown at the pointer position when the user opens the
+ * browser context menu inside the player UI.
+ *
+ * @category Components
+ */
+export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> extends Container<Config> {
+  constructor(config: Config = {} as Config) {
+    super(config);
+
+    this.config = this.mergeConfig(
+      config,
+      {
+        cssClass: 'ui-context-menu',
+        hidden: true,
+        role: 'menu',
+      } as Config,
+      this.config,
+    );
+  }
+
+  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
+    super.configure(player, uimanager);
+
+    const uiContainer = uimanager.getUI();
+
+    this.onHide.subscribe(() => {
+      const contextMenuElement = this.getDomElement();
+
+      contextMenuElement.waitForTransitionEnd('opacity').then(() => {
+        if (this.isHidden()) {
+          contextMenuElement.remove();
+        }
+      });
+    });
+
+    const documentContextMenuHandler = (event: MouseEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (this.isShown()) {
+        if (!this.isEventTargetInsideContextMenu(event)) {
+          this.hide();
+        }
+        // Let the browser handle a second contextmenu event while the custom menu is open,
+        // so users can still access native actions like Inspect Element.
+        return;
+      }
+
+      if (!this.isEventTargetInsideElement(event, uiContainer.getDomElement().get(0))) {
+        return;
+      }
+
+      event.preventDefault();
+      this.showAt(event.clientX, event.clientY);
+    };
+
+    const documentKeyDownHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && this.isShown()) {
+        this.hide();
+      }
+    };
+
+    const documentClickHandler = (event: MouseEvent) => {
+      if (this.isShown() && !this.isEventTargetInsideContextMenu(event)) {
+        this.hide();
+      }
+    };
+
+    const attachDocumentHandlers = () => {
+      document.addEventListener('contextmenu', documentContextMenuHandler);
+      document.addEventListener('keydown', documentKeyDownHandler);
+      document.addEventListener('click', documentClickHandler);
+    };
+
+    const detachDocumentHandlers = () => {
+      document.removeEventListener('contextmenu', documentContextMenuHandler);
+      document.removeEventListener('keydown', documentKeyDownHandler);
+      document.removeEventListener('click', documentClickHandler);
+    };
+
+    const deactivateHandler = () => {
+      detachDocumentHandlers();
+      this.hide();
+    };
+
+    uimanager.onActive.subscribe(attachDocumentHandlers);
+    uimanager.onInactive.subscribe(deactivateHandler);
+  }
+
+  release(): void {
+    super.release();
+
+    if (this.hasDomElement()) {
+      this.getDomElement().remove();
+    }
+  }
+
+  public showAt(clientX: number, clientY: number): void {
+    const contextMenuElement = this.getDomElement();
+    const contextMenuRootElement = contextMenuElement.get(0) as HTMLElement;
+    this.attachContextMenuElement();
+
+    // The element is still laid out while hidden (visibility: hidden, not display: none),
+    // so offsetWidth/Height return the real dimensions.
+    const { offsetWidth, offsetHeight } = contextMenuRootElement;
+    const maxX = Math.max(0, window.innerWidth - offsetWidth - 4);
+    const maxY = Math.max(0, window.innerHeight - offsetHeight - 4);
+    const clampedX = Math.max(0, Math.min(clientX, maxX));
+    const clampedY = Math.max(0, Math.min(clientY, maxY));
+
+    contextMenuElement.css({
+      left: `${clampedX + window.scrollX}px`,
+      top: `${clampedY + window.scrollY}px`,
+    });
+
+    this.show();
+  }
+
+  private isEventTargetInsideContextMenu(event: MouseEvent): boolean {
+    return this.isEventTargetInsideElement(event, this.getDomElement().get(0));
+  }
+
+  private isEventTargetInsideElement(event: MouseEvent, element: HTMLElement): boolean {
+    return event.target instanceof Node && element.contains(event.target);
+  }
+
+  private attachContextMenuElement(): void {
+    const rootElement = this.getDomElement().get(0) as HTMLElement;
+
+    if (rootElement.parentElement === document.body) {
+      return;
+    }
+
+    document.body.appendChild(rootElement);
+  }
+}

--- a/src/ts/components/contextmenu/ContextMenu.ts
+++ b/src/ts/components/contextmenu/ContextMenu.ts
@@ -16,6 +16,8 @@ export interface ContextMenuConfig extends SettingsPanelConfig {}
  * @category Components
  */
 export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> extends SettingsPanel<Config> {
+  private contextMenuHost: HTMLElement;
+
   constructor(config: Config = {} as Config) {
     super(config);
 
@@ -24,6 +26,7 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
       {
         cssClass: 'ui-context-menu',
         hideDelay: -1,
+        hideOnControlsHide: false,
         hidden: true,
         role: 'menu',
       } as Config,
@@ -35,6 +38,7 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
     super.configure(player, uimanager);
 
     const uiContainer = uimanager.getUI();
+    this.contextMenuHost = uiContainer.getDomElement().get(0);
 
     this.onHide.subscribe(() => {
       const contextMenuElement = this.getDomElement();
@@ -99,7 +103,6 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
 
     uimanager.onActive.subscribe(attachDocumentHandlers);
     uimanager.onInactive.subscribe(deactivateHandler);
-    uimanager.onControlsHide.subscribe(() => this.hideAndReset());
   }
 
   release(): void {
@@ -118,14 +121,15 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
     // The element is still laid out while hidden (visibility: hidden, not display: none),
     // so offsetWidth/Height return the real dimensions.
     const { offsetWidth, offsetHeight } = contextMenuRootElement;
-    const maxX = Math.max(0, window.innerWidth - offsetWidth - 4);
-    const maxY = Math.max(0, window.innerHeight - offsetHeight - 4);
-    const clampedX = Math.max(0, Math.min(clientX, maxX));
-    const clampedY = Math.max(0, Math.min(clientY, maxY));
+    const hostRect = this.contextMenuHost.getBoundingClientRect();
+    const maxX = Math.max(0, hostRect.width - offsetWidth - 4);
+    const maxY = Math.max(0, hostRect.height - offsetHeight - 4);
+    const clampedX = Math.max(0, Math.min(clientX - hostRect.left, maxX));
+    const clampedY = Math.max(0, Math.min(clientY - hostRect.top, maxY));
 
     contextMenuElement.css({
-      left: `${clampedX + window.scrollX}px`,
-      top: `${clampedY + window.scrollY}px`,
+      left: `${clampedX}px`,
+      top: `${clampedY}px`,
     });
 
     this.show();
@@ -136,16 +140,16 @@ export class ContextMenu<Config extends ContextMenuConfig = ContextMenuConfig> e
   }
 
   private isEventTargetInsideElement(event: MouseEvent, element: HTMLElement): boolean {
+    const eventPath = event.composedPath?.();
+
+    if (eventPath) {
+      return eventPath.includes(element);
+    }
+
     return event.target instanceof Node && element.contains(event.target);
   }
 
   private attachContextMenuElement(): void {
-    const rootElement = this.getDomElement().get(0) as HTMLElement;
-
-    if (rootElement.parentElement === document.body) {
-      return;
-    }
-
-    document.body.appendChild(rootElement);
+    this.contextMenuHost.appendChild(this.getDomElement().get(0));
   }
 }

--- a/src/ts/components/contextmenu/PlayerContextMenu.ts
+++ b/src/ts/components/contextmenu/PlayerContextMenu.ts
@@ -4,7 +4,8 @@ import { version as UI_VERSION } from '../../main';
 import { Label, LabelConfig } from '../labels/Label';
 import { UIInstanceManager } from '../../UIManager';
 import { ContextMenu, ContextMenuConfig } from './ContextMenu';
-import { Container, ContainerConfig } from '../Container';
+import { SettingsPanelItem, SettingsPanelItemConfig } from '../settings/SettingsPanelItem';
+import { SettingsPanelPage } from '../settings/SettingsPanelPage';
 
 /**
  * Configuration interface for the {@link PlayerContextMenu}.
@@ -23,12 +24,16 @@ export class PlayerContextMenu extends ContextMenu<PlayerContextMenuConfig> {
     super({
       ...config,
       cssClasses: ['ui-player-context-menu', ...(config.cssClasses ?? [])],
-      components: [new PlayerInfoContextMenuItem(), ...(config.components ?? [])],
+      components: [
+        new SettingsPanelPage({
+          components: [new PlayerInfoContextMenuItem(), ...(config.components ?? [])],
+        }),
+      ],
     });
   }
 }
 
-class PlayerInfoContextMenuItem extends Container<ContainerConfig> {
+class PlayerInfoContextMenuItem extends SettingsPanelItem<SettingsPanelItemConfig> {
   private readonly playerVersionLabel: Label<LabelConfig>;
 
   constructor() {
@@ -38,6 +43,7 @@ class PlayerInfoContextMenuItem extends Container<ContainerConfig> {
     });
 
     super({
+      label: null,
       components: [
         new Label<LabelConfig>({
           text: i18n.getLocalizer('contextMenu.title'),
@@ -54,6 +60,7 @@ class PlayerInfoContextMenuItem extends Container<ContainerConfig> {
         }),
       ],
       cssClasses: ['ui-player-context-menu-info-item'],
+      isSetting: false,
       role: 'group',
     });
 

--- a/src/ts/components/contextmenu/PlayerContextMenu.ts
+++ b/src/ts/components/contextmenu/PlayerContextMenu.ts
@@ -1,6 +1,6 @@
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../../localization/i18n';
-import { version as UI_VERSION } from '../../main';
+import { version as UI_VERSION } from '../../version';
 import { Label, LabelConfig } from '../labels/Label';
 import { UIInstanceManager } from '../../UIManager';
 import { ContextMenu, ContextMenuConfig } from './ContextMenu';

--- a/src/ts/components/contextmenu/PlayerContextMenu.ts
+++ b/src/ts/components/contextmenu/PlayerContextMenu.ts
@@ -1,0 +1,62 @@
+import { PlayerAPI } from 'bitmovin-player';
+import { i18n } from '../../localization/i18n';
+import { version as UI_VERSION_RAW } from '../../main';
+import { Label, LabelConfig } from '../labels/Label';
+import { UIInstanceManager } from '../../UIManager';
+import { ContextMenu, ContextMenuConfig } from './ContextMenu';
+
+// `version` in `main.ts` carries the JSON-stringified package version (i.e. surrounded
+// by quotes from the build-time replacement). Peel them off for display.
+const UI_VERSION: string = UI_VERSION_RAW.replace(/^"|"$/g, '');
+
+/**
+ * Configuration interface for the {@link PlayerContextMenu}.
+ *
+ * @category Configs
+ */
+export interface PlayerContextMenuConfig extends ContextMenuConfig {}
+
+/**
+ * A player-specific context menu with Bitmovin info and Player/UI versions.
+ *
+ * @category Components
+ */
+export class PlayerContextMenu extends ContextMenu<PlayerContextMenuConfig> {
+  private readonly playerVersionLabel: Label<LabelConfig>;
+
+  constructor(config: PlayerContextMenuConfig = {}) {
+    const playerVersionLabel = new Label<LabelConfig>({
+      text: 'Player: -',
+      cssClasses: ['ui-player-context-menu-info'],
+    });
+
+    super({
+      ...config,
+      cssClasses: ['ui-player-context-menu', ...(config.cssClasses ?? [])],
+      components: [
+        new Label<LabelConfig>({
+          text: i18n.getLocalizer('contextMenu.title'),
+          cssClasses: ['ui-player-context-menu-header'],
+        }),
+        new Label<LabelConfig>({
+          text: i18n.getLocalizer('contextMenu.subtitle'),
+          cssClasses: ['ui-player-context-menu-subtitle'],
+        }),
+        playerVersionLabel,
+        new Label<LabelConfig>({
+          text: `UI: ${UI_VERSION}`,
+          cssClasses: ['ui-player-context-menu-info'],
+        }),
+        ...(config.components ?? []),
+      ],
+    });
+
+    this.playerVersionLabel = playerVersionLabel;
+  }
+
+  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
+    super.configure(player, uimanager);
+
+    this.playerVersionLabel.setText(`Player: ${player.version}`);
+  }
+}

--- a/src/ts/components/contextmenu/PlayerContextMenu.ts
+++ b/src/ts/components/contextmenu/PlayerContextMenu.ts
@@ -1,14 +1,10 @@
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from '../../localization/i18n';
-import { version as UI_VERSION_RAW } from '../../main';
+import { version as UI_VERSION } from '../../main';
 import { Label, LabelConfig } from '../labels/Label';
 import { UIInstanceManager } from '../../UIManager';
 import { ContextMenu, ContextMenuConfig } from './ContextMenu';
 import { Container, ContainerConfig } from '../Container';
-
-// `version` in `main.ts` carries the JSON-stringified package version (i.e. surrounded
-// by quotes from the build-time replacement). Peel them off for display.
-const UI_VERSION: string = UI_VERSION_RAW.replace(/^"|"$/g, '');
 
 /**
  * Configuration interface for the {@link PlayerContextMenu}.

--- a/src/ts/components/contextmenu/PlayerContextMenu.ts
+++ b/src/ts/components/contextmenu/PlayerContextMenu.ts
@@ -4,6 +4,7 @@ import { version as UI_VERSION_RAW } from '../../main';
 import { Label, LabelConfig } from '../labels/Label';
 import { UIInstanceManager } from '../../UIManager';
 import { ContextMenu, ContextMenuConfig } from './ContextMenu';
+import { Container, ContainerConfig } from '../Container';
 
 // `version` in `main.ts` carries the JSON-stringified package version (i.e. surrounded
 // by quotes from the build-time replacement). Peel them off for display.
@@ -22,17 +23,25 @@ export interface PlayerContextMenuConfig extends ContextMenuConfig {}
  * @category Components
  */
 export class PlayerContextMenu extends ContextMenu<PlayerContextMenuConfig> {
+  constructor(config: PlayerContextMenuConfig = {}) {
+    super({
+      ...config,
+      cssClasses: ['ui-player-context-menu', ...(config.cssClasses ?? [])],
+      components: [new PlayerInfoContextMenuItem(), ...(config.components ?? [])],
+    });
+  }
+}
+
+class PlayerInfoContextMenuItem extends Container<ContainerConfig> {
   private readonly playerVersionLabel: Label<LabelConfig>;
 
-  constructor(config: PlayerContextMenuConfig = {}) {
+  constructor() {
     const playerVersionLabel = new Label<LabelConfig>({
       text: 'Player: -',
       cssClasses: ['ui-player-context-menu-info'],
     });
 
     super({
-      ...config,
-      cssClasses: ['ui-player-context-menu', ...(config.cssClasses ?? [])],
       components: [
         new Label<LabelConfig>({
           text: i18n.getLocalizer('contextMenu.title'),
@@ -47,8 +56,9 @@ export class PlayerContextMenu extends ContextMenu<PlayerContextMenuConfig> {
           text: `UI: ${UI_VERSION}`,
           cssClasses: ['ui-player-context-menu-info'],
         }),
-        ...(config.components ?? []),
       ],
+      cssClasses: ['ui-player-context-menu-info-item'],
+      role: 'group',
     });
 
     this.playerVersionLabel = playerVersionLabel;

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -172,7 +172,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
         );
 
         if (this.cea608Enabled && this.ensureCea608GridSizeUpdated && isCea608PushupTransitionEnabled) {
-          awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
+          this.getDomElement().waitForTransitionEnd('bottom').then(this.ensureCea608GridSizeUpdated);
         }
       }
     });
@@ -185,7 +185,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
         );
 
         if (this.cea608Enabled && this.ensureCea608GridSizeUpdated && isCea608PushupTransitionEnabled) {
-          awaitTransitionEnd(this.getDomElement()).then(this.ensureCea608GridSizeUpdated);
+          this.getDomElement().waitForTransitionEnd('bottom').then(this.ensureCea608GridSizeUpdated);
         }
       }
     });
@@ -905,22 +905,4 @@ export class SubtitleRegionContainer extends Container<ContainerConfig> {
 
 function isCea608SubtitleCue(cue: SubtitleCueEvent): boolean {
   return cue.position != null;
-}
-
-function awaitTransitionEnd(domElement: DOM) {
-  const hasTransition = getComputedStyle(domElement.get(0)).transitionProperty !== 'none';
-
-  if (!hasTransition) {
-    return Promise.resolve();
-  }
-
-  return new Promise<void>(resolve => {
-    const transitionHandler = () => {
-      domElement.off('transitionend', transitionHandler);
-      domElement.off('transitioncancel', transitionHandler);
-      resolve();
-    };
-    domElement.on('transitionend', transitionHandler);
-    domElement.on('transitioncancel', transitionHandler);
-  });
 }

--- a/src/ts/components/settings/SettingsPanel.ts
+++ b/src/ts/components/settings/SettingsPanel.ts
@@ -36,6 +36,12 @@ export interface SettingsPanelConfig extends ContainerConfig {
    * Default: 5 seconds (5000)
    */
   stateResetDelay?: number;
+
+  /**
+   * Specifies if the settings panel should hide when the UI controls hide.
+   * Default: true
+   */
+  hideOnControlsHide?: boolean;
 }
 
 /**
@@ -107,6 +113,7 @@ export class SettingsPanel<Config extends SettingsPanelConfig> extends Container
         hideDelay: 5000,
         pageTransitionAnimation: true,
         stateResetDelay: 5000,
+        hideOnControlsHide: true,
       } as Config,
       this.config,
     );
@@ -222,9 +229,11 @@ export class SettingsPanel<Config extends SettingsPanelConfig> extends Container
       this.onSettingsStateChangedEvent();
     });
 
-    uimanager.onControlsHide.subscribe(() => {
-      this.hide();
-    });
+    if (config.hideOnControlsHide) {
+      uimanager.onControlsHide.subscribe(() => {
+        this.hide();
+      });
+    }
     uimanager.onControlsShow.subscribe(() => {
       if (this.currentState !== null) {
         this.show();

--- a/src/ts/localization/i18n.ts
+++ b/src/ts/localization/i18n.ts
@@ -123,6 +123,8 @@ export interface Vocabulary {
   'seekBar.durationText': string;
   'quickseek.forward': string;
   'quickseek.rewind': string;
+  'contextMenu.title': string;
+  'contextMenu.subtitle': string;
   ecoMode: string;
   'ecoMode.title': string;
 }

--- a/src/ts/localization/languages/de.json
+++ b/src/ts/localization/languages/de.json
@@ -73,6 +73,8 @@
   "watermarkLink": "Link zum Homepage",
   "controlBar": "Videoplayer Kontrollen",
   "player": "Video player",
+  "contextMenu.title": "Bitmovin Player",
+  "contextMenu.subtitle": "Adaptive Streaming for the Web",
   "seekBar": "Video-Timeline",
   "seekBar.value": "Wert",
   "seekBar.timeshift": "Timeshift",

--- a/src/ts/localization/languages/en.json
+++ b/src/ts/localization/languages/en.json
@@ -80,5 +80,7 @@
   "seekBar.timeshift": "Timeshift",
   "seekBar.durationText": "out of",
   "quickseek.forward": "Fast Forward {seekSeconds} seconds",
-  "quickseek.rewind": "Rewind {seekSeconds} seconds"
+  "quickseek.rewind": "Rewind {seekSeconds} seconds",
+  "contextMenu.title": "Bitmovin Player",
+  "contextMenu.subtitle": "Adaptive Streaming for the Web"
 }

--- a/src/ts/localization/languages/es.json
+++ b/src/ts/localization/languages/es.json
@@ -75,6 +75,8 @@
   "watermarkLink": "Enlace al inicio",
   "controlBar": "Controles del Reproductor",
   "player": "Reproductor de Video",
+  "contextMenu.title": "Bitmovin Player",
+  "contextMenu.subtitle": "Adaptive Streaming for the Web",
   "seekBar": "Línea de Tiempo",
   "seekBar.value": "posición",
   "seekBar.timeshift": "cambio de posición",

--- a/src/ts/localization/languages/fr.json
+++ b/src/ts/localization/languages/fr.json
@@ -75,6 +75,8 @@
   "watermarkLink": "Lien vers la page d'accueil",
   "controlBar": "Barre de contrôle",
   "player": "Lecteur vidéo",
+  "contextMenu.title": "Bitmovin Player",
+  "contextMenu.subtitle": "Adaptive Streaming for the Web",
   "seekBar": "Barre de progression",
   "seekBar.value": "Valeur",
   "seekBar.timeshift": "Décalage temporel",

--- a/src/ts/localization/languages/nl.json
+++ b/src/ts/localization/languages/nl.json
@@ -75,6 +75,8 @@
   "watermarkLink": "Link naar homepage",
   "controlBar": "Videospeler bediening",
   "player": "Videospeler",
+  "contextMenu.title": "Bitmovin Player",
+  "contextMenu.subtitle": "Adaptive Streaming for the Web",
   "seekBar": "Video tijdlijn",
   "seekBar.value": "Waarde",
   "seekBar.timeshift": "Tijdverschuiving",

--- a/src/ts/localization/languages/pt.json
+++ b/src/ts/localization/languages/pt.json
@@ -75,6 +75,8 @@
   "watermarkLink": "Link para a página inicial",
   "controlBar": "Controlos do reprodutor de vídeo",
   "player": "Reprodutor de vídeo",
+  "contextMenu.title": "Bitmovin Player",
+  "contextMenu.subtitle": "Adaptive Streaming for the Web",
   "seekBar": "Linha do tempo do vídeo",
   "seekBar.value": "Valor",
   "seekBar.timeshift": "Diferido",

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -95,6 +95,7 @@ export { PlaybackSpeedSelectBox } from './components/settings/PlaybackSpeedSelec
 export { HugeReplayButton } from './components/buttons/HugeReplayButton';
 export { BufferingOverlay, BufferingOverlayConfig } from './components/overlays/BufferingOverlay';
 export { ContextMenu, ContextMenuConfig } from './components/contextmenu/ContextMenu';
+export { PlayerContextMenu, PlayerContextMenuConfig } from './components/contextmenu/PlayerContextMenu';
 export { CastUIContainer } from './components/CastUIContainer';
 export { PlaybackToggleOverlay, PlaybackToggleOverlayConfig } from './components/overlays/PlaybackToggleOverlay';
 export { CloseButton, CloseButtonConfig } from './components/buttons/CloseButton';

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1,4 +1,4 @@
-export const version: string = '{{VERSION}}';
+export { version } from './version';
 // Management
 export * from './UIManager';
 export * from './UIConfig';

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -94,6 +94,7 @@ export { AdCounterLabel } from './components/ads/AdCounterLabel';
 export { PlaybackSpeedSelectBox } from './components/settings/PlaybackSpeedSelectBox';
 export { HugeReplayButton } from './components/buttons/HugeReplayButton';
 export { BufferingOverlay, BufferingOverlayConfig } from './components/overlays/BufferingOverlay';
+export { ContextMenu, ContextMenuConfig } from './components/contextmenu/ContextMenu';
 export { CastUIContainer } from './components/CastUIContainer';
 export { PlaybackToggleOverlay, PlaybackToggleOverlayConfig } from './components/overlays/PlaybackToggleOverlay';
 export { CloseButton, CloseButtonConfig } from './components/buttons/CloseButton';

--- a/src/ts/version.ts
+++ b/src/ts/version.ts
@@ -1,0 +1,1 @@
+export const version: string = '{{VERSION}}';


### PR DESCRIPTION
## Description

Adds a desktop-only player context menu to the default UI layouts. The menu currently shows Bitmovin Player and UI version information and is built on a reusable `ContextMenu` component so future context-menu content can share the same behavior.

### Expected user behavior

- Right-clicking inside the active player UI opens the custom context menu.
- A second right click while the custom context menu is already open is left to the browser, so the native context menu opens again. If the second right click happens outside the custom menu, the custom menu closes first. If it happens inside the custom menu, the custom menu stays open so browser actions like Inspect Element can target the custom menu itself.
- Clicking anywhere outside the custom context menu closes it. Clicking inside the custom menu keeps it open. This prevents stale menus from staying visible after normal page/player interaction while still allowing interaction with the menu content.

### Changes

- Added `UIInstanceManager.onActive` and `onInactive` events so components can attach document-level behavior only while their UI variant is active and cleanly detach it when the active UI changes or the UI is released.
- Added a reusable `ContextMenu` component that attaches document `contextmenu`, `click`, and `keydown` handlers only while active.
- `ContextMenu` subclasses `SettingsPanel` to reuse its explicit page structure, state reset behavior, hide delay handling, and existing settings-panel styling.
  - `ContextMenu` extends `SettingsPanel` so it can reuse the existing panel paging behavior, hide/reset behavior, and styling instead of duplicating those primitives.
- The context menu DOM element is attached lazily to the active root UI element right before opening and removed again after the hide transition. This keeps the menu inside the same styled root as the UI, including Shadow DOM support.
- Positioning uses pointer coordinates relative to the active root UI element with `position: absolute`, so the menu scrolls with the UI/page instead of sticking to the viewport. The coordinates are clamped to the UI bounds to keep the menu reachable near the right and bottom edges.
- Added a player-specific `PlayerContextMenu` subclass and wired it into the default main and small-screen desktop layouts.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
