### PR TITLE
Fix settings panel crash when auto-hide is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] - 2026-06-19
+## [Unreleased]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.16.1] - 2026-06-19
+
+### Fixed
+
+- Settings panels with disabled automatic hiding no longer crash when component view mode changes are dispatched.
+
 ## [4.16.0] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.16.1] - 2026-06-19
+## [Unreleased] - 2026-06-19
 
 ### Fixed
 

--- a/spec/components/settings/SettingsPanel.spec.ts
+++ b/spec/components/settings/SettingsPanel.spec.ts
@@ -122,18 +122,6 @@ describe('SettingsPanel', () => {
       expect(settingsPanel.getActivePage()).toBe(secondPage);
     });
 
-    it('does not crash on component view mode changes when automatic hiding is disabled', () => {
-      const viewModeChanged = new EventDispatcher<Component<ComponentConfig>, ViewModeChangedEventArgs>();
-      Object.defineProperty(uiInstanceManagerMock, 'onComponentViewModeChanged', { value: viewModeChanged });
-      settingsPanel = new SettingsPanel({ components: [rootPage], hideDelay: -1 });
-      settingsPanel.configure(playerMock, uiInstanceManagerMock);
-
-      expect(() => {
-        viewModeChanged.dispatch(settingsPanel as unknown as Component<ComponentConfig>, { mode: ViewMode.Persistent });
-        viewModeChanged.dispatch(settingsPanel as unknown as Component<ComponentConfig>, { mode: ViewMode.Temporary });
-      }).not.toThrow();
-    });
-
     describe('onInactiveEvent', () => {
       it('fires for root page when we navigate to second page', () => {
         const spy = jest.fn();
@@ -209,6 +197,22 @@ describe('SettingsPanel', () => {
     });
 
     describe('onComponentViewModeChanged', () => {
+      it('ignores component view mode changes when automatic hiding is disabled', () => {
+        const viewModeChanged = new EventDispatcher<Component<ComponentConfig>, ViewModeChangedEventArgs>();
+        Object.defineProperty(uiInstanceManagerMock, 'onComponentViewModeChanged', { value: viewModeChanged });
+        settingsPanel = new SettingsPanel({ components: [rootPage], hideDelay: -1 });
+        settingsPanel.configure(playerMock, uiInstanceManagerMock);
+
+        expect(() => {
+          viewModeChanged.dispatch(settingsPanel as unknown as Component<ComponentConfig>, {
+            mode: ViewMode.Persistent,
+          });
+          viewModeChanged.dispatch(settingsPanel as unknown as Component<ComponentConfig>, {
+            mode: ViewMode.Temporary,
+          });
+        }).not.toThrow();
+      });
+
       it('should suspend the hide timeout when a component enters the persistent view mode', () => {
         const suspendTimeoutSpy = jest.spyOn(settingsPanel['hideTimeout'], 'suspend');
 

--- a/spec/components/settings/SettingsPanel.spec.ts
+++ b/spec/components/settings/SettingsPanel.spec.ts
@@ -122,6 +122,18 @@ describe('SettingsPanel', () => {
       expect(settingsPanel.getActivePage()).toBe(secondPage);
     });
 
+    it('does not crash on component view mode changes when automatic hiding is disabled', () => {
+      const viewModeChanged = new EventDispatcher<Component<ComponentConfig>, ViewModeChangedEventArgs>();
+      Object.defineProperty(uiInstanceManagerMock, 'onComponentViewModeChanged', { value: viewModeChanged });
+      settingsPanel = new SettingsPanel({ components: [rootPage], hideDelay: -1 });
+      settingsPanel.configure(playerMock, uiInstanceManagerMock);
+
+      expect(() => {
+        viewModeChanged.dispatch(settingsPanel as unknown as Component<ComponentConfig>, { mode: ViewMode.Persistent });
+        viewModeChanged.dispatch(settingsPanel as unknown as Component<ComponentConfig>, { mode: ViewMode.Temporary });
+      }).not.toThrow();
+    });
+
     describe('onInactiveEvent', () => {
       it('fires for root page when we navigate to second page', () => {
         const spy = jest.fn();

--- a/src/ts/components/settings/SettingsPanel.ts
+++ b/src/ts/components/settings/SettingsPanel.ts
@@ -386,15 +386,11 @@ export class SettingsPanel<Config extends SettingsPanelConfig> extends Container
   }
 
   protected suspendHideTimeout() {
-    if (this.hideTimeout) {
-      this.hideTimeout.suspend();
-    }
+    this.hideTimeout?.suspend();
   }
 
   protected resumeHideTimeout() {
-    if (this.hideTimeout) {
-      this.hideTimeout.resume(true);
-    }
+    this.hideTimeout?.resume(true);
   }
 
   private updateActivePageClass(): void {

--- a/src/ts/components/settings/SettingsPanel.ts
+++ b/src/ts/components/settings/SettingsPanel.ts
@@ -107,7 +107,7 @@ export class SettingsPanel<Config extends SettingsPanelConfig> extends Container
     onActivePageChanged: new EventDispatcher<SettingsPanel<SettingsPanelConfig>, NoArgs>(),
   };
 
-  private hideTimeout: Timeout;
+  private hideTimeout?: Timeout;
 
   constructor(config: Config) {
     super(config);

--- a/src/ts/components/settings/SettingsPanel.ts
+++ b/src/ts/components/settings/SettingsPanel.ts
@@ -386,11 +386,15 @@ export class SettingsPanel<Config extends SettingsPanelConfig> extends Container
   }
 
   protected suspendHideTimeout() {
-    this.hideTimeout.suspend();
+    if (this.hideTimeout) {
+      this.hideTimeout.suspend();
+    }
   }
 
   protected resumeHideTimeout() {
-    this.hideTimeout.resume(true);
+    if (this.hideTimeout) {
+      this.hideTimeout.resume(true);
+    }
   }
 
   private updateActivePageClass(): void {


### PR DESCRIPTION
## Description

Fixes settings panel timeout handling when automatic hiding is disabled with `hideDelay: -1`.

The panel now ignores hide timeout suspend and resume requests when no timeout exists, preventing crashes from component view mode changes.

## Verification

- `npm test -- spec/components/settings/SettingsPanel.spec.ts --runInBand`
- `npm run lint-ts`

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
