### PR TITLE
Introduce toggle settings panel item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `ToggleSettingsPanelItem` for settings rows that toggle their nested `ToggleButton` when the row is selected.
+
 ### Fixed
 
 - Seeking with the remote on the TV UI no longer gets stuck at the start or end of the seek bar: after scrubbing all the way to one edge, pressing the opposite direction now moves the playback position immediately instead of requiring multiple presses.

--- a/spec/components/settings/ToggleSettingsPanelItem.spec.ts
+++ b/spec/components/settings/ToggleSettingsPanelItem.spec.ts
@@ -53,6 +53,7 @@ describe('ToggleSettingsPanelItem', () => {
     configureToggleSettingsPanelItem(toggleButton);
 
     expect(toggleButton.getDomElement().get(0).getAttribute('tabindex')).toBe('-1');
+    expect(toggleButton.getDomElement().get(0).getAttribute('aria-hidden')).toBe('true');
   });
 
   it('adds the toggle settings panel item CSS class', () => {

--- a/spec/components/settings/ToggleSettingsPanelItem.spec.ts
+++ b/spec/components/settings/ToggleSettingsPanelItem.spec.ts
@@ -1,0 +1,66 @@
+import type { PlayerAPI } from 'bitmovin-player';
+
+import { ToggleButton } from '../../../src/ts/components/buttons/ToggleButton';
+import { ToggleSettingsPanelItem } from '../../../src/ts/components/settings/ToggleSettingsPanelItem';
+import type { UIInstanceManager } from '../../../src/ts/UIManager';
+import { MockHelper } from '../../helper/MockHelper';
+
+describe('ToggleSettingsPanelItem', () => {
+  let playerMock: PlayerAPI;
+  let uiInstanceManagerMock: UIInstanceManager;
+
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+  });
+
+  it('toggles the button when the settings row is clicked', () => {
+    const toggleButton = new ToggleButton({});
+    const settingsPanelItem = configureToggleSettingsPanelItem(toggleButton);
+
+    settingsPanelItem['onClickEvent']();
+
+    expect(toggleButton.isOn()).toBe(true);
+    expect(settingsPanelItem.getDomElement().get(0).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('does not toggle twice when the button itself is clicked', () => {
+    const toggleButton = new ToggleButton({});
+    const settingsPanelItem = configureToggleSettingsPanelItem(toggleButton);
+    toggleButton.onClick.subscribe(() => toggleButton.toggle());
+
+    toggleButton.getDomElement().get(0).click();
+
+    expect(toggleButton.isOn()).toBe(true);
+    expect(settingsPanelItem.getDomElement().get(0).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('removes the button from keyboard focus', () => {
+    const toggleButton = new ToggleButton({});
+
+    configureToggleSettingsPanelItem(toggleButton);
+
+    expect(toggleButton.getDomElement().get(0).getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('adds the toggle settings panel item CSS class', () => {
+    const toggleButton = new ToggleButton({});
+    const settingsPanelItem = configureToggleSettingsPanelItem(toggleButton);
+
+    expect(settingsPanelItem.getConfig().cssClasses).toContain('ui-toggle-settings-panel-item');
+  });
+
+  function configureToggleSettingsPanelItem(toggleButton: ToggleButton<any>): ToggleSettingsPanelItem {
+    const settingsPanelItem = new ToggleSettingsPanelItem({
+      label: 'toggle',
+      settingComponent: toggleButton,
+    });
+
+    toggleButton.initialize();
+    settingsPanelItem.initialize();
+    toggleButton.configure(playerMock, uiInstanceManagerMock);
+    settingsPanelItem.configure(playerMock, uiInstanceManagerMock);
+
+    return settingsPanelItem;
+  }
+});

--- a/spec/components/settings/ToggleSettingsPanelItem.spec.ts
+++ b/spec/components/settings/ToggleSettingsPanelItem.spec.ts
@@ -27,10 +27,22 @@ describe('ToggleSettingsPanelItem', () => {
   it('does not toggle twice when the button itself is clicked', () => {
     const toggleButton = new ToggleButton({});
     const settingsPanelItem = configureToggleSettingsPanelItem(toggleButton);
-    toggleButton.onClick.subscribe(() => toggleButton.toggle());
 
     toggleButton.getDomElement().get(0).click();
 
+    expect(toggleButton.isOn()).toBe(true);
+    expect(settingsPanelItem.getDomElement().get(0).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('does not dispatch the button click when forwarding to the row', () => {
+    const toggleButton = new ToggleButton({});
+    const settingsPanelItem = configureToggleSettingsPanelItem(toggleButton);
+    const onButtonClick = jest.fn();
+    toggleButton.onClick.subscribe(onButtonClick);
+
+    toggleButton.getDomElement().get(0).click();
+
+    expect(onButtonClick).not.toHaveBeenCalled();
     expect(toggleButton.isOn()).toBe(true);
     expect(settingsPanelItem.getDomElement().get(0).getAttribute('aria-checked')).toBe('true');
   });

--- a/src/scss/bitmovinplayer-ui.scss
+++ b/src/scss/bitmovinplayer-ui.scss
@@ -19,6 +19,7 @@
 @import 'components/settings/settings-panel';
 @import 'components/settings/settings-panel-page';
 @import 'components/settings/settings-panel-item';
+@import 'components/settings/toggle-settings-panel-item';
 @import 'components/settings/settings-panel-separator';
 @import 'components/panels/player-insights-panel';
 @import 'components/settings/settings-panel-page-open-button';

--- a/src/scss/components/buttons/_eco-mode-toggle-button.scss
+++ b/src/scss/components/buttons/_eco-mode-toggle-button.scss
@@ -1,31 +1,7 @@
 @import '../../variables';
-@import '../../mixins';
 
 .#{$prefix}-ui-ecomodetogglebutton {
   @extend %ui-button;
-  height: 1em;
-  min-width: 5em;
-
-  &:hover {
-    @include svg-icon-shadow;
-  }
-
-  &.#{$prefix}-on {
-    .#{$prefix}-ui-icon {
-      background-image: svg-load('../../assets/images/toggleOn.svg', fill=$color-icon);
-      background-position: 20px center;
-      background-size: 45% auto;
-      margin-left: 2%;
-    }
-  }
-
-  &.#{$prefix}-off {
-    .#{$prefix}-ui-icon {
-      background-image: svg-load('../../assets/images/toggleOff.svg', stroke=$color-icon);
-      background-position: 20px center;
-      background-size: 45% auto;
-    }
-  }
 }
 
 // sass-lint:disable no-ids

--- a/src/scss/components/buttons/_eco-mode-toggle-button.scss
+++ b/src/scss/components/buttons/_eco-mode-toggle-button.scss
@@ -1,9 +1,5 @@
 @import '../../variables';
 
-.#{$prefix}-ui-ecomodetogglebutton {
-  @extend %ui-button;
-}
-
 // sass-lint:disable no-ids
 #ecomodelabel {
   &::before {

--- a/src/scss/components/settings/_toggle-settings-panel-item.scss
+++ b/src/scss/components/settings/_toggle-settings-panel-item.scss
@@ -31,10 +31,7 @@
 
 .#{$prefix}-ui-toggle-settings-panel-item {
   button {
+    @extend %ui-button;
     @include toggle-settings-panel-button;
   }
-}
-
-.#{$prefix}-ui-ecomodetogglebutton {
-  @include toggle-settings-panel-button;
 }

--- a/src/scss/components/settings/_toggle-settings-panel-item.scss
+++ b/src/scss/components/settings/_toggle-settings-panel-item.scss
@@ -1,0 +1,40 @@
+@import '../../variables';
+@import '../../mixins';
+
+@mixin toggle-settings-panel-button {
+  height: 1em;
+  margin-left: auto;
+  min-width: 2.25em;
+  padding-left: 0;
+  padding-right: 0;
+
+  &:hover {
+    @include svg-icon-shadow;
+  }
+
+  .#{$prefix}-ui-icon {
+    background-size: 100% auto;
+  }
+
+  &.#{$prefix}-on {
+    .#{$prefix}-ui-icon {
+      background-image: svg-load('../../assets/images/toggleOn.svg', fill=$color-icon);
+    }
+  }
+
+  &.#{$prefix}-off {
+    .#{$prefix}-ui-icon {
+      background-image: svg-load('../../assets/images/toggleOff.svg', stroke=$color-icon);
+    }
+  }
+}
+
+.#{$prefix}-ui-toggle-settings-panel-item {
+  button {
+    @include toggle-settings-panel-button;
+  }
+}
+
+.#{$prefix}-ui-ecomodetogglebutton {
+  @include toggle-settings-panel-button;
+}

--- a/src/ts/UIComponentConfigOverrides.ts
+++ b/src/ts/UIComponentConfigOverrides.ts
@@ -46,6 +46,7 @@ import type { SubtitleSettingsPanelPageConfig } from './components/settings/subt
 import type { TitleBarConfig } from './components/TitleBar';
 import type { UIContainerConfig } from './components/UIContainer';
 import type { WatermarkConfig } from './components/Watermark';
+import type { ToggleSettingsPanelItem } from './components/settings/ToggleSettingsPanelItem';
 
 /**
  * Component config overrides keyed by public component class name, optionally scoped by UI variant.
@@ -474,6 +475,10 @@ export interface UIComponentConfigMap {
    * @category Components
    */
   ToggleButton?: Partial<ToggleButtonConfig>;
+  /**
+   * @category Components
+   */
+  ToggleSettingsPanelItem?: Partial<ToggleSettingsPanelItem>;
   /**
    * @category Components
    */

--- a/src/ts/components/EcoModeContainer.ts
+++ b/src/ts/components/EcoModeContainer.ts
@@ -4,6 +4,7 @@ import { Container, ContainerConfig } from './Container';
 import { EcoModeToggleButton } from './buttons/EcoModeToggleButton';
 import { Label, LabelConfig } from './labels/Label';
 import { SettingsPanelItem, SettingsPanelItemConfig } from './settings/SettingsPanelItem';
+import { ToggleSettingsPanelItem } from './settings/ToggleSettingsPanelItem';
 
 /**
  * @category Containers
@@ -29,7 +30,7 @@ export class EcoModeContainer extends Container<ContainerConfig> {
       cssClass: 'ui-label-savedEnergy',
     });
 
-    this.ecoModeToggleButtonItem = new SettingsPanelItem({
+    this.ecoModeToggleButtonItem = new ToggleSettingsPanelItem({
       label: labelEcoMode,
       settingComponent: ecoModeToggleButton,
     });

--- a/src/ts/components/settings/ToggleSettingsPanelItem.ts
+++ b/src/ts/components/settings/ToggleSettingsPanelItem.ts
@@ -1,0 +1,63 @@
+import { PlayerAPI } from 'bitmovin-player';
+
+import { UIInstanceManager } from '../../UIManager';
+import { ToggleButton, ToggleButtonConfig } from '../buttons/ToggleButton';
+import { InteractiveSettingsPanelItem } from './InteractiveSettingsPanelItem';
+import { SettingsPanelItemConfig } from './SettingsPanelItem';
+
+/**
+ * Configuration interface for a {@link ToggleSettingsPanelItem}.
+ *
+ * @category Configs
+ */
+export interface ToggleSettingsPanelItemConfig extends SettingsPanelItemConfig {
+  /**
+   * The toggle button that will be toggled when this item is clicked.
+   */
+  settingComponent: ToggleButton<ToggleButtonConfig>;
+}
+
+/**
+ * A settings panel item that toggles a {@link ToggleButton} when the row is clicked.
+ *
+ * @category Components
+ */
+export class ToggleSettingsPanelItem extends InteractiveSettingsPanelItem<ToggleSettingsPanelItemConfig> {
+  protected settingComponent: ToggleButton<ToggleButtonConfig>;
+
+  constructor(config: ToggleSettingsPanelItemConfig) {
+    super(config);
+
+    this.config = this.mergeConfig(
+      config,
+      {
+        cssClasses: ['ui-toggle-settings-panel-item'],
+        role: 'menuitemcheckbox',
+        tabIndex: 0,
+      } as ToggleSettingsPanelItemConfig,
+      this.config,
+    );
+  }
+
+  configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
+    super.configure(player, uimanager);
+
+    // Keyboard selection belongs to the row, otherwise Enter/Space can activate both the button and the row.
+    this.settingComponent.getDomElement().attr('tabindex', '-1');
+    // The button handles its own click; keep that click from bubbling into the row and toggling twice.
+    this.settingComponent.getDomElement().on('click', event => event.stopPropagation());
+
+    this.onClick.subscribe(() => {
+      if (!this.settingComponent.isDisabled()) {
+        this.settingComponent.toggle();
+      }
+    });
+
+    this.settingComponent.onToggle.subscribe(() => this.updateAriaChecked());
+    this.updateAriaChecked();
+  }
+
+  private updateAriaChecked(): void {
+    this.getDomElement().attr('aria-checked', this.settingComponent.isOn() ? 'true' : 'false');
+  }
+}

--- a/src/ts/components/settings/ToggleSettingsPanelItem.ts
+++ b/src/ts/components/settings/ToggleSettingsPanelItem.ts
@@ -42,10 +42,17 @@ export class ToggleSettingsPanelItem extends InteractiveSettingsPanelItem<Toggle
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    // Keyboard selection belongs to the row, otherwise Enter/Space can activate both the button and the row.
+    // Keyboard and click selection belong to the row, otherwise Enter/Space or click can toggle twice.
     this.settingComponent.getDomElement().attr('tabindex', '-1');
-    // The button handles its own click; keep that click from bubbling into the row and toggling twice.
-    this.settingComponent.getDomElement().on('click', event => event.stopPropagation());
+    this.settingComponent.getDomElement().on(
+      'click',
+      event => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        this.onClickEvent();
+      },
+      true,
+    );
 
     this.onClick.subscribe(() => {
       if (!this.settingComponent.isDisabled()) {

--- a/src/ts/components/settings/ToggleSettingsPanelItem.ts
+++ b/src/ts/components/settings/ToggleSettingsPanelItem.ts
@@ -42,8 +42,9 @@ export class ToggleSettingsPanelItem extends InteractiveSettingsPanelItem<Toggle
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    // Keyboard and click selection belong to the row, otherwise Enter/Space or click can toggle twice.
+    // Keyboard, click, and accessibility semantics belong to the row. Disabling it on the ToggleButton explicitly.
     this.settingComponent.getDomElement().attr('tabindex', '-1');
+    this.settingComponent.setAriaAttr('hidden', 'true');
     this.settingComponent.getDomElement().on(
       'click',
       event => {

--- a/src/ts/components/settings/ToggleSettingsPanelItem.ts
+++ b/src/ts/components/settings/ToggleSettingsPanelItem.ts
@@ -54,6 +54,10 @@ export class ToggleSettingsPanelItem extends InteractiveSettingsPanelItem<Toggle
       },
       true,
     );
+    // Mirror the disabled state from the ToggleButton to the row
+    const updateDisabledState = () => {
+      this.setAriaAttr('disabled', this.settingComponent.isDisabled() ? 'true' : 'false');
+    };
 
     this.onClick.subscribe(() => {
       if (!this.settingComponent.isDisabled()) {
@@ -62,7 +66,10 @@ export class ToggleSettingsPanelItem extends InteractiveSettingsPanelItem<Toggle
     });
 
     this.settingComponent.onToggle.subscribe(() => this.updateAriaChecked());
+    this.settingComponent.onDisabled.subscribe(updateDisabledState);
+    this.settingComponent.onEnabled.subscribe(updateDisabledState);
     this.updateAriaChecked();
+    updateDisabledState();
   }
 
   private updateAriaChecked(): void {

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -137,6 +137,7 @@ export {
   DynamicSettingsPanelItem,
   DynamicSettingsPanelItemConfig,
 } from './components/settings/DynamicSettingsPanelItem';
+export { ToggleSettingsPanelItem, ToggleSettingsPanelItemConfig } from './components/settings/ToggleSettingsPanelItem';
 export { ReplayButton } from './components/buttons/ReplayButton';
 export { QuickSeekButton, QuickSeekButtonConfig } from './components/buttons/QuickSeekButton';
 export {

--- a/src/ts/spatialnavigation/SettingsPanelNavigationGroup.ts
+++ b/src/ts/spatialnavigation/SettingsPanelNavigationGroup.ts
@@ -2,8 +2,7 @@ import { NavigationGroup } from './NavigationGroup';
 import { Action, Focusable } from './types';
 import { SettingsPanel, SettingsPanelConfig } from '../components/settings/SettingsPanel';
 import { resolveAllComponents } from './helper/resolveAllComponents';
-import { SettingsPanelSelectOption } from '../components/settings/SettingsPanelSelectOption';
-import { DynamicSettingsPanelItem } from '../components/settings/DynamicSettingsPanelItem';
+import { InteractiveSettingsPanelItem } from '../components/settings/InteractiveSettingsPanelItem';
 
 export class SettingsPanelNavigationGroupConfig {
   /**
@@ -57,9 +56,7 @@ export class SettingsPanelNavigationGroup extends NavigationGroup {
 
     const componentsToConsider: Focusable[] = [];
     pageComponents.forEach(component => {
-      if (component instanceof SettingsPanelSelectOption) {
-        componentsToConsider.push(component);
-      } else if (component instanceof DynamicSettingsPanelItem) {
+      if (component instanceof InteractiveSettingsPanelItem) {
         componentsToConsider.push(component);
       } else {
         componentsToConsider.push(...resolveAllComponents(component));


### PR DESCRIPTION
## Description
Introduce `ToggleSettingsPanelItem`, a settings row that toggles its nested `ToggleButton` when the row is selected. Use it for the existing eco-mode settings toggle and keep spatial navigation focused on interactive settings rows.

## Manual Testing
Enable `ecoMode: true,` in the `UIConfig` for easier manual testing.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry