### PR TITLE
Preserve component names in production builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Production builds now preserve public component class names during minification.
+
 ### Fixed
 
 - Seeking with the remote on the TV UI no longer gets stuck at the start or end of the seek bar: after scrubbing all the way to one edge, pressing the opposite direction now moves the playback position immediately instead of requiring multiple presses.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "semver": "^7.5.4",
         "stream-combiner2": "^1.1.1",
         "string-replace-loader": "^3.2.0",
+        "terser-webpack-plugin": "^5.5.0",
         "ts-jest": "^29.0.5",
         "ts-loader": "^9.5.4",
         "typedoc": "^0.28.13",
@@ -16921,6 +16922,7 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
       "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "semver": "^7.5.4",
     "stream-combiner2": "^1.1.1",
     "string-replace-loader": "^3.2.0",
+    "terser-webpack-plugin": "^5.5.0",
     "ts-jest": "^29.0.5",
     "ts-loader": "^9.5.4",
     "typedoc": "^0.28.13",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const replacer = require('replacer-util').replacer;
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
@@ -136,6 +137,15 @@ module.exports = (env, { mode }) => {
     ],
     resolve: {
       extensions: ['.ts', '.js', '.scss', '.css'],
+    },
+    optimization: {
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            keep_fnames: true,
+          },
+        }),
+      ],
     },
     output: {
       path: path.resolve(__dirname, OUTPUT_ROOT_DIRECTORY),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,6 +142,7 @@ module.exports = (env, { mode }) => {
       minimizer: [
         new TerserPlugin({
           terserOptions: {
+            keep_classnames: true,
             keep_fnames: true,
           },
         }),


### PR DESCRIPTION
## Description
Preserves public component constructor names in production builds so component config lookup can continue to use public component class names after minification. This is required for #906 to look up component overrides from the new API in #905.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
