### PR TITLE
fix(spatialnavigation): clamp TV seek bar cursor to its bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Seeking with the remote on the TV UI no longer gets stuck at the start or end of the seek bar: after scrubbing all the way to one edge, pressing the opposite direction now moves the playback position immediately instead of requiring multiple presses.
+
 ## [4.16.0] - 2026-06-18
 
 ### Added

--- a/spec/spatialnavigation/SeekBarHandler.spec.ts
+++ b/spec/spatialnavigation/SeekBarHandler.spec.ts
@@ -114,6 +114,54 @@ describe('SeekBarHandler', () => {
     });
   });
 
+  describe('cursor position clamping', () => {
+    let preventDefaultSpy: jest.Mock;
+    let targetComponentMock: AnyComponent;
+
+    beforeEach(() => {
+      preventDefaultSpy = jest.fn();
+      targetComponentMock = createComponentMock();
+      jest.spyOn(toHtmlElementModule, 'toHtmlElement').mockReturnValue(seekBarWrapperMock);
+    });
+
+    it('should not move the cursor position beyond the end of the seek bar', () => {
+      for (let i = 0; i < 50; i++) {
+        rootNavigationGroupMock.onNavigation!(Direction.RIGHT, targetComponentMock, preventDefaultSpy);
+      }
+
+      const positions = clientXPositionsFromMouseEventMock(seekBarMock.dispatchEvent);
+
+      // wrapper rect is { x: 0, width: 100 }, so the cursor must never exceed the right edge (100)
+      expect(Math.max(...positions)).toBeLessThanOrEqual(100);
+    });
+
+    it('should not move the cursor position before the start of the seek bar', () => {
+      for (let i = 0; i < 50; i++) {
+        rootNavigationGroupMock.onNavigation!(Direction.LEFT, targetComponentMock, preventDefaultSpy);
+      }
+
+      const positions = clientXPositionsFromMouseEventMock(seekBarMock.dispatchEvent);
+
+      // the cursor must never move before the left edge (0)
+      expect(Math.min(...positions)).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should immediately move away from the end when reversing direction (ZD #32258)', () => {
+      for (let i = 0; i < 50; i++) {
+        rootNavigationGroupMock.onNavigation!(Direction.RIGHT, targetComponentMock, preventDefaultSpy);
+      }
+      seekBarMock.dispatchEvent.mockClear();
+
+      rootNavigationGroupMock.onNavigation!(Direction.LEFT, targetComponentMock, preventDefaultSpy);
+
+      const [clientXAfterReverse] = clientXPositionsFromMouseEventMock(seekBarMock.dispatchEvent);
+
+      // Because the cursor was clamped at the end instead of overshooting, a single left navigation
+      // must already move it back inside the seek bar rather than first unwinding the overshoot.
+      expect(clientXAfterReverse).toBeLessThan(100);
+    });
+  });
+
   describe('onAction', () => {
     let preventDefaultSpy: jest.Mock;
     let targetComponentMock: AnyComponent;
@@ -230,6 +278,10 @@ function getPlaybackPositionMarker(seekBarWrapperMock: jest.Mocked<HTMLElement>)
 
 function scrubbingPositionsFromMouseEventMock(spy: jest.MockInstance<any, any>): number[] {
   return spy.mock.calls.map(([event]) => Math.abs((event as MouseEvent).clientX));
+}
+
+function clientXPositionsFromMouseEventMock(spy: jest.MockInstance<any, any>): number[] {
+  return spy.mock.calls.map(([event]) => (event as MouseEvent).clientX);
 }
 
 function getScrubbingSpeeds(scrubbingPositions: number[]): number[] {

--- a/src/ts/spatialnavigation/SeekBarHandler.ts
+++ b/src/ts/spatialnavigation/SeekBarHandler.ts
@@ -49,7 +49,17 @@ export class SeekBarHandler {
   }
 
   private updateCursorPosition(direction: Direction, seekBarWrapper: HTMLElement): void {
-    this.cursorPosition.x += this.getIncrement(direction, seekBarWrapper);
+    const increment = this.getIncrement(direction, seekBarWrapper);
+    // Use getBoundingRectFromElement (not getBoundingClientRect directly) so that `x` is also
+    // populated on older TV browsers that only return `left`/`top` - same as initializeCursorPosition.
+    const rect = getBoundingRectFromElement(seekBarWrapper);
+    const minX = rect.x;
+    const maxX = rect.x + rect.width;
+
+    // Clamp the cursor position to the seek bar bounds. Without this, holding the remote in one
+    // direction past the start/end keeps moving the (invisible) cursor beyond the seek bar, and the
+    // user then has to "unwind" all that overshoot before scrubbing back the other way has any effect.
+    this.cursorPosition.x = Math.min(Math.max(this.cursorPosition.x + increment, minX), maxX);
   }
 
   private initializeCursorPosition(seekBarWrapper: HTMLElement): void {

--- a/src/ts/spatialnavigation/SeekBarHandler.ts
+++ b/src/ts/spatialnavigation/SeekBarHandler.ts
@@ -34,10 +34,9 @@ export class SeekBarHandler {
     );
   }
 
-  private getIncrement(direction: Direction, seekBarWrapper: HTMLElement): number {
+  private getIncrement(direction: Direction, seekBarWidth: number): number {
     this.updateScrubSpeedPercentage();
 
-    const seekBarWidth = seekBarWrapper.getBoundingClientRect().width;
     const increment = seekBarWidth * this.scrubSpeedPercentage;
 
     return direction === Direction.RIGHT ? increment : -increment;
@@ -49,10 +48,12 @@ export class SeekBarHandler {
   }
 
   private updateCursorPosition(direction: Direction, seekBarWrapper: HTMLElement): void {
-    const increment = this.getIncrement(direction, seekBarWrapper);
+    // Read the layout once and reuse it for both the increment and the clamp bounds, to avoid two
+    // getBoundingClientRect() reflows per navigation while scrubbing on low-powered TV devices.
     // Use getBoundingRectFromElement (not getBoundingClientRect directly) so that `x` is also
     // populated on older TV browsers that only return `left`/`top` - same as initializeCursorPosition.
     const rect = getBoundingRectFromElement(seekBarWrapper);
+    const increment = this.getIncrement(direction, rect.width);
     const minX = rect.x;
     const maxX = rect.x + rect.width;
 


### PR DESCRIPTION
## Summary

Fixes the TV UI seek bar "hanging" at its start/end when scrubbing with a remote.

`SeekBarHandler.updateCursorPosition()` accumulated `cursorPosition.x` unconditionally on every navigation:

```ts
this.cursorPosition.x += this.getIncrement(direction, seekBarWrapper);
```

The `SeekBar` only *visually* clamps the dispatched position (`getHorizontalOffset` → `sanitizeOffset` → `[0, 1]`), so holding the remote in one direction past an edge keeps pushing the (invisible) cursor far beyond the seek bar with no upper bound. Reversing direction then does nothing visible until all that overshoot has been "unwound" — to the user it looks like the seek bar is stuck.

The fix clamps the cursor to the seek bar bounds so reversing direction at either edge takes effect immediately:

```ts
const rect = getBoundingRectFromElement(seekBarWrapper);
const minX = rect.x;
const maxX = rect.x + rect.width;
this.cursorPosition.x = Math.min(Math.max(this.cursorPosition.x + increment, minX), maxX);
```

Notes for review:
- Uses `getBoundingRectFromElement` rather than `getBoundingClientRect()` directly, matching `initializeCursorPosition`, so `x` is populated on older TV browsers that only return `left`/`top`.
- `getIncrement()` is still called exactly once (it has the scrub-speed acceleration side effect).
- Clamps to the seek bar **wrapper** rect — the same reference frame `getIncrement` and `initializeCursorPosition` already use.

Reported by a customer who pinpointed the exact method (via support).

## Test plan

- [x] Build the TV UI (`UIFactory.buildTvUI`), focus the seek bar, **hold Right** to the end, then press **Left** — playback position moves back immediately (previously needed many presses). Same at the start with hold-Left → Right.
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` green (551/551). Added 3 cases to `SeekBarHandler.spec.ts` covering clamp-at-end, clamp-at-start, and immediate reverse-direction; verified each fails on the unpatched source.

## Known limitations / open questions for reviewers

- While the cursor is pinned at an edge, `getIncrement()` keeps accelerating `scrubSpeedPercentage`, so an *immediate* reverse can make the first step large. It auto-resets after `ScrubSpeedClearInterval` (100 ms) idle. Happy to reset scrub speed on clamp if preferred.
- Clamps to the wrapper, not the inner seek bar element. If there's horizontal padding between them, the cursor can still travel a few px past the inner bar before `sanitizeOffset` pins it — negligible on the current TV skin. Can switch to `getSeekBar(seekBarWrapper)` bounds if you'd rather be exact.
