### PR TITLE
Fix vertical seek bar and volume slider layout in UI v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Vertical seek bars and volume sliders (`vertical: true`, e.g. the slide-out volume slider of the `VolumeControlButton`) were rendered with a broken horizontal layout.
-  Note for custom skins: the control bar rule sizing the inline volume slider now uses the selector `.bmpui-ui-volumeslider:not(.bmpui-vertical)`, which has a higher specificity than before. Custom styles relying on overriding the previous `.bmpui-ui-volumeslider` rule at equal specificity may need to be adjusted.
+- Vertical seek bars and volume sliders (`vertical: true`, e.g. the slide-out volume slider of the `VolumeControlButton`) were rendered with a broken horizontal layout
 
 ## [4.15.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Vertical seek bars and volume sliders (`vertical: true`, e.g. the slide-out volume slider of the `VolumeControlButton`) were rendered with a broken horizontal layout.
+  Note for custom skins: the control bar rule sizing the inline volume slider now uses the selector `.bmpui-ui-volumeslider:not(.bmpui-vertical)`, which has a higher specificity than before. Custom styles relying on overriding the previous `.bmpui-ui-volumeslider` rule at equal specificity may need to be adjusted.
+
 ## [4.14.0] - 2026-05-14
 
 ### Added

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -147,6 +147,16 @@
   }
 }
 
+// Overrides for `seekbar-position-marker` on vertical seek bars: centers the marker horizontally
+// on the bar (it is wider than the bar) and anchors it to the top edge, as the SeekBar component
+// positions it via translateY() from the top. Must be passed the same dimension as the
+// corresponding `seekbar-position-marker` call.
+@mixin seekbar-position-marker-vertical($marker-dimension) {
+  bottom: auto;
+  left: calc(50% - $marker-dimension / 2);
+  top: 0;
+}
+
 @mixin focusable($inset: false, $border-radius: 0.3em, $focus-element-box-shadow: 0 0 0 0.1em rgba($color-focus, 0.4)) {
   &:focus {
     outline: none;

--- a/src/scss/components/_control-bar.scss
+++ b/src/scss/components/_control-bar.scss
@@ -42,7 +42,9 @@
     margin-top: 0.5em;
 
     > .#{$prefix}-container-wrapper {
-      .#{$prefix}-ui-volumeslider {
+      // Only size the inline (horizontal) volume slider; a vertical slider (e.g. the slide-out slider
+      // of the VolumeControlButton) defines its own dimensions.
+      .#{$prefix}-ui-volumeslider:not(.#{$prefix}-vertical) {
         margin: auto 0.5em;
         width: 8rem;
       }

--- a/src/scss/components/buttons/_volume-control-button.scss
+++ b/src/scss/components/buttons/_volume-control-button.scss
@@ -26,5 +26,13 @@
       top: 0.5em;
       width: auto;
     }
+
+    &.#{$prefix}-vertical {
+      .#{$prefix}-seekbar {
+        // The round playback position marker (knob) is wider than the vertical bar
+        // and must not be clipped away
+        overflow: visible;
+      }
+    }
   }
 }

--- a/src/scss/components/seekbar/_seek-bar.scss
+++ b/src/scss/components/seekbar/_seek-bar.scss
@@ -180,8 +180,6 @@ $seekbar-marker-dimension: calc($seekbar-bar-height * 3);
 
       &:after {
         @include invisible-hit-area(0, -$horizontal-margin, 0, -$horizontal-margin);
-        // Uncomment to expose hit area for debugging
-        // background-color: rgba(lime, 0.5);
       }
 
       .#{$prefix}-seekbar-bars,

--- a/src/scss/components/seekbar/_seek-bar.scss
+++ b/src/scss/components/seekbar/_seek-bar.scss
@@ -189,17 +189,9 @@ $seekbar-marker-dimension: calc($seekbar-bar-height * 3);
       .#{$prefix}-seekbar-bufferlevel,
       .#{$prefix}-seekbar-seekposition,
       .#{$prefix}-seekbar-playbackposition {
-        // sass-lint:disable no-vendor-prefixes
         -webkit-transform-origin: 0 100%; // required for Android 4.4 WebView
         height: 100%;
         transform-origin: 0 100%;
-      }
-
-      .#{$prefix}-seekbar-backdrop,
-      .#{$prefix}-seekbar-bufferlevel,
-      .#{$prefix}-seekbar-seekposition,
-      .#{$prefix}-seekbar-playbackposition {
-        margin: 0 $bar-inset;
       }
     }
   }

--- a/src/scss/components/seekbar/_seek-bar.scss
+++ b/src/scss/components/seekbar/_seek-bar.scss
@@ -3,6 +3,8 @@
 
 // Defines the height of the bars within the seekbar container
 $seekbar-bar-height: calc($font-size / 3);
+// Defines the size of the playback position marker (the knob)
+$seekbar-marker-dimension: calc($seekbar-bar-height * 3);
 
 // sass-lint:disable no-vendor-prefixes
 %bar {
@@ -36,7 +38,7 @@ $seekbar-bar-height: calc($font-size / 3);
   .#{$prefix}-seekbar-playbackposition-marker {
     @extend %bar;
 
-    @include seekbar-position-marker($seekbar-bar-height * 3);
+    @include seekbar-position-marker($seekbar-marker-dimension);
     background-color: $color-highlight;
     border-radius: 50%;
     box-shadow: 0 0 3px 0 transparentize($color: #000, $amount: 0.75);
@@ -151,6 +153,53 @@ $seekbar-bar-height: calc($font-size / 3);
           background-color: $color-primary;
           border-radius: $marker-indicator-border-radius;
         }
+      }
+    }
+  }
+
+  // Vertical orientation (e.g. vertical volume slider): swaps the layout axis of the bars.
+  // The fill bars are scaled with scaleY() instead of scaleX() and grow from the bottom,
+  // matching the transforms applied by the SeekBar component for `vertical: true`.
+  // Note: timeline markers are not supported on vertical seek bars; the TimelineMarkersHandler
+  // positions markers along the horizontal axis only.
+  &.#{$prefix}-vertical {
+    height: 100%;
+    justify-content: center;
+    width: $font-size;
+
+    .#{$prefix}-seekbar-playbackposition-marker {
+      @include seekbar-position-marker-vertical($seekbar-marker-dimension);
+    }
+
+    .#{$prefix}-seekbar {
+      $horizontal-margin: calc((1rem - $seekbar-bar-height) / 2);
+      // Reduce height to leave some padding for the focus indicator on the top and bottom side
+      height: calc(100% - 0.5rem);
+      margin: auto $horizontal-margin;
+      width: $seekbar-bar-height;
+
+      &:after {
+        @include invisible-hit-area(0, -$horizontal-margin, 0, -$horizontal-margin);
+        // Uncomment to expose hit area for debugging
+        // background-color: rgba(lime, 0.5);
+      }
+
+      .#{$prefix}-seekbar-bars,
+      .#{$prefix}-seekbar-backdrop,
+      .#{$prefix}-seekbar-bufferlevel,
+      .#{$prefix}-seekbar-seekposition,
+      .#{$prefix}-seekbar-playbackposition {
+        // sass-lint:disable no-vendor-prefixes
+        -webkit-transform-origin: 0 100%; // required for Android 4.4 WebView
+        height: 100%;
+        transform-origin: 0 100%;
+      }
+
+      .#{$prefix}-seekbar-backdrop,
+      .#{$prefix}-seekbar-bufferlevel,
+      .#{$prefix}-seekbar-seekposition,
+      .#{$prefix}-seekbar-playbackposition {
+        margin: 0 $bar-inset;
       }
     }
   }

--- a/src/scss/components/seekbar/_volume-slider.scss
+++ b/src/scss/components/seekbar/_volume-slider.scss
@@ -2,15 +2,28 @@
 @import '../../mixins';
 @import 'seek-bar';
 
+// Defines the size of the playback position marker (the knob) of the volume slider
+$volume-slider-marker-dimension: calc($seekbar-bar-height * 3 - 0.25rem);
+
 .#{$prefix}-ui-volumeslider {
   @extend %ui-seekbar;
 
   min-width: 50px;
 
   .#{$prefix}-seekbar-playbackposition-marker {
-    @include seekbar-position-marker($seekbar-bar-height * 3 - 0.25rem);
+    @include seekbar-position-marker($volume-slider-marker-dimension);
     background-color: $color-highlight;
     border: 0;
+  }
+
+  &.#{$prefix}-vertical {
+    min-height: 50px;
+    min-width: 0;
+
+    .#{$prefix}-seekbar-playbackposition-marker {
+      // Re-center as the volume slider marker is smaller than the default seek bar marker
+      @include seekbar-position-marker-vertical($volume-slider-marker-dimension);
+    }
   }
 
   .#{$prefix}-seekbar {


### PR DESCRIPTION
## Description

The UI v4 stylesheet rewrite dropped the v3 vertical seek bar styles, so seek bars and volume sliders configured with `vertical: true` were laid out horizontally while the `SeekBar` component applied vertical transforms, resulting in a broken layout.

### Changes

- `_seek-bar.scss`: reintroduce a `&.bmpui-vertical` variant where the bar grows from the bottom
- `_mixins.scss`: new mixin so the knob centering formula is shared between the seek bar and volume slider styles
- `_control-bar.scss`: scope the fixed `8rem` inline volume slider width to horizontal sliders
- `_volume-control-button.scss`: keep `overflow: hidden` on the popup seek bar for horizontal sliders, but allow the knob (which is wider than the vertical bar) to be visible for vertical ones
- `_volume-slider.scss`: vertical sliders get `min-height: 50px` instead of `min-width: 50px`

### Test coverage

No automated CSS regression coverage exists in this repo; verified manually in Chrome.


#### Manual testing

Drop-in patch:
[test-ui-sample.txt](https://github.com/user-attachments/files/28620014/test-ui-sample.txt)


Select the vertical UI variant from UI selectBox in sample page.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry


[PUI-53]: https://bitmovin.atlassian.net/browse/PUI-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ