### PR TITLE
Fix wrong changelog section of newly added APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.14.1] - 2026-05-28
-
-### Fixed
-
-- The exported UI `version` (`window.bitmovin.playerui.version`) no longer includes extra quote characters
+## [Unreleased]
 
 ### Added
 
 - `UIManager.recommendations` namespace for dynamically updating recommendation items for the `RecommendationOverlay`
 - `UIManager.timelineMarkers` namespace for dynamically updating `TimelineMarker`s for the seek bar
+
+## [4.14.1] - 2026-05-28
+
+### Fixed
+
+- The exported UI `version` (`window.bitmovin.playerui.version`) no longer includes extra quote characters
 
 ### Internal
 


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
#880 and #878 added the changelog entry accidentially to the already release version section.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
