### PR TITLE
Add flag to treat closed captions like subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- New `SubtitleOverlayConfig.treatClosedCaptionsAsSubtitles` flag: by default, the player UI applies specific styling to Closed Captions. When enabled, this flag disables that behaviour and treats 608/708 captions like regular VTT subtitles from a styling perspective.
+- New `SubtitleOverlayConfig.enableCea608CaptionPositioning` flag (default `true`): by default, the player UI applies CEA-608 grid-based row/column positioning to Closed Captions. Setting this to `false` disables that positioning so that 608/708 captions are laid out like regular VTT subtitles, while CEA-608-specific text formatting remains independently controlled via `enableCea608CaptionFormatting`.
 
 ### Fixed
 
 - Seeking with the remote on the TV UI no longer gets stuck at the start or end of the seek bar: after scrubbing all the way to one edge, pressing the opposite direction now moves the playback position immediately instead of requiring multiple presses.
 - Settings panels with disabled automatic hiding no longer crash when component view mode changes are dispatched.
-
 
 ## [4.16.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- New `UIConfig.treatClosedCaptionsAsSubtitles` flag: when `true`, CEA-608 closed captions are rendered with the same CSS classes, styling, and DOM structure as regular VTT subtitles, with no CEA-608-specific grid positioning or formatting applied.
+- New `UIConfig.treatClosedCaptionsAsSubtitles` flag: by default, the player UI applies specific styling to Closed Captions. When enabled, this flag disables that behaviour and treats 608/708 captions like regular VTT subtitles from a styling perspective.
 
 ## [4.16.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- New `UIConfig.treatClosedCaptionsAsSubtitles` flag: when `true`, CEA-608 closed captions are rendered with the same CSS classes, styling, and DOM structure as regular VTT subtitles, with no CEA-608-specific grid positioning or formatting applied.
+
 ## [4.16.0] - 2026-06-18
 
 ### Added

--- a/spec/components/overlays/SubtitleOverlay.spec.ts
+++ b/spec/components/overlays/SubtitleOverlay.spec.ts
@@ -326,7 +326,9 @@ describe('SubtitleOverlay', () => {
       playerMock.eventEmitter.fireSubtitleCueEnterEvent({ position: { row: 5, column: 10 } });
     }
 
-    function setupOverlay(config: { enableCea608CaptionFormatting?: boolean } = {}): {
+    function setupOverlay(
+      config: { enableCea608CaptionFormatting?: boolean; enableCea608CaptionPositioning?: boolean } = {},
+    ): {
       overlay: SubtitleOverlay;
       overlayDom: jest.Mocked<DOM>;
     } {
@@ -452,6 +454,106 @@ describe('SubtitleOverlay', () => {
       const writtenStyles = cssCalls.map((call: unknown[]) => call[0]).filter(arg => arg && typeof arg === 'object');
       const hasLetterSpacingWrite = writtenStyles.some(style => 'letter-spacing' in (style as object));
       expect(hasLetterSpacingWrite).toBe(letterSpacingExpected);
+    });
+  });
+
+  describe('CEA-608 caption positioning config', () => {
+    let RealSubtitleOverlay: typeof SubtitleOverlay;
+    let RealSubtitleRegionContainer: typeof SubtitleRegionContainer;
+
+    beforeAll(() => {
+      jest.isolateModules(() => {
+        jest.unmock('../../../src/ts/components/Container');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const module = require('../../../src/ts/components/overlays/SubtitleOverlay');
+        RealSubtitleOverlay = module.SubtitleOverlay;
+        RealSubtitleRegionContainer = module.SubtitleRegionContainer;
+      });
+    });
+
+    beforeEach(() => {
+      playerMock = MockHelper.getPlayerMock() as jest.Mocked<TestingPlayerAPI>;
+      uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    function fireCea608CueEnter() {
+      playerMock.eventEmitter.fireSubtitleCueEnterEvent({ position: { row: 5, column: 10 } });
+    }
+
+    function setupPositioningOverlay(
+      config: { enableCea608CaptionFormatting?: boolean; enableCea608CaptionPositioning?: boolean } = {},
+    ): {
+      overlay: SubtitleOverlay;
+      overlayDom: jest.Mocked<DOM>;
+    } {
+      const overlay = new RealSubtitleOverlay(config);
+      overlay.configure(playerMock, uiInstanceManagerMock);
+      (overlay as any).ensureCea608GridSizeUpdated = (): void => undefined;
+      const overlayDom = MockHelper.generateDOMMock();
+      jest.spyOn(overlay, 'getDomElement').mockReturnValue(overlayDom);
+      jest.spyOn(RealSubtitleRegionContainer.prototype, 'getDomElement').mockReturnValue(MockHelper.generateDOMMock());
+      jest.spyOn(overlay, 'updateComponents').mockImplementation(() => undefined);
+      jest.spyOn(RealSubtitleRegionContainer.prototype, 'updateComponents').mockImplementation(() => undefined);
+      return { overlay, overlayDom };
+    }
+
+    it('does not apply the cea608 class when enableCea608CaptionPositioning is false', () => {
+      const { overlayDom } = setupPositioningOverlay({ enableCea608CaptionPositioning: false });
+
+      fireCea608CueEnter();
+
+      expect(overlayDom.addClass).not.toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
+    });
+
+    it('does not set left offset or regionStyle on the label when enableCea608CaptionPositioning is false', () => {
+      const { overlay } = setupPositioningOverlay({ enableCea608CaptionPositioning: false });
+      const addLabelSpy = jest.spyOn((overlay as any).subtitleContainerManager, 'addLabel');
+
+      fireCea608CueEnter();
+
+      const label = addLabelSpy.mock.calls[0][0] as SubtitleLabel;
+      const cssCalls = (label.getDomElement().css as jest.Mock).mock.calls;
+      expect(cssCalls).toHaveLength(0);
+      expect((label as any).regionStyle).toBeUndefined();
+    });
+
+    it('still applies cea608-formatting class when positioning is disabled and formatting is enabled', () => {
+      const { overlayDom } = setupPositioningOverlay({ enableCea608CaptionPositioning: false });
+
+      fireCea608CueEnter();
+
+      expect(overlayDom.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
+    });
+
+    it('does not apply cea608-formatting class when both positioning and formatting are disabled', () => {
+      const { overlayDom } = setupPositioningOverlay({
+        enableCea608CaptionPositioning: false,
+        enableCea608CaptionFormatting: false,
+      });
+
+      fireCea608CueEnter();
+
+      expect(overlayDom.addClass).not.toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
+    });
+
+    it('removes the cea608-formatting class on reset when positioning was disabled', () => {
+      const { overlayDom } = setupPositioningOverlay({ enableCea608CaptionPositioning: false });
+
+      fireCea608CueEnter();
+      playerMock.eventEmitter.fireSourceUnloadedEvent();
+
+      expect(overlayDom.removeClass).toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
+    });
+
+    it('adds both cea608 and cea608-formatting classes when positioning and formatting are both enabled (default)', () => {
+      const { overlayDom } = setupPositioningOverlay();
+
+      fireCea608CueEnter();
+
+      expect(overlayDom.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608$/));
+      expect(overlayDom.addClass).toHaveBeenCalledWith(expect.stringMatching(/cea608-formatting$/));
     });
   });
 

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -215,6 +215,15 @@ export interface UIConfig {
   localization?: LocalizationConfig;
 
   /**
+   * When `true`, closed captions (CEA-608) are treated identically to regular subtitles: no CEA-608-specific
+   * CSS classes (`cea608`, `cea608-formatting`), no grid-based row positioning, and no monospaced/uppercase
+   * formatting are applied. The captions render with the same styles and DOM structure as VTT subtitles.
+   *
+   * Default: `false`
+   */
+  treatClosedCaptionsAsSubtitles?: boolean;
+
+  /**
    * The rendered player height threshold in pixels at or below which small-player adjustments are applied to
    * CEA-608 captions:
    *

--- a/src/ts/UIConfig.ts
+++ b/src/ts/UIConfig.ts
@@ -215,15 +215,6 @@ export interface UIConfig {
   localization?: LocalizationConfig;
 
   /**
-   * When `true`, closed captions (CEA-608) are treated identically to regular subtitles: no CEA-608-specific
-   * CSS classes (`cea608`, `cea608-formatting`), no grid-based row positioning, and no monospaced/uppercase
-   * formatting are applied. The captions render with the same styles and DOM structure as VTT subtitles.
-   *
-   * Default: `false`
-   */
-  treatClosedCaptionsAsSubtitles?: boolean;
-
-  /**
    * The rendered player height threshold in pixels at or below which small-player adjustments are applied to
    * CEA-608 captions:
    *

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -28,13 +28,13 @@ export interface SubtitleOverlayConfig extends ContainerConfig {
    */
   enableCea608CaptionFormatting?: boolean;
   /**
-   * When `true`, closed captions (CEA-608/708) are treated identically to regular subtitles: no CEA-608-specific
-   * CSS classes (`cea608`, `cea608-formatting`), no grid-based row positioning, and no monospaced/uppercase
-   * formatting are applied. The captions render with the same styles and DOM structure as VTT subtitles.
+   * Controls whether the CEA-608 grid-based row/column positioning is used or not.
+   * The formatting (monospaced font, uppercase transform, character letter-spacing) is preserved
+   * and still controlled independently via {@link enableCea608CaptionFormatting}.
    *
-   * Default: `false`
+   * Defaults to `true` (CEA-608 grid is used for positioning, matching historical behavior).
    */
-  treatClosedCaptionsAsSubtitles?: boolean;
+  enableCea608CaptionPositioning?: boolean;
 }
 
 /**
@@ -64,7 +64,6 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
   private cea608FontSizeFactor = 1;
   private ensureCea608GridSizeUpdated: () => void;
   private cea608SmallPlayerHeightThreshold = SubtitleOverlay.DEFAULT_CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD;
-  private treatClosedCaptionsAsSubtitles = false;
 
   constructor(config: SubtitleOverlayConfig = {}) {
     super(config);
@@ -77,6 +76,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
       {
         cssClass: 'ui-subtitle-overlay',
         enableCea608CaptionFormatting: true,
+        enableCea608CaptionPositioning: true,
       },
       this.config,
     );
@@ -89,10 +89,6 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
 
     if (uiConfig.cea608SmallPlayerHeightThreshold !== undefined) {
       this.cea608SmallPlayerHeightThreshold = uiConfig.cea608SmallPlayerHeightThreshold;
-    }
-
-    if (this.config.treatClosedCaptionsAsSubtitles) {
-      this.treatClosedCaptionsAsSubtitles = true;
     }
 
     const subtitleManager = new ActiveSubtitleManager();
@@ -270,7 +266,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
     // We need to keep track of the original row position in case of recalculation.
     const originalRowNumber = event.position?.row || 0;
 
-    if (isCea608SubtitleCue(event) && !this.treatClosedCaptionsAsSubtitles) {
+    if (isCea608SubtitleCue(event) && this.isCea608PositioningEnabled()) {
       event.position.row = event.position.row || 0;
       event.position.column = event.position.column || 0;
 
@@ -322,6 +318,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
     let windowMargin: number;
     /** Flag telling if the CEA-608 rendering mode is currently enabled */
     this.cea608Enabled = false;
+    let cea608FormattingClassAdded = false;
     /** Track last known grid params to avoid unnecessary recalculations */
     let lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
 
@@ -477,36 +474,40 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
     });
 
     this.preprocessLabelEventCallback.subscribe((event: SubtitleCueEvent, label: SubtitleLabel) => {
-      if (!isCea608SubtitleCue(event) || this.treatClosedCaptionsAsSubtitles) {
-        // Skip all non-CEA608 cues, and skip CEA-608 cues when they should be treated as regular subtitles
+      if (!isCea608SubtitleCue(event)) {
         return;
       }
 
-      if (!this.cea608Enabled) {
-        this.cea608Enabled = true;
-        this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
-        if (this.isCea608FormattingEnabled()) {
-          this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608_FORMATTING));
+      if (this.isCea608PositioningEnabled()) {
+        if (!this.cea608Enabled) {
+          this.cea608Enabled = true;
+          this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608));
+          if (this.isCea608FormattingEnabled()) {
+            this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608_FORMATTING));
+          }
         }
-      }
 
-      let leftOffset = event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET + '%';
-      if (leftOffset === '0%') {
-        // ensure that a little of the window still shows for better readability
-        leftOffset = SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET;
-      }
+        let leftOffset = event.position.column * SubtitleOverlay.CEA608_COLUMN_OFFSET + '%';
+        if (leftOffset === '0%') {
+          // ensure that a little of the window still shows for better readability
+          leftOffset = SubtitleOverlay.DEFAULT_CAPTION_LEFT_OFFSET;
+        }
 
-      const labelCss: Record<string, string> = {
-        left: leftOffset,
-        'font-size': `${fontSize}px`,
-        'line-height': `${rowHeight - windowMargin}px`,
-      };
-      if (this.isCea608FormattingEnabled()) {
-        labelCss['letter-spacing'] = `${fontLetterSpacing}px`;
-      }
-      label.getDomElement().css(labelCss);
+        const labelCss: Record<string, string> = {
+          left: leftOffset,
+          'font-size': `${fontSize}px`,
+          'line-height': `${rowHeight - windowMargin}px`,
+        };
+        if (this.isCea608FormattingEnabled()) {
+          labelCss['letter-spacing'] = `${fontLetterSpacing}px`;
+        }
+        label.getDomElement().css(labelCss);
 
-      label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
+        label.regionStyle = `margin: ${windowMargin / 2}px; height: ${rowHeight}px`;
+      } else if (this.isCea608FormattingEnabled() && !cea608FormattingClassAdded) {
+        cea608FormattingClassAdded = true;
+        this.getDomElement().addClass(this.prefixCss(SubtitleOverlay.CLASS_CEA_608_FORMATTING));
+      }
     });
 
     const reset = () => {
@@ -517,6 +518,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
         lastCeaGridRecalculation = { overlayWidth: 0, overlayHeight: 0, fontSizeFactor: 0 };
       }
       this.cea608Enabled = false;
+      cea608FormattingClassAdded = false;
     };
 
     player.on(player.exports.PlayerEvent.CueExit, () => {
@@ -551,6 +553,10 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
 
   private isCea608FormattingEnabled(): boolean {
     return this.config?.enableCea608CaptionFormatting !== false;
+  }
+
+  private isCea608PositioningEnabled(): boolean {
+    return this.config?.enableCea608CaptionPositioning !== false;
   }
 }
 

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -21,16 +21,21 @@ interface SubtitleCropDetectionResult {
 export interface SubtitleOverlayConfig extends ContainerConfig {
   /**
    * Controls whether CEA-608 caption-specific text formatting (monospaced font, uppercase transform,
-   * and character letter-spacing) is applied. The CEA-608 grid-based row/column positioning is
-   * always preserved so captions still render at their authored on-screen positions.
+   * and character letter-spacing) is applied. Grid-based row/column positioning is controlled
+   * independently via {@link enableCea608CaptionPositioning}.
+   *
+   * Note: character letter-spacing is only applied when positioning is also enabled, as it depends
+   * on the grid size calculations.
    *
    * Defaults to `true` (CEA-608 text formatting is applied, matching historical behavior).
    */
   enableCea608CaptionFormatting?: boolean;
   /**
    * Controls whether the CEA-608 grid-based row/column positioning is used or not.
-   * The formatting (monospaced font, uppercase transform, character letter-spacing) is preserved
-   * and still controlled independently via {@link enableCea608CaptionFormatting}.
+   * When disabled, captions fall back to the default subtitle layout. Text formatting
+   * (monospaced font, uppercase transform) is still controlled independently via
+   * {@link enableCea608CaptionFormatting}, though character letter-spacing will not be applied
+   * as it depends on the grid size calculations.
    *
    * Defaults to `true` (CEA-608 grid is used for positioning, matching historical behavior).
    */

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -56,6 +56,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
   private cea608FontSizeFactor = 1;
   private ensureCea608GridSizeUpdated: () => void;
   private cea608SmallPlayerHeightThreshold = SubtitleOverlay.DEFAULT_CEA608_SMALL_PLAYER_HEIGHT_THRESHOLD;
+  private treatClosedCaptionsAsSubtitles = false;
 
   constructor(config: SubtitleOverlayConfig = {}) {
     super(config);
@@ -80,6 +81,10 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
 
     if (uiConfig.cea608SmallPlayerHeightThreshold !== undefined) {
       this.cea608SmallPlayerHeightThreshold = uiConfig.cea608SmallPlayerHeightThreshold;
+    }
+
+    if (uiConfig.treatClosedCaptionsAsSubtitles) {
+      this.treatClosedCaptionsAsSubtitles = true;
     }
 
     const subtitleManager = new ActiveSubtitleManager();
@@ -257,7 +262,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
     // We need to keep track of the original row position in case of recalculation.
     const originalRowNumber = event.position?.row || 0;
 
-    if (isCea608SubtitleCue(event)) {
+    if (isCea608SubtitleCue(event) && !this.treatClosedCaptionsAsSubtitles) {
       event.position.row = event.position.row || 0;
       event.position.column = event.position.column || 0;
 
@@ -464,8 +469,8 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
     });
 
     this.preprocessLabelEventCallback.subscribe((event: SubtitleCueEvent, label: SubtitleLabel) => {
-      if (!isCea608SubtitleCue(event)) {
-        // Skip all non-CEA608 cues
+      if (!isCea608SubtitleCue(event) || this.treatClosedCaptionsAsSubtitles) {
+        // Skip all non-CEA608 cues, and skip CEA-608 cues when they should be treated as regular subtitles
         return;
       }
 

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -271,11 +271,13 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
     // We need to keep track of the original row position in case of recalculation.
     const originalRowNumber = event.position?.row || 0;
 
-    if (isCea608SubtitleCue(event) && this.isCea608PositioningEnabled()) {
+    if (isCea608SubtitleCue(event)) {
       event.position.row = event.position.row || 0;
       event.position.column = event.position.column || 0;
 
-      region = region || `cea608-row-${event.position.row}`;
+      if (this.isCea608PositioningEnabled()) {
+        region = region || `cea608-row-${event.position.row}`;
+      }
     }
 
     const label = new SubtitleLabel({

--- a/src/ts/components/overlays/SubtitleOverlay.ts
+++ b/src/ts/components/overlays/SubtitleOverlay.ts
@@ -27,6 +27,14 @@ export interface SubtitleOverlayConfig extends ContainerConfig {
    * Defaults to `true` (CEA-608 text formatting is applied, matching historical behavior).
    */
   enableCea608CaptionFormatting?: boolean;
+  /**
+   * When `true`, closed captions (CEA-608/708) are treated identically to regular subtitles: no CEA-608-specific
+   * CSS classes (`cea608`, `cea608-formatting`), no grid-based row positioning, and no monospaced/uppercase
+   * formatting are applied. The captions render with the same styles and DOM structure as VTT subtitles.
+   *
+   * Default: `false`
+   */
+  treatClosedCaptionsAsSubtitles?: boolean;
 }
 
 /**
@@ -83,7 +91,7 @@ export class SubtitleOverlay extends Container<SubtitleOverlayConfig> {
       this.cea608SmallPlayerHeightThreshold = uiConfig.cea608SmallPlayerHeightThreshold;
     }
 
-    if (uiConfig.treatClosedCaptionsAsSubtitles) {
+    if (this.config.treatClosedCaptionsAsSubtitles) {
       this.treatClosedCaptionsAsSubtitles = true;
     }
 


### PR DESCRIPTION

## Description
By default, the player UI applies a specific styling to Closed Captions.

I'm proposing a flag that disables this behaviour and treats 608/708 captions like regular subtitles from a styling perspective.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
