### PR TITLE
Fix UI version replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The exported UI `version` (`window.bitmovin.playerui.version`) no longer includes extra quote characters
+
 ### Internal
 
 - Webpack dev server uses automatic port selection starting from `9000`, allowing multiple local checkouts to run concurrently

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = (env, { mode }) => {
           exclude: /node_modules/,
           options: {
             multiple: [
-              { search: '{{VERSION}}', replace: JSON.stringify(require('./package.json').version), flags: 'g' },
+              { search: '{{VERSION}}', replace: require('./package.json').version, flags: 'g' },
               { search: '{{PREFIX}}', replace: outputnames.cssPrefix, flags: 'g' },
               { search: '{{FILENAME}}', replace: outputnames.filename, flags: 'g' },
             ],


### PR DESCRIPTION
## Description
Fixes the generated UI `version` export so it contains the package version without embedded quote characters.

### Old
<img width="181" height="47" alt="Screenshot 2026-05-22 at 10 07 24" src="https://github.com/user-attachments/assets/3810cb94-f9ef-41ba-af84-7c37700c21f5" />

### New
<img width="185" height="49" alt="Screenshot 2026-05-22 at 10 07 43" src="https://github.com/user-attachments/assets/b53f5e36-8e03-4d7c-b171-fe095959dddf" />

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
