### PR TITLE
Lazily initialize UI variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `UIVariantFactory` to lazily resolve UI variants only when they are selected.
+
 ### Fixed
 
 - Seeking with the remote on the TV UI no longer gets stuck at the start or end of the seek bar: after scrubbing all the way to one edge, pressing the opposite direction now moves the playback position immediately instead of requiring multiple presses.

--- a/spec/UIManager.spec.ts
+++ b/spec/UIManager.spec.ts
@@ -150,6 +150,22 @@ describe('UIManager', () => {
 
       expect(onUiChanged).not.toHaveBeenCalled();
     });
+
+    it('should resolve lazy UIs with spatial navigation', () => {
+      const ui = new UIContainer({ components: [new Container({})] });
+      const spatialNavigation = { release: jest.fn() };
+      const uiManager = new UIManager(playerMock, [
+        {
+          ui: () => ({
+            ui: ui,
+            spatialNavigation: spatialNavigation as any,
+          }),
+        },
+      ]);
+
+      expect(uiManager.activeUi.getUI()).toBe(ui);
+      expect(uiManager.activeUi['spatialNavigation']).toBe(spatialNavigation);
+    });
   });
 
   describe('ui variant resolution', () => {

--- a/spec/UIManager.spec.ts
+++ b/spec/UIManager.spec.ts
@@ -166,6 +166,42 @@ describe('UIManager', () => {
       expect(uiManager.activeUi.getUI()).toBe(ui);
       expect(uiManager.activeUi['spatialNavigation']).toBe(spatialNavigation);
     });
+
+    it('should resolve lazy UIs only when selected and reuse resolved UIs', () => {
+      const adUi = new UIContainer({ components: [new Container({})] });
+      const defaultUi = new UIContainer({ components: [new Container({})] });
+      const adFactory = jest.fn(() => adUi);
+      const defaultFactory = jest.fn(() => defaultUi);
+      const uiManager = new UIManager(playerMock, [
+        {
+          ui: adFactory,
+          condition: context => context.isAd,
+        },
+        {
+          ui: defaultFactory,
+        },
+      ]);
+
+      expect(defaultFactory).toHaveBeenCalledTimes(1);
+      expect(adFactory).not.toHaveBeenCalled();
+
+      expect(uiManager.activeUi.getUI()).toBe(defaultUi);
+      expect(defaultFactory).toHaveBeenCalledTimes(1);
+
+      uiManager.resolveUiVariant({ isAd: true });
+
+      expect(adFactory).toHaveBeenCalledTimes(1);
+      expect(uiManager.activeUi.getUI()).toBe(adUi);
+
+      uiManager.resolveUiVariant({ isAd: true });
+
+      expect(adFactory).toHaveBeenCalledTimes(1);
+
+      uiManager.resolveUiVariant();
+
+      expect(defaultFactory).toHaveBeenCalledTimes(1);
+      expect(uiManager.activeUi.getUI()).toBe(defaultUi);
+    });
   });
 
   describe('ui variant resolution', () => {

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -38,7 +38,7 @@ import { AdControlBar } from './components/ads/AdControlBar';
 import { MetadataLabel, MetadataLabelContent } from './components/labels/MetadataLabel';
 import { PlayerUtils } from './utils/PlayerUtils';
 import { CastUIContainer } from './components/CastUIContainer';
-import { UIConditionContext, UIManager, UIVariant, UIVariantFactory, UIVariantIdentifier } from './UIManager';
+import { UIConditionContext, UIManager, UIVariant, UIVariantFactory } from './UIManager';
 import { UIConfig } from './UIConfig';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from './localization/i18n';
@@ -87,49 +87,42 @@ export namespace UIFactory {
           condition: context => {
             return !context.isSourceLoaded;
           },
-          identifier: UIVariantIdentifier.empty,
         },
         {
           ui: UIFactory.defaultLayouts.smallScreenAds,
           condition: (context: UIConditionContext) => {
             return context.documentWidth < smallScreenSwitchWidth && context.isAd && context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.smallScreenAds,
         },
         {
           ui: UIFactory.defaultLayouts.smallScreen,
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi && context.documentWidth < smallScreenSwitchWidth;
           },
-          identifier: UIVariantIdentifier.smallScreen,
         },
         {
           ui: UIFactory.defaultLayouts.tvAds,
           condition: (context: UIConditionContext) => {
             return context.isTv && context.isAd && context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.tvAds,
         },
         {
           ui: UIFactory.defaultLayouts.tv,
           condition: (context: UIConditionContext) => {
             return context.isTv && !context.isAd && !context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.tv,
         },
         {
           ui: UIFactory.defaultLayouts.ads,
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.ads,
         },
         {
           ui: () => UIFactory.defaultLayouts.main(config),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.main,
         },
       ],
       config,
@@ -156,14 +149,12 @@ export namespace UIFactory {
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.smallScreenAds,
         },
         {
           ui: UIFactory.defaultLayouts.smallScreen,
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.smallScreen,
         },
       ],
       config,
@@ -185,7 +176,6 @@ export namespace UIFactory {
       [
         {
           ui: () => UIFactory.defaultLayouts.castReceiver(config),
-          identifier: UIVariantIdentifier.castReceiver,
         },
       ],
       config,
@@ -210,14 +200,12 @@ export namespace UIFactory {
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.tvAds,
         },
         {
           ui: UIFactory.defaultLayouts.tv,
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
-          identifier: UIVariantIdentifier.tv,
         },
       ],
       config,
@@ -240,7 +228,6 @@ export namespace UIFactory {
       [
         {
           ui: UIFactory.defaultLayouts.subtitle,
-          identifier: UIVariantIdentifier.subtitle,
         },
       ],
       config,

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -38,7 +38,7 @@ import { AdControlBar } from './components/ads/AdControlBar';
 import { MetadataLabel, MetadataLabelContent } from './components/labels/MetadataLabel';
 import { PlayerUtils } from './utils/PlayerUtils';
 import { CastUIContainer } from './components/CastUIContainer';
-import { UIConditionContext, UIManager, UIVariant } from './UIManager';
+import { UIConditionContext, UIManager, UIVariant, UIVariantFactory, UIVariantIdentifier } from './UIManager';
 import { UIConfig } from './UIConfig';
 import { PlayerAPI } from 'bitmovin-player';
 import { i18n } from './localization/i18n';
@@ -83,46 +83,53 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: UIFactory.defaultLayouts.emptyState(),
+          ui: UIFactory.defaultLayouts.emptyState,
           condition: context => {
             return !context.isSourceLoaded;
           },
+          identifier: UIVariantIdentifier.empty,
         },
         {
-          ui: UIFactory.defaultLayouts.smallScreenAds(),
+          ui: UIFactory.defaultLayouts.smallScreenAds,
           condition: (context: UIConditionContext) => {
             return context.documentWidth < smallScreenSwitchWidth && context.isAd && context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.smallScreenAds,
         },
         {
-          ui: UIFactory.defaultLayouts.smallScreen(),
+          ui: UIFactory.defaultLayouts.smallScreen,
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi && context.documentWidth < smallScreenSwitchWidth;
           },
+          identifier: UIVariantIdentifier.smallScreen,
         },
         {
-          ...UIFactory.defaultLayouts.tvAds(),
+          ui: UIFactory.defaultLayouts.tvAds,
           condition: (context: UIConditionContext) => {
             return context.isTv && context.isAd && context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.tvAds,
         },
         {
-          ...UIFactory.defaultLayouts.tv(),
+          ui: UIFactory.defaultLayouts.tv,
           condition: (context: UIConditionContext) => {
             return context.isTv && !context.isAd && !context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.tv,
         },
         {
-          ui: UIFactory.defaultLayouts.ads(),
+          ui: UIFactory.defaultLayouts.ads,
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.ads,
         },
         {
-          ui: UIFactory.defaultLayouts.main(config),
+          ui: () => UIFactory.defaultLayouts.main(config),
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.main,
         },
       ],
       config,
@@ -145,16 +152,18 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: UIFactory.defaultLayouts.smallScreenAds(),
+          ui: UIFactory.defaultLayouts.smallScreenAds,
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.smallScreenAds,
         },
         {
-          ui: UIFactory.defaultLayouts.smallScreen(),
+          ui: UIFactory.defaultLayouts.smallScreen,
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.smallScreen,
         },
       ],
       config,
@@ -171,7 +180,16 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildCastReceiverUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, UIFactory.defaultLayouts.castReceiver(config), config);
+    return new UIManager(
+      player,
+      [
+        {
+          ui: UIFactory.defaultLayouts.castReceiver,
+          identifier: UIVariantIdentifier.castReceiver,
+        },
+      ],
+      config,
+    );
   }
 
   /**
@@ -188,16 +206,18 @@ export namespace UIFactory {
       player,
       [
         {
-          ...UIFactory.defaultLayouts.tvAds(),
+          ui: UIFactory.defaultLayouts.tvAds,
           condition: (context: UIConditionContext) => {
             return context.isAd && context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.tvAds,
         },
         {
-          ...UIFactory.defaultLayouts.tv(),
+          ui: UIFactory.defaultLayouts.tv,
           condition: (context: UIConditionContext) => {
             return !context.isAd && !context.adRequiresUi;
           },
+          identifier: UIVariantIdentifier.tv,
         },
       ],
       config,
@@ -215,7 +235,16 @@ export namespace UIFactory {
    * @param config The UIConfig object
    */
   export function buildSubtitleUI(player: PlayerAPI, config: UIConfig = {}): UIManager {
-    return new UIManager(player, UIFactory.defaultLayouts.subtitle(), config);
+    return new UIManager(
+      player,
+      [
+        {
+          ui: UIFactory.defaultLayouts.subtitle,
+          identifier: UIVariantIdentifier.subtitle,
+        },
+      ],
+      config,
+    );
   }
 
   /**

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -184,7 +184,7 @@ export namespace UIFactory {
       player,
       [
         {
-          ui: UIFactory.defaultLayouts.castReceiver,
+          ui: () => UIFactory.defaultLayouts.castReceiver(config),
           identifier: UIVariantIdentifier.castReceiver,
         },
       ],

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -585,7 +585,7 @@ export class UIManager {
 
   /**
    * Returns the list of UI variants as passed into the constructor of {@link UIManager}.
-   * @returns {UIVariant[]} the list of available UI variants
+   * @returns {Array<UIVariant | UIVariantFactory>} the list of available UI variants
    */
   getUiVariants(): Array<UIVariant | UIVariantFactory> {
     return this.uiVariants;
@@ -593,7 +593,7 @@ export class UIManager {
 
   /**
    * Switches to a UI variant from the list returned by {@link getUiVariants}.
-   * @param {UIVariant} uiVariant the UI variant to switch to
+   * @param {UIVariant | UIVariantFactory} uiVariant or UIVariantFactory the UI variant to switch to
    * @param {() => void} onShow a callback that is executed just before the new UI variant is shown
    */
   switchToUiVariant(uiVariant: UIVariant | UIVariantFactory, onShow?: () => void): void {

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -169,21 +169,6 @@ export interface UIConditionResolver {
 }
 
 /**
- * Identifier for the different {@link UIVariant}s.
- */
-export enum UIVariantIdentifier {
-  main = 'main',
-  ads = 'ads',
-  smallScreen = 'smallScreen',
-  smallScreenAds = 'smallScreenAds',
-  tv = 'tv',
-  tvAds = 'tvAds',
-  subtitle = 'subtitle',
-  castReceiver = 'castReceiver',
-  empty = 'empty',
-}
-
-/**
  * Lazily creates a UI variant the first time it is selected.
  *
  * If the variant also needs {@link SpatialNavigation}, return it together with the created UI so both are built from the
@@ -198,10 +183,6 @@ export interface UIVariantFactory {
    * Determines whether this variant can be displayed for the current player and document state.
    */
   condition?: UIConditionResolver;
-  /**
-   * Stable identifier for this variant.
-   */
-  identifier?: UIVariantIdentifier;
 }
 
 /**
@@ -220,10 +201,6 @@ export interface UIVariant {
    * Spatial navigation instance used by this variant, if keyboard or remote-control navigation is enabled.
    */
   spatialNavigation?: SpatialNavigation;
-  /**
-   * Stable identifier for this variant.
-   */
-  identifier?: UIVariantIdentifier;
 }
 
 export interface ActiveUiChangedArgs extends NoArgs {

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -187,9 +187,22 @@ export enum UIVariantIdentifier {
  * Associates a UI instance with an optional {@link UIConditionResolver} that determines if the UI should be displayed.
  */
 export interface UIVariant {
-  ui: UIContainer;
+  /**
+   * The UI container for this variant, or a factory that creates it lazily when the variant is first resolved.
+   */
+  ui: UIContainer | (() => UIContainer);
+  /**
+   * Determines whether this variant can be displayed for the current player and document state.
+   */
   condition?: UIConditionResolver;
+  /**
+   * Spatial navigation instance used by this variant, if keyboard or remote-control navigation is enabled.
+   */
   spatialNavigation?: SpatialNavigation;
+  /**
+   * Stable identifier for this variant, used to scope variant-specific component config in {@link UIConfig.components}.
+   */
+  identifier?: UIVariantIdentifier;
 }
 
 export interface ActiveUiChangedArgs extends NoArgs {

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -594,7 +594,13 @@ export class UIManager {
    * @param {UIVariant} uiVariant the UI variant to switch to
    * @param {() => void} onShow a callback that is executed just before the new UI variant is shown
    */
-  switchToUiVariant(nextUi: InternalUIInstanceManager, onShow?: () => void): void {
+  switchToUiVariant(uiVariant: UIVariant, onShow?: () => void): void {
+    const uiVariantIndex = this.uiVariants.indexOf(uiVariant);
+    const nextUi: InternalUIInstanceManager = this.uiInstanceManagers[uiVariantIndex];
+    this.switchToUiInstance(nextUi, onShow);
+  }
+
+  private switchToUiInstance(nextUi: InternalUIInstanceManager, onShow?: () => void): void {
     const previousUi = this.currentUi;
     // Determine if the UI variant is changing
     // Only if the UI variant is changing, we need to do some stuff. Else we just leave everything as-is.
@@ -682,7 +688,7 @@ export class UIManager {
       }
     }
 
-    this.switchToUiVariant(nextUi, () => {
+    this.switchToUiInstance(nextUi, () => {
       if (onShow) {
         onShow(switchingContext);
       }

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -417,11 +417,10 @@ export class UIManager {
       this.uiInstanceManagers.push(
         new InternalUIInstanceManager(
           player,
-          uiVariant.ui,
+          uiVariant,
           this.config,
           this.subtitleSettingsManager,
           this.uiWrapperElement,
-          uiVariant.spatialNavigation,
         ),
       );
     }
@@ -595,11 +594,8 @@ export class UIManager {
    * @param {UIVariant} uiVariant the UI variant to switch to
    * @param {() => void} onShow a callback that is executed just before the new UI variant is shown
    */
-  switchToUiVariant(uiVariant: UIVariant, onShow?: () => void): void {
-    const uiVariantIndex = this.uiVariants.indexOf(uiVariant);
-
+  switchToUiVariant(nextUi: InternalUIInstanceManager, onShow?: () => void): void {
     const previousUi = this.currentUi;
-    const nextUi: InternalUIInstanceManager = this.uiInstanceManagers[uiVariantIndex];
     // Determine if the UI variant is changing
     // Only if the UI variant is changing, we need to do some stuff. Else we just leave everything as-is.
     if (nextUi === this.currentUi) {
@@ -610,8 +606,9 @@ export class UIManager {
 
     // Hide the currently active UI variant
     if (this.currentUi) {
-      this.currentUi.onInactive.dispatch(this.currentUi.getUI());
-      this.currentUi.getUI().hide();
+      const currentUiContainer = this.currentUi.resolveUI();
+      this.currentUi.onInactive.dispatch(currentUiContainer);
+      currentUiContainer.hide();
     }
 
     // Assign the new UI variant as current UI
@@ -622,19 +619,21 @@ export class UIManager {
     if (this.currentUi == null) {
       return;
     }
+
+    const currentUiContainer = this.currentUi.resolveUI();
     // Add the UI to the DOM (and configure it) the first time it is selected
     if (!this.currentUi.isConfigured()) {
       this.addUi(this.currentUi);
       // ensure that the internal state is ready for the upcoming show call
-      if (!this.currentUi.getUI().isHidden()) {
-        this.currentUi.getUI().hide();
+      if (!currentUiContainer.isHidden()) {
+        currentUiContainer.hide();
       }
     }
     if (onShow) {
       onShow();
     }
-    this.currentUi.getUI().show();
-    this.currentUi.onActive.dispatch(this.currentUi.getUI());
+    currentUiContainer.show();
+    this.currentUi.onActive.dispatch(currentUiContainer);
     this.events.onActiveUiChanged.dispatch(this, { previousUi, currentUi: nextUi });
   }
 
@@ -666,21 +665,24 @@ export class UIManager {
     // Fire the event and allow modification of the context before it is used to resolve the UI variant
     this.events.onUiVariantResolve.dispatch(this, switchingContext);
 
-    let nextUiVariant: UIVariant = null;
+    let nextUi: InternalUIInstanceManager = null;
 
     // Select new UI variant
     // If no variant condition is fulfilled, we switch to *no* UI
-    for (const uiVariant of this.uiVariants) {
-      const matchesCondition = uiVariant.condition == null || uiVariant.condition(switchingContext) === true;
-      if (nextUiVariant == null && matchesCondition) {
-        nextUiVariant = uiVariant;
+    for (const uiInstanceManager of this.uiInstanceManagers) {
+      const matchesCondition =
+        uiInstanceManager.conditionResolver == null || uiInstanceManager.conditionResolver(switchingContext) === true;
+      if (nextUi == null && matchesCondition) {
+        nextUi = uiInstanceManager;
       } else {
         // hide all UIs besides the one which should be active
-        uiVariant.ui.hide();
+        if (uiInstanceManager.isUIResolved()) {
+          uiInstanceManager.getUI().hide();
+        }
       }
     }
 
-    this.switchToUiVariant(nextUiVariant, () => {
+    this.switchToUiVariant(nextUi, () => {
       if (onShow) {
         onShow(switchingContext);
       }
@@ -697,7 +699,8 @@ export class UIManager {
   }
 
   private addUi(ui: InternalUIInstanceManager): void {
-    const dom = ui.getUI().getDomElement();
+    const uiContainer = ui.resolveUI();
+    const dom = uiContainer.getDomElement();
     const player = ui.getWrappedPlayer();
 
     ui.configureControls();
@@ -728,6 +731,10 @@ export class UIManager {
 
   private releaseUi(ui: InternalUIInstanceManager): void {
     ui.releaseControls();
+
+    if (!ui.isUIResolved()) {
+      return;
+    }
 
     const uiContainer = ui.getUI();
     if (uiContainer.hasDomElement()) {
@@ -838,7 +845,8 @@ export interface SeekPreviewArgs extends NoArgs {
  */
 export class UIInstanceManager {
   private playerWrapper: PlayerWrapper;
-  private ui: UIContainer;
+  private uiVariant: UIVariant;
+  private uiContainer?: UIContainer;
   private config: InternalUIConfig;
   private subtitleSettingsManager: SubtitleSettingsManager;
   protected spatialNavigation?: SpatialNavigation;
@@ -864,18 +872,17 @@ export class UIInstanceManager {
 
   constructor(
     player: PlayerAPI,
-    ui: UIContainer,
+    uiVariant: UIVariant,
     config: InternalUIConfig,
     subtitleSettingsManager: SubtitleSettingsManager,
     uiWrapperElement: DOM,
-    spatialNavigation?: SpatialNavigation,
   ) {
     this.playerWrapper = new PlayerWrapper(player);
-    this.ui = ui;
+    this.uiVariant = uiVariant;
     this.config = config;
     this.subtitleSettingsManager = subtitleSettingsManager;
     this.uiWrapperElement = uiWrapperElement;
-    this.spatialNavigation = spatialNavigation;
+    this.spatialNavigation = uiVariant.spatialNavigation;
   }
 
   getSubtitleSettingsManager() {
@@ -886,8 +893,31 @@ export class UIInstanceManager {
     return this.config;
   }
 
+  get conditionResolver(): UIConditionResolver {
+    return this.uiVariant.condition;
+  }
+
+  resolveUI(): UIContainer {
+    if (this.uiContainer) {
+      return this.uiContainer;
+    }
+
+    if (typeof this.uiVariant.ui === 'function') {
+      this.uiContainer = this.uiVariant.ui();
+    } else {
+      this.uiContainer = this.uiVariant.ui;
+    }
+
+    return this.uiContainer;
+  }
+
   getUI(): UIContainer {
-    return this.ui;
+    // Keep getUI() resolving lazily for existing integrations that expect it to always return a UIContainer.
+    return this.resolveUI();
+  }
+
+  isUIResolved(): boolean {
+    return this.uiContainer != null;
   }
 
   getPlayer(): PlayerAPI {

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -184,13 +184,34 @@ export enum UIVariantIdentifier {
 }
 
 /**
+ * Lazily creates a UI variant the first time it is selected.
+ *
+ * If the variant also needs {@link SpatialNavigation}, return it together with the created UI so both are built from the
+ * same component instances.
+ */
+export interface UIVariantFactory {
+  /**
+   * Creates the UI container, optionally together with matching spatial navigation.
+   */
+  ui: () => UIContainer | Pick<UIVariant, 'ui' | 'spatialNavigation'>;
+  /**
+   * Determines whether this variant can be displayed for the current player and document state.
+   */
+  condition?: UIConditionResolver;
+  /**
+   * Stable identifier for this variant.
+   */
+  identifier?: UIVariantIdentifier;
+}
+
+/**
  * Associates a UI instance with an optional {@link UIConditionResolver} that determines if the UI should be displayed.
  */
 export interface UIVariant {
   /**
-   * The UI container for this variant, or a factory that creates it lazily when the variant is first resolved.
+   * The UI container for this variant.
    */
-  ui: UIContainer | (() => UIContainer);
+  ui: UIContainer;
   /**
    * Determines whether this variant can be displayed for the current player and document state.
    */
@@ -200,7 +221,7 @@ export interface UIVariant {
    */
   spatialNavigation?: SpatialNavigation;
   /**
-   * Stable identifier for this variant, used to scope variant-specific component config in {@link UIConfig.components}.
+   * Stable identifier for this variant.
    */
   identifier?: UIVariantIdentifier;
 }
@@ -219,7 +240,7 @@ export interface ActiveUiChangedArgs extends NoArgs {
 export class UIManager {
   private player: PlayerAPI;
   private uiContainerElement: DOM;
-  private uiVariants: UIVariant[];
+  private uiVariants: Array<UIVariant | UIVariantFactory>;
   private uiInstanceManagers: InternalUIInstanceManager[];
   private currentUi: InternalUIInstanceManager;
   private config: InternalUIConfig; // Conjunction of provided uiConfig and sourceConfig from the player
@@ -255,8 +276,12 @@ export class UIManager {
    * @param uiVariants a list of UI variants that will be dynamically switched
    * @param uiconfig optional UI configuration
    */
-  constructor(player: PlayerAPI, uiVariants: UIVariant[], uiconfig?: UIConfig);
-  constructor(player: PlayerAPI, playerUiOrUiVariants: UIContainer | UIVariant[], uiconfig: UIConfig = {}) {
+  constructor(player: PlayerAPI, uiVariants: Array<UIVariant | UIVariantFactory>, uiconfig?: UIConfig);
+  constructor(
+    player: PlayerAPI,
+    playerUiOrUiVariants: UIContainer | Array<UIVariant | UIVariantFactory>,
+    uiconfig: UIConfig = {},
+  ) {
     if (playerUiOrUiVariants instanceof UIContainer) {
       // Single-UI constructor has been called, transform arguments to UIVariant[] signature
       const playerUi = <UIContainer>playerUiOrUiVariants;
@@ -268,7 +293,7 @@ export class UIManager {
       this.uiVariants = uiVariants;
     } else {
       // Default constructor (UIVariant[]) has been called
-      this.uiVariants = <UIVariant[]>playerUiOrUiVariants;
+      this.uiVariants = playerUiOrUiVariants;
     }
 
     this.subtitleSettingsManager = new SubtitleSettingsManager();
@@ -585,7 +610,7 @@ export class UIManager {
    * Returns the list of UI variants as passed into the constructor of {@link UIManager}.
    * @returns {UIVariant[]} the list of available UI variants
    */
-  getUiVariants(): UIVariant[] {
+  getUiVariants(): Array<UIVariant | UIVariantFactory> {
     return this.uiVariants;
   }
 
@@ -594,7 +619,7 @@ export class UIManager {
    * @param {UIVariant} uiVariant the UI variant to switch to
    * @param {() => void} onShow a callback that is executed just before the new UI variant is shown
    */
-  switchToUiVariant(uiVariant: UIVariant, onShow?: () => void): void {
+  switchToUiVariant(uiVariant: UIVariant | UIVariantFactory, onShow?: () => void): void {
     const uiVariantIndex = this.uiVariants.indexOf(uiVariant);
     const nextUi: InternalUIInstanceManager = this.uiInstanceManagers[uiVariantIndex];
     this.switchToUiInstance(nextUi, onShow);
@@ -851,7 +876,7 @@ export interface SeekPreviewArgs extends NoArgs {
  */
 export class UIInstanceManager {
   private playerWrapper: PlayerWrapper;
-  private uiVariant: UIVariant;
+  private uiVariant: UIVariant | UIVariantFactory;
   private uiContainer?: UIContainer;
   private config: InternalUIConfig;
   private subtitleSettingsManager: SubtitleSettingsManager;
@@ -878,17 +903,24 @@ export class UIInstanceManager {
 
   constructor(
     player: PlayerAPI,
-    uiVariant: UIVariant,
+    uiVariant: UIVariant | UIVariantFactory,
     config: InternalUIConfig,
     subtitleSettingsManager: SubtitleSettingsManager,
     uiWrapperElement: DOM,
   ) {
+    if (typeof uiVariant.ui === 'function' && (uiVariant as UIVariant).spatialNavigation) {
+      throw Error('Lazy UI variants must return spatialNavigation from the ui factory');
+    }
+
     this.playerWrapper = new PlayerWrapper(player);
     this.uiVariant = uiVariant;
     this.config = config;
     this.subtitleSettingsManager = subtitleSettingsManager;
     this.uiWrapperElement = uiWrapperElement;
-    this.spatialNavigation = uiVariant.spatialNavigation;
+    if (typeof uiVariant.ui !== 'function') {
+      this.uiContainer = uiVariant.ui;
+      this.spatialNavigation = (uiVariant as UIVariant).spatialNavigation;
+    }
   }
 
   getSubtitleSettingsManager() {
@@ -909,7 +941,14 @@ export class UIInstanceManager {
     }
 
     if (typeof this.uiVariant.ui === 'function') {
-      this.uiContainer = this.uiVariant.ui();
+      const resolved = this.uiVariant.ui();
+
+      if (resolved instanceof UIContainer) {
+        this.uiContainer = resolved;
+      } else {
+        this.uiContainer = resolved.ui;
+        this.spatialNavigation = resolved.spatialNavigation;
+      }
     } else {
       this.uiContainer = this.uiVariant.ui;
     }

--- a/src/ts/UIManager.ts
+++ b/src/ts/UIManager.ts
@@ -169,6 +169,21 @@ export interface UIConditionResolver {
 }
 
 /**
+ * Identifier for the different {@link UIVariant}s.
+ */
+export enum UIVariantIdentifier {
+  main = 'main',
+  ads = 'ads',
+  smallScreen = 'smallScreen',
+  smallScreenAds = 'smallScreenAds',
+  tv = 'tv',
+  tvAds = 'tvAds',
+  subtitle = 'subtitle',
+  castReceiver = 'castReceiver',
+  empty = 'empty',
+}
+
+/**
  * Associates a UI instance with an optional {@link UIConditionResolver} that determines if the UI should be displayed.
  */
 export interface UIVariant {


### PR DESCRIPTION
## Description
Introduces lazy UI variant initialization so UI containers are created only when their variant is selected. This also keeps `switchToUiVariant` backwards compatible and supports lazy variants that create matching spatial navigation from the same component instances.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
