### PR TITLE
Add more information on touch devices in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New `ContextMenu` component to show custom context menus on right-click.
 - Default `PlayerContextMenu` to access player information directly from the UI.
 - `PlayerInsightsPanel` to show detailed player insights and diagnostics.
+- `SettingsPanelPageNavigationItem` component to simplify navigating to a different `SettingsPanelPage`
 
 ## [4.15.0] - 2026-06-04
 

--- a/src/scss/bitmovinplayer-ui.scss
+++ b/src/scss/bitmovinplayer-ui.scss
@@ -22,6 +22,7 @@
 @import 'components/settings/settings-panel-page-navigation-item';
 @import 'components/settings/settings-panel-separator';
 @import 'components/panels/player-insights-panel';
+@import 'components/settings/player-info-settings-panel-page';
 @import 'components/settings/settings-panel-page-open-button';
 @import 'components/settings/settings-panel-page-back-button';
 @import 'components/settings/settings-toggle-button';

--- a/src/scss/bitmovinplayer-ui.scss
+++ b/src/scss/bitmovinplayer-ui.scss
@@ -19,6 +19,7 @@
 @import 'components/settings/settings-panel';
 @import 'components/settings/settings-panel-page';
 @import 'components/settings/settings-panel-item';
+@import 'components/settings/settings-panel-page-navigation-item';
 @import 'components/settings/settings-panel-separator';
 @import 'components/panels/player-insights-panel';
 @import 'components/settings/settings-panel-page-open-button';

--- a/src/scss/components/settings/_player-info-settings-panel-page.scss
+++ b/src/scss/components/settings/_player-info-settings-panel-page.scss
@@ -1,0 +1,55 @@
+@import '../../variables';
+
+%ui-player-info-settings-panel-page {
+  @extend %ui-settings-panel-page;
+
+  .#{$prefix}-ui-player-info-settings-panel-item {
+    cursor: default;
+
+    * {
+      cursor: default;
+    }
+
+    &:active,
+    &:hover {
+      background-color: transparent;
+    }
+
+    > .#{$prefix}-container-wrapper {
+      display: block;
+    }
+
+    .#{$prefix}-ui-label {
+      display: block;
+      line-height: 1.2;
+      min-height: unset;
+    }
+
+    .#{$prefix}-ui-label-text {
+      white-space: normal;
+    }
+  }
+
+  .#{$prefix}-ui-player-info-settings-panel-page-title {
+    color: $color-primary;
+    font-weight: $font-weight-semi-bold;
+    margin-bottom: 0.35rem;
+  }
+
+  .#{$prefix}-ui-player-info-settings-panel-page-subtitle {
+    color: $color-secondary;
+    font-size: $font-size-small;
+    margin-bottom: 0.55rem;
+  }
+
+  .#{$prefix}-ui-player-info-settings-panel-page-info {
+    color: transparentize($color-primary, 0.15);
+    font-family: monospace;
+    font-size: $font-size-small;
+    margin-top: 0.35rem;
+  }
+}
+
+.#{$prefix}-ui-player-info-settings-panel-page {
+  @extend %ui-player-info-settings-panel-page;
+}

--- a/src/scss/components/settings/_settings-panel-page-navigation-item.scss
+++ b/src/scss/components/settings/_settings-panel-page-navigation-item.scss
@@ -1,0 +1,21 @@
+@import '../../variables';
+
+%ui-settings-panel-page-navigation-item {
+  @extend %ui-settings-panel-item;
+
+  .#{$prefix}-ui-settings-panel-page-navigation-item-trailing-label {
+    align-self: center;
+    margin-left: auto;
+    width: fit-content;
+
+    .#{$prefix}-ui-icon {
+      background-image: svg-load('../../assets/images/angle-right.svg', stroke=$color-icon);
+      min-width: unset;
+      width: 0.8em;
+    }
+  }
+}
+
+.#{$prefix}-ui-settings-panel-page-navigation-item {
+  @extend %ui-settings-panel-page-navigation-item;
+}

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -57,6 +57,9 @@ import { FocusableContainer } from './spatialnavigation/FocusableContainer';
 import { BrowserUtils } from './utils/BrowserUtils';
 import { RecommendationOverlayNavigationGroup } from './spatialnavigation/RecommendationOverlayNavigationGroup';
 import { PlayerInsightsPanel } from './components/panels/player-insights/PlayerInsightsPanel';
+import { SettingsPanelPageNavigationItem } from './components/settings/SettingsPanelPageNavigationItem';
+import { SettingsPanelSeparator } from './components/settings/SettingsPanelSeparator';
+import { PlayerInfoSettingsPanelPage } from './components/settings/PlayerInfoSettingsPanelPage';
 
 /**
  * Provides factory methods to create Bitmovin provided UIs.
@@ -786,6 +789,19 @@ export namespace UIFactory {
     });
     mainSettingsPanelPage.addComponent(subtitleSelectItem);
     settingsPanel.addComponent(subtitleSettingsPanelPage);
+
+    if (BrowserUtils.isMobile) {
+      const moreSettingsPanelPage = new PlayerInfoSettingsPanelPage({ settingsPanel });
+      mainSettingsPanelPage.addComponent(new SettingsPanelSeparator());
+      mainSettingsPanelPage.addComponent(
+        new SettingsPanelPageNavigationItem({
+          label: i18n.getLocalizer('settings.more'),
+          container: settingsPanel,
+          targetPage: moreSettingsPanelPage,
+        }),
+      );
+      settingsPanel.addComponent(moreSettingsPanelPage);
+    }
 
     return settingsPanel;
   }

--- a/src/ts/components/settings/PlayerInfoSettingsPanelPage.ts
+++ b/src/ts/components/settings/PlayerInfoSettingsPanelPage.ts
@@ -1,0 +1,99 @@
+import { PlayerAPI } from 'bitmovin-player';
+import { UIInstanceManager } from '../../UIManager';
+import { i18n } from '../../localization/i18n';
+import { version as UI_VERSION_RAW } from '../../main';
+import { Label, LabelConfig } from '../labels/Label';
+import { SettingsPanel, SettingsPanelConfig } from './SettingsPanel';
+import { SettingsPanelItem, SettingsPanelItemConfig } from './SettingsPanelItem';
+import { SettingsPanelPage, SettingsPanelPageConfig } from './SettingsPanelPage';
+import { SettingsPanelPageBackButton } from './SettingsPanelPageBackButton';
+
+const UI_VERSION: string = UI_VERSION_RAW.replace(/^"|"$/g, '');
+
+/**
+ * Configuration interface for a {@link PlayerInfoSettingsPanelPage}.
+ *
+ * @category Configs
+ */
+export interface PlayerInfoSettingsPanelPageConfig extends SettingsPanelPageConfig {
+  /**
+   * Container `SettingsPanel` where the navigation takes place.
+   */
+  settingsPanel: SettingsPanel<SettingsPanelConfig>;
+}
+
+/**
+ * A settings panel page with player and UI information.
+ *
+ * @category Components
+ */
+export class PlayerInfoSettingsPanelPage extends SettingsPanelPage {
+  constructor(config: PlayerInfoSettingsPanelPageConfig) {
+    const pageConfig = {
+      ...config,
+      components: [
+        new SettingsPanelItem({
+          label: new SettingsPanelPageBackButton({
+            container: config.settingsPanel,
+            text: i18n.getLocalizer('settings.more'),
+          }),
+          cssClasses: ['title-item'],
+          isSetting: false,
+        }),
+        new PlayerInfoSettingsPanelItem(),
+        ...(config.components ?? []),
+      ],
+    };
+
+    super(pageConfig);
+
+    this.config = this.mergeConfig(
+      pageConfig,
+      {
+        cssClass: 'ui-player-info-settings-panel-page',
+      },
+      this.config,
+    );
+  }
+}
+
+class PlayerInfoSettingsPanelItem extends SettingsPanelItem<SettingsPanelItemConfig> {
+  private readonly playerVersionLabel: Label<LabelConfig>;
+
+  constructor() {
+    const playerVersionLabel = new Label<LabelConfig>({
+      text: 'Player: -',
+      cssClasses: ['ui-player-info-settings-panel-page-info'],
+    });
+
+    super({
+      label: null,
+      components: [
+        new Label<LabelConfig>({
+          text: i18n.getLocalizer('contextMenu.title'),
+          cssClasses: ['ui-player-info-settings-panel-page-title'],
+        }),
+        new Label<LabelConfig>({
+          text: i18n.getLocalizer('contextMenu.subtitle'),
+          cssClasses: ['ui-player-info-settings-panel-page-subtitle'],
+        }),
+        playerVersionLabel,
+        new Label<LabelConfig>({
+          text: `UI: ${UI_VERSION}`,
+          cssClasses: ['ui-player-info-settings-panel-page-info'],
+        }),
+      ],
+      cssClasses: ['ui-player-info-settings-panel-item'],
+      isSetting: false,
+      role: 'group',
+    });
+
+    this.playerVersionLabel = playerVersionLabel;
+  }
+
+  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
+    super.configure(player, uimanager);
+
+    this.playerVersionLabel.setText(`Player: ${player.version}`);
+  }
+}

--- a/src/ts/components/settings/PlayerInfoSettingsPanelPage.ts
+++ b/src/ts/components/settings/PlayerInfoSettingsPanelPage.ts
@@ -1,14 +1,12 @@
 import { PlayerAPI } from 'bitmovin-player';
 import { UIInstanceManager } from '../../UIManager';
 import { i18n } from '../../localization/i18n';
-import { version as UI_VERSION_RAW } from '../../main';
+import { version as UI_VERSION } from '../../main';
 import { Label, LabelConfig } from '../labels/Label';
 import { SettingsPanel, SettingsPanelConfig } from './SettingsPanel';
 import { SettingsPanelItem, SettingsPanelItemConfig } from './SettingsPanelItem';
 import { SettingsPanelPage, SettingsPanelPageConfig } from './SettingsPanelPage';
 import { SettingsPanelPageBackButton } from './SettingsPanelPageBackButton';
-
-const UI_VERSION: string = UI_VERSION_RAW.replace(/^"|"$/g, '');
 
 /**
  * Configuration interface for a {@link PlayerInfoSettingsPanelPage}.

--- a/src/ts/components/settings/SettingsPanelPageNavigationItem.ts
+++ b/src/ts/components/settings/SettingsPanelPageNavigationItem.ts
@@ -1,0 +1,74 @@
+import { PlayerAPI } from 'bitmovin-player';
+import { UIInstanceManager } from '../../UIManager';
+import { LocalizableText } from '../../localization/i18n';
+import { Label, LabelConfig, LabelStyle } from '../labels/Label';
+import { SettingsPanel, SettingsPanelConfig } from './SettingsPanel';
+import { SettingsPanelItemConfig } from './SettingsPanelItem';
+import { SettingsPanelPage } from './SettingsPanelPage';
+import { InteractiveSettingsPanelItem } from './InteractiveSettingsPanelItem';
+
+/**
+ * Configuration interface for a {@link SettingsPanelPageNavigationItem}.
+ *
+ * @category Configs
+ */
+export interface SettingsPanelPageNavigationItemConfig extends SettingsPanelItemConfig {
+  /**
+   * The label component or the text for the label.
+   */
+  label: LocalizableText;
+  /**
+   * Optional label shown at the end of the navigation row.
+   */
+  trailingLabel?: LocalizableText;
+  /**
+   * Container `SettingsPanel` where the navigation takes place.
+   */
+  container: SettingsPanel<SettingsPanelConfig>;
+  /**
+   * Page where this item should navigate to.
+   */
+  targetPage: SettingsPanelPage;
+}
+
+/**
+ * A settings panel row that navigates to another {@link SettingsPanelPage}.
+ *
+ * @category Components
+ */
+export class SettingsPanelPageNavigationItem extends InteractiveSettingsPanelItem<SettingsPanelPageNavigationItemConfig> {
+  constructor(config: SettingsPanelPageNavigationItemConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(
+      config,
+      {
+        cssClass: 'ui-settings-panel-page-navigation-item',
+        addSettingAsComponent: false,
+        isSetting: true,
+        role: 'menuitem',
+        tabIndex: 0,
+      } as SettingsPanelPageNavigationItemConfig,
+      this.config,
+    );
+
+    this.addComponent(
+      new Label<LabelConfig>({
+        text: this.config.trailingLabel || '',
+        cssClasses: ['ui-settings-panel-page-navigation-item-trailing-label'],
+        labelStyle: LabelStyle.TextWithTrailingIcon,
+      }),
+    );
+  }
+
+  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
+    super.configure(player, uimanager);
+
+    this.getDomElement().attr('aria-haspopup', 'true');
+    this.getDomElement().attr('aria-owns', this.config.targetPage.getConfig().id);
+
+    this.onClick.subscribe(() => {
+      this.config.container.setActivePage(this.config.targetPage);
+    });
+  }
+}

--- a/src/ts/localization/i18n.ts
+++ b/src/ts/localization/i18n.ts
@@ -91,6 +91,7 @@ export interface Vocabulary {
   'colors.magenta': string;
   percent: string;
   settings: string;
+  'settings.more': string;
   'ads.remainingTime': string;
   'ads.skip': string;
   'ads.skippableIn': string;

--- a/src/ts/localization/languages/de.json
+++ b/src/ts/localization/languages/de.json
@@ -15,6 +15,7 @@
   "googleCast": "Google Cast",
   "vr": "VR",
   "settings": "Einstellungen",
+  "settings.more": "Mehr",
   "fullscreen": "Vollbild",
   "off": "aus",
   "settings.subtitles": "Untertitel",

--- a/src/ts/localization/languages/en.json
+++ b/src/ts/localization/languages/en.json
@@ -49,6 +49,7 @@
   "ads.skippableIn": "Skip ad in {remainingTime}",
   "ads.adNumberOfTotal": "Ad {activeAdIndex} of {totalAdsCount}",
   "settings": "Settings",
+  "settings.more": "More",
   "fullscreen": "Fullscreen",
   "speed": "Speed",
   "playPause": "Play/Pause",

--- a/src/ts/localization/languages/es.json
+++ b/src/ts/localization/languages/es.json
@@ -49,6 +49,7 @@
   "ads.skippableIn": "Saltar anuncio en {remainingTime}",
   "ads.adNumberOfTotal": "Anuncio {activeAdIndex} de {totalAdsCount}",
   "settings": "Configuración",
+  "settings.more": "Más",
   "fullscreen": "Pantalla Completa",
   "speed": "Velocidad",
   "playPause": "Reproducir/Pausa",

--- a/src/ts/localization/languages/fr.json
+++ b/src/ts/localization/languages/fr.json
@@ -49,6 +49,7 @@
   "ads.skippableIn": "Passer l'annonce dans {remainingTime}",
   "ads.adNumberOfTotal": "Annonce {activeAdIndex} sur {totalAdsCount}",
   "settings": "Réglages",
+  "settings.more": "Plus",
   "fullscreen": "Plein écran",
   "speed": "Vitesse",
   "playPause": "Lecture/Pause",

--- a/src/ts/localization/languages/nl.json
+++ b/src/ts/localization/languages/nl.json
@@ -49,6 +49,7 @@
   "ads.skippableIn": "Advertentie overslaan over {remainingTime}",
   "ads.adNumberOfTotal": "Advertentie {activeAdIndex} van {totalAdsCount}",
   "settings": "Instellingen",
+  "settings.more": "Meer",
   "fullscreen": "Volledig scherm",
   "speed": "Snelheid",
   "playPause": "Afspelen/Pauzeren",

--- a/src/ts/localization/languages/pt.json
+++ b/src/ts/localization/languages/pt.json
@@ -49,6 +49,7 @@
   "ads.skippableIn": "Ignorar anúncio em {remainingTime}",
   "ads.adNumberOfTotal": "Anúncio {activeAdIndex} de {totalAdsCount}",
   "settings": "Definições",
+  "settings.more": "Mais",
   "fullscreen": "Ecrã inteiro",
   "speed": "Velocidade",
   "playPause": "Reproduzir/Pausar",

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -162,6 +162,10 @@ export {
   SettingsPanelPageNavigatorButton,
   SettingsPanelPageNavigatorConfig,
 } from './components/settings/SettingsPanelPageNavigatorButton';
+export {
+  SettingsPanelPageNavigationItem,
+  SettingsPanelPageNavigationItemConfig,
+} from './components/settings/SettingsPanelPageNavigationItem';
 export { SettingsPanelSeparator, SettingsPanelSeparatorConfig } from './components/settings/SettingsPanelSeparator';
 export {
   PlayerInsightsPanel,

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -171,6 +171,10 @@ export {
   PlayerInsightsPanel,
   PlayerInsightsPanelConfig,
 } from './components/panels/player-insights/PlayerInsightsPanel';
+export {
+  PlayerInfoSettingsPanelPage,
+  PlayerInfoSettingsPanelPageConfig,
+} from './components/settings/PlayerInfoSettingsPanelPage';
 export { InteractiveSettingsPanelItem } from './components/settings/InteractiveSettingsPanelItem';
 export { TouchControlOverlay, TouchControlOverlayConfig } from './components/overlays/TouchControlOverlay';
 export { CharacterEdgeColorSelectBox } from './components/settings/subtitlesettings/CharacterEdgeColorSelectBox';

--- a/src/ts/spatialnavigation/SettingsPanelNavigationGroup.ts
+++ b/src/ts/spatialnavigation/SettingsPanelNavigationGroup.ts
@@ -2,8 +2,7 @@ import { NavigationGroup } from './NavigationGroup';
 import { Action, Focusable } from './types';
 import { SettingsPanel, SettingsPanelConfig } from '../components/settings/SettingsPanel';
 import { resolveAllComponents } from './helper/resolveAllComponents';
-import { SettingsPanelSelectOption } from '../components/settings/SettingsPanelSelectOption';
-import { DynamicSettingsPanelItem } from '../components/settings/DynamicSettingsPanelItem';
+import { InteractiveSettingsPanelItem } from '../components/settings/InteractiveSettingsPanelItem';
 
 export class SettingsPanelNavigationGroupConfig {
   /**
@@ -57,9 +56,7 @@ export class SettingsPanelNavigationGroup extends NavigationGroup {
 
     const componentsToConsider: Focusable[] = [];
     pageComponents.forEach(component => {
-      if (component instanceof SettingsPanelSelectOption) {
-        componentsToConsider.push(component);
-      } else if (component instanceof DynamicSettingsPanelItem) {
+      if (component instanceof InteractiveSettingsPanelItem) {
         componentsToConsider.push(component);
       } else {
         componentsToConsider.push(...resolveAllComponents(component));


### PR DESCRIPTION
## Description
Adds a More page to mobile settings panels so touch users can access Bitmovin Player and UI version information without relying on the desktop context menu.

<img width="311" height="548" alt="Screenshot 2026-05-22 at 10 33 05" src="https://github.com/user-attachments/assets/ae2443c7-ecec-49a0-ba7a-aadc2f6862fa" />

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
