### PR TITLE
Disable CORS for local development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,6 +146,7 @@ module.exports = (env, { mode }) => {
       static: {
         directory: path.join(__dirname, OUTPUT_ROOT_DIRECTORY),
       },
+      allowedHosts: 'all',
       port: 'auto',
       hot: true,
       client: {


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->
Since the last webpack update, it's no longer possible to use the local dev server to test the UI, e.g., on iOS or Android. (ref: https://github.com/webpack/webpack-dev-server/security/advisories/GHSA-79cf-xcqc-c78w)

This PR explicitly allows all hosts in the webpack config to enable it again.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry **IMO not needed for a small config change**
