### PR TITLE
Fix component constructor initialization order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Seeking with the remote on the TV UI no longer gets stuck at the start or end of the seek bar: after scrubbing all the way to one edge, pressing the opposite direction now moves the playback position immediately instead of requiring multiple presses.
 - Settings panels with disabled automatic hiding no longer crash when component view mode changes are dispatched.
+- Settings panel items no longer render an empty label when no label config is provided.
 
 ## [4.16.0] - 2026-06-18
 

--- a/spec/components/settings/SettingsPanel.spec.ts
+++ b/spec/components/settings/SettingsPanel.spec.ts
@@ -264,5 +264,12 @@ describe('SettingsPanel', () => {
     it('does not create a label for an omitted label config', () => {
       expect(new SettingsPanelItem({}).getComponents()).toHaveLength(0);
     });
+
+    it('creates a label for a defined label config', () => {
+      const components = new SettingsPanelItem({ label: 'Quality' }).getComponents();
+
+      expect(components).toHaveLength(1);
+      expect(components[0]).toBeInstanceOf(Label);
+    });
   });
 });

--- a/spec/components/settings/SettingsPanel.spec.ts
+++ b/spec/components/settings/SettingsPanel.spec.ts
@@ -259,4 +259,10 @@ describe('SettingsPanel', () => {
       });
     });
   });
+
+  describe('items', () => {
+    it('does not create a label for an omitted label config', () => {
+      expect(new SettingsPanelItem({}).getComponents()).toHaveLength(0);
+    });
+  });
 });

--- a/src/ts/components/contextmenu/PlayerContextMenu.ts
+++ b/src/ts/components/contextmenu/PlayerContextMenu.ts
@@ -29,58 +29,73 @@ export interface PlayerContextMenuConfig extends ContextMenuConfig {
  */
 export class PlayerContextMenu extends ContextMenu<PlayerContextMenuConfig> {
   constructor(config: PlayerContextMenuConfig) {
-    const actionItems = [
-      new PlayerInsightsContextMenuItem({
-        playerInsightsPanel: config.playerInsightsPanel,
-      }),
-      ...(config.components ?? []),
-    ];
+    super(config);
 
-    super({
-      ...config,
-      cssClasses: ['ui-player-context-menu', ...(config.cssClasses ?? [])],
-      components: [
-        new SettingsPanelPage({
-          components: [new PlayerInfoContextMenuItem(), new SettingsPanelSeparator(), ...actionItems],
-        }),
-      ],
-    });
+    this.config = this.mergeConfig(
+      config,
+      {
+        cssClasses: ['ui-player-context-menu', ...(config.cssClasses ?? [])],
+      },
+      this.config,
+    );
+
+    this.addComponent(
+      new SettingsPanelPage({
+        components: [
+          new PlayerInfoContextMenuItem(),
+          new SettingsPanelSeparator(),
+          new PlayerInsightsContextMenuItem({
+            playerInsightsPanel: config.playerInsightsPanel,
+          }),
+        ],
+      }),
+    );
   }
 }
 
 class PlayerInfoContextMenuItem extends SettingsPanelItem<SettingsPanelItemConfig> {
   private readonly playerVersionLabel: Label<LabelConfig>;
 
-  constructor() {
+  constructor(config: SettingsPanelItemConfig = {}) {
+    super(config);
+
     const playerVersionLabel = new Label<LabelConfig>({
       text: 'Player: -',
       cssClasses: ['ui-player-context-menu-info'],
     });
 
-    super({
-      label: null,
-      components: [
-        new Label<LabelConfig>({
-          text: i18n.getLocalizer('contextMenu.title'),
-          cssClasses: ['ui-player-context-menu-header'],
-        }),
-        new Label<LabelConfig>({
-          text: i18n.getLocalizer('contextMenu.subtitle'),
-          cssClasses: ['ui-player-context-menu-subtitle'],
-        }),
-        playerVersionLabel,
-        new Label<LabelConfig>({
-          text: `UI: ${UI_VERSION}`,
-          cssClasses: ['ui-player-context-menu-info'],
-        }),
-      ],
-      cssClasses: ['ui-player-context-menu-info-item'],
-      isSetting: false,
-      role: 'group',
-      tabIndex: -1,
-    });
+    this.config = this.mergeConfig(
+      config,
+      {
+        label: null,
+        cssClasses: ['ui-player-context-menu-info-item'],
+        isSetting: false,
+        role: 'group',
+        tabIndex: -1,
+      },
+      this.config,
+    );
 
     this.playerVersionLabel = playerVersionLabel;
+    this.addComponent(
+      new Label<LabelConfig>({
+        text: i18n.getLocalizer('contextMenu.title'),
+        cssClasses: ['ui-player-context-menu-header'],
+      }),
+    );
+    this.addComponent(
+      new Label<LabelConfig>({
+        text: i18n.getLocalizer('contextMenu.subtitle'),
+        cssClasses: ['ui-player-context-menu-subtitle'],
+      }),
+    );
+    this.addComponent(playerVersionLabel);
+    this.addComponent(
+      new Label<LabelConfig>({
+        text: `UI: ${UI_VERSION}`,
+        cssClasses: ['ui-player-context-menu-info'],
+      }),
+    );
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/contextmenu/PlayerContextMenu.ts
+++ b/src/ts/components/contextmenu/PlayerContextMenu.ts
@@ -34,7 +34,7 @@ export class PlayerContextMenu extends ContextMenu<PlayerContextMenuConfig> {
     this.config = this.mergeConfig(
       config,
       {
-        cssClasses: ['ui-player-context-menu', ...(config.cssClasses ?? [])],
+        cssClasses: ['ui-player-context-menu'],
       },
       this.config,
     );

--- a/src/ts/components/panels/player-insights/PlayerInsightsContextMenuItem.ts
+++ b/src/ts/components/panels/player-insights/PlayerInsightsContextMenuItem.ts
@@ -30,19 +30,24 @@ export class PlayerInsightsContextMenuItem extends InteractiveContextMenuItem<Pl
   private readonly playerInsightsPanel: PlayerInsightsPanel;
 
   constructor(config: PlayerInsightsContextMenuItemConfig) {
+    super(config);
+
     const itemLabel = new Label<LabelConfig>({
       text: i18n.getLocalizer('playerInsights.show'),
     });
 
-    super({
-      ...config,
-      label: itemLabel,
-      ariaLabel: i18n.getLocalizer('playerInsights.show'),
-      closeContextMenuOnAction: true,
-    });
+    this.config = this.mergeConfig(
+      config,
+      {
+        ariaLabel: i18n.getLocalizer('playerInsights.show'),
+        closeContextMenuOnAction: true,
+      },
+      this.config,
+    );
 
     this.itemLabel = itemLabel;
     this.playerInsightsPanel = config.playerInsightsPanel;
+    this.addComponent(itemLabel);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/panels/player-insights/PlayerInsightsPanel.ts
+++ b/src/ts/components/panels/player-insights/PlayerInsightsPanel.ts
@@ -30,6 +30,8 @@ export class PlayerInsightsPanel extends SettingsPanel<PlayerInsightsPanelConfig
   private readonly insightItems: PlayerInsightsPanelItem[];
 
   constructor(config: PlayerInsightsPanelConfig = {}) {
+    super(config);
+
     const insightsProvider = new PlayerInsightsProvider();
     const insightItems = insightsProvider.getInsights().map(
       insight =>
@@ -39,31 +41,26 @@ export class PlayerInsightsPanel extends SettingsPanel<PlayerInsightsPanelConfig
     );
     const titleItem = new PlayerInsightsPanelTitleItem();
     const rootPage = new SettingsPanelPage({
-      components: [titleItem, ...insightItems, ...(config.components ?? [])],
+      components: [titleItem, ...insightItems],
     });
-    const panelConfig = {
-      ...config,
-      cssClasses: ['ui-player-insights-panel', ...(config.cssClasses ?? [])],
-      components: [rootPage],
-    };
-
-    super(panelConfig);
 
     titleItem.setTarget(this);
     this.insightsProvider = insightsProvider;
     this.insightItems = insightItems;
 
     this.config = this.mergeConfig(
-      panelConfig,
+      config,
       {
+        cssClasses: ['ui-player-insights-panel'],
         hidden: true,
         hideDelay: -1,
         hideOnControlsHide: false,
         hideOnOtherSettingsPanelOpening: false,
         refreshIntervalMs: 1000,
-      } as PlayerInsightsPanelConfig,
+      },
       this.config,
     );
+    this.addComponent(rootPage);
   }
 
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {

--- a/src/ts/components/panels/player-insights/PlayerInsightsPanelItem.ts
+++ b/src/ts/components/panels/player-insights/PlayerInsightsPanelItem.ts
@@ -10,6 +10,8 @@ export class PlayerInsightsPanelItem extends SettingsPanelItem<PlayerInsightsPan
   private readonly trailingLabel: Label<LabelConfig>;
 
   constructor(config: PlayerInsightsPanelItemConfig) {
+    super(config);
+
     const leadingLabel = new Label<LabelConfig>({
       text: config.leadingLabel,
       cssClasses: ['ui-player-insights-panel-item-leading-label'],
@@ -19,17 +21,20 @@ export class PlayerInsightsPanelItem extends SettingsPanelItem<PlayerInsightsPan
       cssClasses: ['ui-player-insights-panel-item-trailing-label'],
     });
 
-    super({
-      ...config,
-      label: null,
-      components: [leadingLabel, trailingLabel, ...(config.components ?? [])],
-      cssClasses: ['ui-player-insights-panel-item', ...(config.cssClasses ?? [])],
-      isSetting: false,
-      role: 'group',
-      tabIndex: -1,
-    });
+    this.config = this.mergeConfig(
+      config,
+      {
+        cssClasses: ['ui-player-insights-panel-item'],
+        isSetting: false,
+        role: 'group',
+        tabIndex: -1,
+      },
+      this.config,
+    );
 
     this.trailingLabel = trailingLabel;
+    this.addComponent(leadingLabel);
+    this.addComponent(trailingLabel);
   }
 
   setTrailingLabel(text: LocalizableText): void {

--- a/src/ts/components/panels/player-insights/PlayerInsightsPanelTitleItem.ts
+++ b/src/ts/components/panels/player-insights/PlayerInsightsPanelTitleItem.ts
@@ -13,7 +13,9 @@ export class PlayerInsightsPanelTitleItem extends SettingsPanelItem<SettingsPane
   private readonly closeButton: Button<ButtonConfig>;
   private target: PlayerInsightsPanelTitleTarget | null = null;
 
-  constructor() {
+  constructor(config: SettingsPanelItemConfig = {}) {
+    super(config);
+
     const titleLabel = new Label<LabelConfig>({
       text: 'Player Insights',
       cssClasses: ['ui-player-insights-panel-title-label'],
@@ -24,16 +26,20 @@ export class PlayerInsightsPanelTitleItem extends SettingsPanelItem<SettingsPane
       text: i18n.getLocalizer('close'),
     });
 
-    super({
-      label: null,
-      components: [titleLabel, closeButton],
-      cssClasses: ['title-item', 'ui-player-insights-panel-title-item'],
-      isSetting: false,
-      role: 'group',
-      tabIndex: -1,
-    });
+    this.config = this.mergeConfig(
+      config,
+      {
+        cssClasses: ['title-item', 'ui-player-insights-panel-title-item'],
+        isSetting: false,
+        role: 'group',
+        tabIndex: -1,
+      },
+      this.config,
+    );
 
     this.closeButton = closeButton;
+    this.addComponent(titleLabel);
+    this.addComponent(closeButton);
   }
 
   setTarget(target: PlayerInsightsPanelTitleTarget): void {

--- a/src/ts/components/settings/SettingsPanelItem.ts
+++ b/src/ts/components/settings/SettingsPanelItem.ts
@@ -75,7 +75,7 @@ export class SettingsPanelItem<Config extends SettingsPanelItemConfig> extends C
     );
 
     const label = config.label;
-    if (label !== null) {
+    if (label != null) {
       if (label instanceof Component) {
         this.label = label;
       } else {

--- a/src/ts/components/settings/SubtitleSelectBox.ts
+++ b/src/ts/components/settings/SubtitleSelectBox.ts
@@ -15,6 +15,8 @@ import { i18n } from '../../localization/i18n';
  */
 export class SubtitleSelectBox extends SelectBox {
   constructor(config: ListSelectorConfig = {}) {
+    super(config);
+
     const comparator = config.comparator
       ? (itemA: ListItem, itemB: ListItem) => {
           if (
@@ -33,13 +35,10 @@ export class SubtitleSelectBox extends SelectBox {
         }
       : undefined;
 
-    super({
-      ...config,
-      comparator,
-    });
-
     this.config = this.mergeConfig(
       {
+        // Overriding the comparator from config to ensure the OFF item
+        // is properly pinned to the top
         ...config,
         comparator,
       },


### PR DESCRIPTION
## Description
Fixes component constructors that needed to prepare config before calling `super`, while still preserving JavaScript constructor initialization order. Adds regression coverage for omitted `SettingsPanelItem` label config.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry