### PR TITLE
[PUI-73] - Apply persisted subtitle styling preferences to the rendered subtitles on initial load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - The exported UI `version` (`window.bitmovin.playerui.version`) no longer includes extra quote characters
+- Saved subtitle styling preferences are now correctly applied to the rendered subtitles on initial load
 
 ### Internal
 

--- a/spec/components/settings/subtitlesettings/SubtitleSettingSelectBox.spec.ts
+++ b/spec/components/settings/subtitlesettings/SubtitleSettingSelectBox.spec.ts
@@ -126,7 +126,7 @@ const cases: BoxCase[] = [
   },
 ];
 
-describe('SubtitleSettingSelectBox.initFromSettings() (PUI-73)', () => {
+describe('subtitle setting select boxes persisted values', () => {
   let playerMock: PlayerAPI;
   let uiManagerMock: UIInstanceManager;
   let settingsManager: SubtitleSettingsManager;

--- a/spec/components/settings/subtitlesettings/SubtitleSettingSelectBox.spec.ts
+++ b/spec/components/settings/subtitlesettings/SubtitleSettingSelectBox.spec.ts
@@ -1,0 +1,171 @@
+import type { PlayerAPI } from 'bitmovin-player';
+
+import { MockHelper } from '../../../helper/MockHelper';
+import type { UIInstanceManager } from '../../../../src/ts/UIManager';
+import type { SubtitleOverlay } from '../../../../src/ts/components/overlays/SubtitleOverlay';
+import type { SubtitleSettingsManager } from '../../../../src/ts/utils/SubtitleSettingsManager';
+import {
+  SubtitleSettingSelectBox,
+  SubtitleSettingSelectBoxConfig,
+} from '../../../../src/ts/components/settings/subtitlesettings/SubtitleSettingSelectBox';
+import { FontSizeSelectBox } from '../../../../src/ts/components/settings/subtitlesettings/FontSizeSelectBox';
+import { FontStyleSelectBox } from '../../../../src/ts/components/settings/subtitlesettings/FontStyleSelectBox';
+import { FontFamilySelectBox } from '../../../../src/ts/components/settings/subtitlesettings/FontFamilySelectBox';
+import { FontColorSelectBox } from '../../../../src/ts/components/settings/subtitlesettings/FontColorSelectBox';
+import { FontOpacitySelectBox } from '../../../../src/ts/components/settings/subtitlesettings/FontOpacitySelectBox';
+import { CharacterEdgeSelectBox } from '../../../../src/ts/components/settings/subtitlesettings/CharacterEdgeSelectBox';
+import { CharacterEdgeColorSelectBox } from '../../../../src/ts/components/settings/subtitlesettings/CharacterEdgeColorSelectBox';
+import { BackgroundColorSelectBox } from '../../../../src/ts/components/settings/subtitlesettings/BackgroundColorSelectBox';
+import { BackgroundOpacitySelectBox } from '../../../../src/ts/components/settings/subtitlesettings/BackgroundOpacitySelectBox';
+import { WindowColorSelectBox } from '../../../../src/ts/components/settings/subtitlesettings/WindowColorSelectBox';
+import { WindowOpacitySelectBox } from '../../../../src/ts/components/settings/subtitlesettings/WindowOpacitySelectBox';
+import type { DOM } from '../../../../src/ts/DOM';
+
+type BoxCtor = new (config: SubtitleSettingSelectBoxConfig) => SubtitleSettingSelectBox;
+
+interface BoxCase {
+  name: string;
+  Box: BoxCtor;
+  setPersisted: (sm: SubtitleSettingsManager) => void;
+  /** null = paired box that does not drive its own overlay class */
+  expectedClassSuffix: string | null;
+}
+
+const cases: BoxCase[] = [
+  {
+    name: 'FontSizeSelectBox',
+    Box: FontSizeSelectBox,
+    setPersisted: sm => {
+      sm.fontSize.value = '400';
+    },
+    expectedClassSuffix: '-fontsize-400',
+  },
+  {
+    name: 'FontStyleSelectBox',
+    Box: FontStyleSelectBox,
+    setPersisted: sm => {
+      sm.fontStyle.value = 'italic';
+    },
+    expectedClassSuffix: '-fontstyle-italic',
+  },
+  {
+    name: 'FontFamilySelectBox',
+    Box: FontFamilySelectBox,
+    setPersisted: sm => {
+      sm.fontFamily.value = 'monospacedserif';
+    },
+    expectedClassSuffix: '-fontfamily-monospacedserif',
+  },
+  {
+    name: 'FontColorSelectBox',
+    Box: FontColorSelectBox,
+    setPersisted: sm => {
+      sm.fontColor.value = 'green';
+      sm.fontOpacity.value = '100';
+    },
+    expectedClassSuffix: '-fontcolor-green100',
+  },
+  {
+    name: 'FontOpacitySelectBox',
+    Box: FontOpacitySelectBox,
+    setPersisted: sm => {
+      sm.fontOpacity.value = '75';
+    },
+    expectedClassSuffix: null,
+  },
+  {
+    name: 'CharacterEdgeSelectBox',
+    Box: CharacterEdgeSelectBox,
+    setPersisted: sm => {
+      sm.characterEdge.value = 'raised';
+      sm.characterEdgeColor.value = 'white';
+    },
+    expectedClassSuffix: '-characteredge-raised-white',
+  },
+  {
+    name: 'CharacterEdgeColorSelectBox',
+    Box: CharacterEdgeColorSelectBox,
+    setPersisted: sm => {
+      sm.characterEdgeColor.value = 'red';
+    },
+    expectedClassSuffix: null,
+  },
+  {
+    name: 'BackgroundColorSelectBox',
+    Box: BackgroundColorSelectBox,
+    setPersisted: sm => {
+      sm.backgroundColor.value = 'black';
+      sm.backgroundOpacity.value = '50';
+    },
+    expectedClassSuffix: '-bgcolor-black50',
+  },
+  {
+    name: 'BackgroundOpacitySelectBox',
+    Box: BackgroundOpacitySelectBox,
+    setPersisted: sm => {
+      sm.backgroundOpacity.value = '25';
+    },
+    expectedClassSuffix: null,
+  },
+  {
+    name: 'WindowColorSelectBox',
+    Box: WindowColorSelectBox,
+    setPersisted: sm => {
+      sm.windowColor.value = 'blue';
+      sm.windowOpacity.value = '100';
+    },
+    expectedClassSuffix: '-windowcolor-blue100',
+  },
+  {
+    name: 'WindowOpacitySelectBox',
+    Box: WindowOpacitySelectBox,
+    setPersisted: sm => {
+      sm.windowOpacity.value = '50';
+    },
+    expectedClassSuffix: null,
+  },
+];
+
+describe('SubtitleSettingSelectBox.initFromSettings() (PUI-73)', () => {
+  let playerMock: PlayerAPI;
+  let uiManagerMock: UIInstanceManager;
+  let settingsManager: SubtitleSettingsManager;
+  let overlayDom: jest.Mocked<DOM>;
+  let overlay: SubtitleOverlay;
+  let addClassSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiManagerMock = MockHelper.getUiInstanceManagerMock();
+    settingsManager = uiManagerMock.getSubtitleSettingsManager();
+    overlayDom = MockHelper.generateDOMMock();
+    addClassSpy = jest.spyOn(overlayDom, 'addClass');
+    overlay = {
+      getDomElement: () => overlayDom,
+      filterFontSizeOptions: () => true,
+    } as unknown as SubtitleOverlay;
+  });
+
+  it.each(cases)(
+    '$name applies its persisted value to the overlay on configure',
+    ({ Box, setPersisted, expectedClassSuffix }) => {
+      setPersisted(settingsManager);
+
+      new Box({ overlay }).configure(playerMock, uiManagerMock);
+
+      if (expectedClassSuffix === null) {
+        // Paired box: it has no overlay class of its own; its value participates
+        // via the partner color/edge box's combined class, not via this one.
+        expect(addClassSpy).not.toHaveBeenCalled();
+      } else {
+        expect(addClassSpy).toHaveBeenCalledWith(expect.stringContaining(expectedClassSuffix));
+      }
+    },
+  );
+
+  it.each(cases)('$name does not touch the overlay when no value is persisted', ({ Box }) => {
+    new Box({ overlay }).configure(playerMock, uiManagerMock);
+
+    expect(addClassSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/ts/components/settings/subtitlesettings/BackgroundColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/BackgroundColorSelectBox.ts
@@ -58,7 +58,7 @@ export class BackgroundColorSelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.backgroundColor.isSet()) {
       this.selectItem(this.settingsManager.backgroundColor.value);
       this.setColorAndOpacity();

--- a/src/ts/components/settings/subtitlesettings/BackgroundColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/BackgroundColorSelectBox.ts
@@ -34,16 +34,6 @@ export class BackgroundColorSelectBox extends SubtitleSettingSelectBox {
     this.addItem('yellow', i18n.getLocalizer('colors.yellow'));
     this.addItem('magenta', i18n.getLocalizer('colors.magenta'));
 
-    const setColorAndOpacity = () => {
-      if (this.settingsManager.backgroundColor.isSet() && this.settingsManager.backgroundOpacity.isSet()) {
-        this.toggleOverlayClass(
-          'bgcolor-' + this.settingsManager.backgroundColor.value + this.settingsManager.backgroundOpacity.value,
-        );
-      } else {
-        this.toggleOverlayClass(null);
-      }
-    };
-
     this.onItemSelectionChanged.subscribe((sender, key: string) => {
       this.settingsManager.backgroundColor.value = key;
     });
@@ -58,16 +48,30 @@ export class BackgroundColorSelectBox extends SubtitleSettingSelectBox {
         this.settingsManager.backgroundOpacity.value = '100';
       }
       this.selectItem(property.value);
-      setColorAndOpacity();
+      this.setColorAndOpacity();
     });
 
     this.settingsManager.backgroundOpacity.onChanged.subscribe(() => {
-      setColorAndOpacity();
+      this.setColorAndOpacity();
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.backgroundColor.isSet()) {
       this.selectItem(this.settingsManager.backgroundColor.value);
+      this.setColorAndOpacity();
+    }
+  }
+
+  private setColorAndOpacity(): void {
+    if (this.settingsManager.backgroundColor.isSet() && this.settingsManager.backgroundOpacity.isSet()) {
+      this.toggleOverlayClass(
+        'bgcolor-' + this.settingsManager.backgroundColor.value + this.settingsManager.backgroundOpacity.value,
+      );
+    } else {
+      this.toggleOverlayClass(null);
     }
   }
 }

--- a/src/ts/components/settings/subtitlesettings/BackgroundOpacitySelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/BackgroundOpacitySelectBox.ts
@@ -49,7 +49,10 @@ export class BackgroundOpacitySelectBox extends SubtitleSettingSelectBox {
       this.selectItem(property.value);
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.backgroundOpacity.isSet()) {
       this.selectItem(this.settingsManager.backgroundOpacity.value);
     }

--- a/src/ts/components/settings/subtitlesettings/BackgroundOpacitySelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/BackgroundOpacitySelectBox.ts
@@ -52,7 +52,7 @@ export class BackgroundOpacitySelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.backgroundOpacity.isSet()) {
       this.selectItem(this.settingsManager.backgroundOpacity.value);
     }

--- a/src/ts/components/settings/subtitlesettings/CharacterEdgeColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/CharacterEdgeColorSelectBox.ts
@@ -55,7 +55,7 @@ export class CharacterEdgeColorSelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.characterEdgeColor.isSet()) {
       this.selectItem(this.settingsManager.characterEdgeColor.value);
     }

--- a/src/ts/components/settings/subtitlesettings/CharacterEdgeColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/CharacterEdgeColorSelectBox.ts
@@ -52,7 +52,10 @@ export class CharacterEdgeColorSelectBox extends SubtitleSettingSelectBox {
       this.selectItem(property.value);
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.characterEdgeColor.isSet()) {
       this.selectItem(this.settingsManager.characterEdgeColor.value);
     }

--- a/src/ts/components/settings/subtitlesettings/CharacterEdgeSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/CharacterEdgeSelectBox.ts
@@ -54,7 +54,7 @@ export class CharacterEdgeSelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.characterEdge.isSet()) {
       this.selectItem(this.settingsManager.characterEdge.value);
       this.setColorAndEdgeType();

--- a/src/ts/components/settings/subtitlesettings/CharacterEdgeSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/CharacterEdgeSelectBox.ts
@@ -30,19 +30,6 @@ export class CharacterEdgeSelectBox extends SubtitleSettingSelectBox {
     this.addItem('uniform', i18n.getLocalizer('settings.subtitles.characterEdge.uniform'));
     this.addItem('dropshadowed', i18n.getLocalizer('settings.subtitles.characterEdge.dropshadowed'));
 
-    const setColorAndEdgeType = () => {
-      if (this.settingsManager.characterEdge.isSet() && this.settingsManager.characterEdgeColor.isSet()) {
-        this.toggleOverlayClass(
-          'characteredge-' +
-            this.settingsManager.characterEdge.value +
-            '-' +
-            this.settingsManager.characterEdgeColor.value,
-        );
-      } else {
-        this.toggleOverlayClass(null);
-      }
-    };
-
     this.onItemSelectionChanged.subscribe((sender, key: string) => {
       this.settingsManager.characterEdge.value = key;
     });
@@ -57,16 +44,33 @@ export class CharacterEdgeSelectBox extends SubtitleSettingSelectBox {
         this.settingsManager.characterEdgeColor.value = 'black';
       }
       this.selectItem(property.value);
-      setColorAndEdgeType();
+      this.setColorAndEdgeType();
     });
 
     this.settingsManager.characterEdgeColor.onChanged.subscribe(() => {
-      setColorAndEdgeType();
+      this.setColorAndEdgeType();
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.characterEdge.isSet()) {
       this.selectItem(this.settingsManager.characterEdge.value);
+      this.setColorAndEdgeType();
+    }
+  }
+
+  private setColorAndEdgeType(): void {
+    if (this.settingsManager.characterEdge.isSet() && this.settingsManager.characterEdgeColor.isSet()) {
+      this.toggleOverlayClass(
+        'characteredge-' +
+          this.settingsManager.characterEdge.value +
+          '-' +
+          this.settingsManager.characterEdgeColor.value,
+      );
+    } else {
+      this.toggleOverlayClass(null);
     }
   }
 }

--- a/src/ts/components/settings/subtitlesettings/FontColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontColorSelectBox.ts
@@ -34,16 +34,6 @@ export class FontColorSelectBox extends SubtitleSettingSelectBox {
     this.addItem('yellow', i18n.getLocalizer('colors.yellow'));
     this.addItem('magenta', i18n.getLocalizer('colors.magenta'));
 
-    const setColorAndOpacity = () => {
-      if (this.settingsManager.fontColor.isSet() && this.settingsManager.fontOpacity.isSet()) {
-        this.toggleOverlayClass(
-          'fontcolor-' + this.settingsManager.fontColor.value + this.settingsManager.fontOpacity.value,
-        );
-      } else {
-        this.toggleOverlayClass(null);
-      }
-    };
-
     this.onItemSelectionChanged.subscribe((sender, key: string) => {
       this.settingsManager.fontColor.value = key;
     });
@@ -58,16 +48,30 @@ export class FontColorSelectBox extends SubtitleSettingSelectBox {
         this.settingsManager.fontOpacity.value = '100';
       }
       this.selectItem(property.value);
-      setColorAndOpacity();
+      this.setColorAndOpacity();
     });
 
     this.settingsManager.fontOpacity.onChanged.subscribe(() => {
-      setColorAndOpacity();
+      this.setColorAndOpacity();
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.fontColor.isSet()) {
       this.selectItem(this.settingsManager.fontColor.value);
+      this.setColorAndOpacity();
+    }
+  }
+
+  private setColorAndOpacity(): void {
+    if (this.settingsManager.fontColor.isSet() && this.settingsManager.fontOpacity.isSet()) {
+      this.toggleOverlayClass(
+        'fontcolor-' + this.settingsManager.fontColor.value + this.settingsManager.fontOpacity.value,
+      );
+    } else {
+      this.toggleOverlayClass(null);
     }
   }
 }

--- a/src/ts/components/settings/subtitlesettings/FontColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontColorSelectBox.ts
@@ -58,7 +58,7 @@ export class FontColorSelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.fontColor.isSet()) {
       this.selectItem(this.settingsManager.fontColor.value);
       this.setColorAndOpacity();

--- a/src/ts/components/settings/subtitlesettings/FontFamilySelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontFamilySelectBox.ts
@@ -51,7 +51,7 @@ export class FontFamilySelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.fontFamily.isSet()) {
       this.selectItem(this.settingsManager.fontFamily.value);
       this.toggleOverlayClass('fontfamily-' + this.settingsManager.fontFamily.value);

--- a/src/ts/components/settings/subtitlesettings/FontFamilySelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontFamilySelectBox.ts
@@ -48,9 +48,13 @@ export class FontFamilySelectBox extends SubtitleSettingSelectBox {
       this.settingsManager.fontFamily.value = key;
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.fontFamily.isSet()) {
       this.selectItem(this.settingsManager.fontFamily.value);
+      this.toggleOverlayClass('fontfamily-' + this.settingsManager.fontFamily.value);
     }
   }
 }

--- a/src/ts/components/settings/subtitlesettings/FontOpacitySelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontOpacitySelectBox.ts
@@ -51,7 +51,7 @@ export class FontOpacitySelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.fontOpacity.isSet()) {
       this.selectItem(this.settingsManager.fontOpacity.value);
     }

--- a/src/ts/components/settings/subtitlesettings/FontOpacitySelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontOpacitySelectBox.ts
@@ -48,7 +48,10 @@ export class FontOpacitySelectBox extends SubtitleSettingSelectBox {
       this.selectItem(property.value);
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.fontOpacity.isSet()) {
       this.selectItem(this.settingsManager.fontOpacity.value);
     }

--- a/src/ts/components/settings/subtitlesettings/FontSizeSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontSizeSelectBox.ts
@@ -79,7 +79,7 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.fontSize.isSet()) {
       this.toggleOverlayClass('fontsize-' + this.settingsManager.fontSize.value);
     }

--- a/src/ts/components/settings/subtitlesettings/FontSizeSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontSizeSelectBox.ts
@@ -76,5 +76,12 @@ export class FontSizeSelectBox extends SubtitleSettingSelectBox {
 
     // init
     this.populateItemsWithFilter();
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
+    if (this.settingsManager.fontSize.isSet()) {
+      this.toggleOverlayClass('fontsize-' + this.settingsManager.fontSize.value);
+    }
   }
 }

--- a/src/ts/components/settings/subtitlesettings/FontStyleSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontStyleSelectBox.ts
@@ -48,7 +48,7 @@ export class FontStyleSelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager?.fontStyle.isSet()) {
       this.selectItem(this.settingsManager.fontStyle.value);
       this.toggleOverlayClass('fontstyle-' + this.settingsManager.fontStyle.value);

--- a/src/ts/components/settings/subtitlesettings/FontStyleSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/FontStyleSelectBox.ts
@@ -45,9 +45,13 @@ export class FontStyleSelectBox extends SubtitleSettingSelectBox {
       }
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager?.fontStyle.isSet()) {
       this.selectItem(this.settingsManager.fontStyle.value);
+      this.toggleOverlayClass('fontstyle-' + this.settingsManager.fontStyle.value);
     }
   }
 }

--- a/src/ts/components/settings/subtitlesettings/SubtitleSettingSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/SubtitleSettingSelectBox.ts
@@ -49,4 +49,13 @@ export class SubtitleSettingSelectBox extends SelectBox {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     this.settingsManager = uimanager.getSubtitleSettingsManager();
   }
+
+  /**
+   * Applies the persisted value on init. Subclasses call this at the end of
+   * `configure()`; the `onChanged` events from `SubtitleSettingsManager.load`
+   * fire before subscribers are attached, so each subclass must re-apply.
+   */
+  protected initFromSettings(): void {
+    // no-op; subclasses override
+  }
 }

--- a/src/ts/components/settings/subtitlesettings/SubtitleSettingSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/SubtitleSettingSelectBox.ts
@@ -49,13 +49,4 @@ export class SubtitleSettingSelectBox extends SelectBox {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     this.settingsManager = uimanager.getSubtitleSettingsManager();
   }
-
-  /**
-   * Applies the persisted value on init. Subclasses call this at the end of
-   * `configure()`; the `onChanged` events from `SubtitleSettingsManager.load`
-   * fire before subscribers are attached, so each subclass must re-apply.
-   */
-  protected initFromSettings(): void {
-    // no-op; subclasses override
-  }
 }

--- a/src/ts/components/settings/subtitlesettings/WindowColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/WindowColorSelectBox.ts
@@ -34,16 +34,6 @@ export class WindowColorSelectBox extends SubtitleSettingSelectBox {
     this.addItem('yellow', i18n.getLocalizer('colors.yellow'));
     this.addItem('magenta', i18n.getLocalizer('colors.magenta'));
 
-    const setColorAndOpacity = () => {
-      if (this.settingsManager.windowColor.isSet() && this.settingsManager.windowOpacity.isSet()) {
-        this.toggleOverlayClass(
-          'windowcolor-' + this.settingsManager.windowColor.value + this.settingsManager.windowOpacity.value,
-        );
-      } else {
-        this.toggleOverlayClass(null);
-      }
-    };
-
     this.onItemSelectionChanged.subscribe((sender, key: string) => {
       this.settingsManager.windowColor.value = key;
     });
@@ -58,16 +48,30 @@ export class WindowColorSelectBox extends SubtitleSettingSelectBox {
         this.settingsManager.windowOpacity.value = '100';
       }
       this.selectItem(property.value);
-      setColorAndOpacity();
+      this.setColorAndOpacity();
     });
 
     this.settingsManager.windowOpacity.onChanged.subscribe(() => {
-      setColorAndOpacity();
+      this.setColorAndOpacity();
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.windowColor.isSet()) {
       this.selectItem(this.settingsManager.windowColor.value);
+      this.setColorAndOpacity();
+    }
+  }
+
+  private setColorAndOpacity(): void {
+    if (this.settingsManager.windowColor.isSet() && this.settingsManager.windowOpacity.isSet()) {
+      this.toggleOverlayClass(
+        'windowcolor-' + this.settingsManager.windowColor.value + this.settingsManager.windowOpacity.value,
+      );
+    } else {
+      this.toggleOverlayClass(null);
     }
   }
 }

--- a/src/ts/components/settings/subtitlesettings/WindowColorSelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/WindowColorSelectBox.ts
@@ -58,7 +58,7 @@ export class WindowColorSelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.windowColor.isSet()) {
       this.selectItem(this.settingsManager.windowColor.value);
       this.setColorAndOpacity();

--- a/src/ts/components/settings/subtitlesettings/WindowOpacitySelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/WindowOpacitySelectBox.ts
@@ -52,7 +52,7 @@ export class WindowOpacitySelectBox extends SubtitleSettingSelectBox {
     this.initFromSettings();
   }
 
-  protected initFromSettings(): void {
+  private initFromSettings(): void {
     if (this.settingsManager.windowOpacity.isSet()) {
       this.selectItem(this.settingsManager.windowOpacity.value);
     }

--- a/src/ts/components/settings/subtitlesettings/WindowOpacitySelectBox.ts
+++ b/src/ts/components/settings/subtitlesettings/WindowOpacitySelectBox.ts
@@ -49,7 +49,10 @@ export class WindowOpacitySelectBox extends SubtitleSettingSelectBox {
       this.selectItem(property.value);
     });
 
-    // Load initial value
+    this.initFromSettings();
+  }
+
+  protected initFromSettings(): void {
     if (this.settingsManager.windowOpacity.isSet()) {
       this.selectItem(this.settingsManager.windowOpacity.value);
     }


### PR DESCRIPTION

## Description
<!-- Add a short description about the changes -->

Apply persisted subtitle styling preferences to the rendered subtitles on initial load. Fixes [PUI-73](https://bitmovin.atlassian.net/browse/PUI-73).

# Problem

When a user has previously configured subtitle settings (font size, style, family, color, character edge, background, window), reloading the player shows the saved values in the settings dropdowns, but the subtitles render with **default styling**. The styling is only applied after the user manually changes a setting in the panel.

Root cause: `SubtitleSettingsManager.initialize()` runs during `UIManager` construction and calls `load()`, which assigns each persisted value to its `SubtitleSettingsProperty`. Each assignment dispatches `onChanged`. The `Sub*SelectBox` components that translate a setting into the overlay CSS class (`bmpui-fontsize-*`, `bmpui-fontcolor-*`, …) subscribe to that `onChanged` in their `configure()`, which runs **after** the load-time dispatch. So the load-time dispatch reaches no listeners, and the persisted value never becomes an overlay class. The dropdown still shows the value because that path uses `selectItem()`, which is independent of the overlay class.

# Changes

Each subtitle SelectBox initializes its state from the persisted settings at the end of `configure()`. Implemented as a `protected initFromSettings(): void` hook on the `SubtitleSettingSelectBox` base class (default no-op). Every subclass overrides it with the same shape — read the persisted value, sync the dropdown, and apply the overlay class if relevant — and each subclass's `configure()` ends with `this.initFromSettings()`.

| SelectBox                     | `initFromSettings()` does                                         |
| ----------------------------- | ----------------------------------------------------------------- |
| `FontSizeSelectBox`           | `toggleOverlayClass('fontsize-' + value)`                         |
| `FontStyleSelectBox`          | `selectItem(value)` + `toggleOverlayClass('fontstyle-' + value)`  |
| `FontFamilySelectBox`         | `selectItem(value)` + `toggleOverlayClass('fontfamily-' + value)` |
| `FontColorSelectBox`          | `selectItem(value)` + `setColorAndOpacity()`                      |
| `FontOpacitySelectBox`        | `selectItem(value)`                                               |
| `CharacterEdgeSelectBox`      | `selectItem(value)` + `setColorAndEdgeType()`                     |
| `CharacterEdgeColorSelectBox` | `selectItem(value)`                                               |
| `BackgroundColorSelectBox`    | `selectItem(value)` + `setColorAndOpacity()`                      |
| `BackgroundOpacitySelectBox`  | `selectItem(value)`                                               |
| `WindowColorSelectBox`        | `selectItem(value)` + `setColorAndOpacity()`                      |
| `WindowOpacitySelectBox`      | `selectItem(value)`                                               |

The four boxes that compose two settings into one overlay class (`FontColor`, `BackgroundColor`, `WindowColor`, `CharacterEdge`) had their local `setColorAndOpacity` / `setColorAndEdgeType` closures promoted to `private` methods so both the `onChanged` subscribers and the new `initFromSettings()` reuse them.

No changes to `UIManager` or `SubtitleSettingsManager` — the fix stays local to the components responsible for the overlay classes.

# Test

New parameterized spec at `spec/components/settings/subtitlesettings/SubtitleSettingSelectBox.spec.ts`, 22 cases (11 boxes × 2 behaviors):

- _Applies its persisted value to the overlay on configure_ — for each box, set the persisted value on `SubtitleSettingsManager` before `configure()` and assert the expected overlay class is added (or, for the 4 paired boxes, that no class is added since their value participates via the partner color/edge box's combined class).
- _Does not touch the overlay when no value is persisted_ — sanity check.

Verified the suite genuinely guards the fix by stashing the source changes and re-running: **7 fail** (the 7 boxes that drive their own overlay class), **15 pass**. With the fix applied: **22 / 22 pass**. Lint clean.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry


[PUI-73]: https://bitmovin.atlassian.net/browse/PUI-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ