### PR TITLE
adcounterlabel: if there is only one ad, show a different message so we never show "ad 1 of 1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- New `AdCounterLabelConfig.adLabelIfOneAd` option: message shown while an ad is playing when the ad break contains only a single ad.
+
+### Changed
+
+- `AdCounterLabel` now displays the `adLabelIfOneAd` message ("Advertisement") for single-ad ad breaks instead of the "Ad 1 of 1" count.
+
 ## [4.17.0] - 2026-07-02
 
 ### Added

--- a/spec/components/ads/AdCounterLabel.spec.ts
+++ b/spec/components/ads/AdCounterLabel.spec.ts
@@ -47,4 +47,20 @@ describe('AdCounterLabel', () => {
     adCountChangedDispatcher.dispatch(null, { currentAdIndex: 0, totalNumberOfAds: 0 });
     expect(adCounterLabel.getText()).toBe('');
   });
+
+  it('shows the single-ad label when the ad break contains only one ad', () => {
+    adCounterLabel = new AdCounterLabel({ adLabelIfOneAd: 'Anzeige' });
+    adCounterLabel.configure(playerMock, uiInstanceManagerMock);
+
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 1 });
+    expect(adCounterLabel.getText()).toBe('Anzeige');
+  });
+
+  it('falls back to the default localized single-ad label', () => {
+    adCounterLabel = new AdCounterLabel();
+    adCounterLabel.configure(playerMock, uiInstanceManagerMock);
+
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 1 });
+    expect(adCounterLabel.getText()).toBe('Advertisement');
+  });
 });

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -12,6 +12,11 @@ export interface AdCounterLabelConfig extends LabelConfig {
    * Supported placeholders: look at {@link StringUtils.replaceAdMessagePlaceholders}
    */
   adCountOutOfTotal?: LocalizableText;
+  /**
+   * Message displayed during an ad if only one ad is in the adbreak.
+   * Supported placeholders: look at {@link StringUtils.replaceAdMessagePlaceholders}
+   */
+  adLabelIfOneAd?: LocalizableText;
 }
 
 /**
@@ -31,6 +36,7 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
       {
         cssClass: 'ui-label-ad-counter',
         adCountOutOfTotal: i18n.getLocalizer('ads.adNumberOfTotal'),
+        adLabelIfOneAd: i18n.getLocalizer('ads.adLabelIfOne'),
       },
       this.config,
     );
@@ -79,14 +85,13 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
       return;
     }
 
+    const message =
+      totalNumberOfAds > 1
+        ? i18n.performLocalization(this.config.adCountOutOfTotal)
+        : i18n.performLocalization(this.config.adLabelIfOneAd);
+
     this.setText(
-      StringUtils.replaceAdMessagePlaceholders(
-        i18n.performLocalization(this.config.adCountOutOfTotal),
-        this.player,
-        undefined,
-        currentAdIndex,
-        totalNumberOfAds,
-      ),
+      StringUtils.replaceAdMessagePlaceholders(message, this.player, undefined, currentAdIndex, totalNumberOfAds),
     );
   }
 }

--- a/src/ts/localization/i18n.ts
+++ b/src/ts/localization/i18n.ts
@@ -95,6 +95,7 @@ export interface Vocabulary {
   'ads.skip': string;
   'ads.skippableIn': string;
   'ads.adNumberOfTotal': string;
+  'ads.adLabelIfOne': string;
   pictureInPicture: string;
   appleAirplay: string;
   googleCast: string;

--- a/src/ts/localization/languages/de.json
+++ b/src/ts/localization/languages/de.json
@@ -48,6 +48,7 @@
   "ads.skip": "Überspringen",
   "ads.skippableIn": "Überspringen in {remainingTime}",
   "ads.adNumberOfTotal": "Anzeige {activeAdIndex} von {totalAdsCount}",
+  "ads.adLabelIfOne": "Anzeige",
   "settings": "Einstellungen",
   "fullscreen": "Vollbild",
   "speed": "Geschwindigkeit",

--- a/src/ts/localization/languages/en.json
+++ b/src/ts/localization/languages/en.json
@@ -48,6 +48,7 @@
   "ads.skip": "Skip",
   "ads.skippableIn": "Skip ad in {remainingTime}",
   "ads.adNumberOfTotal": "Ad {activeAdIndex} of {totalAdsCount}",
+  "ads.adLabelIfOne": "Advertisement",
   "settings": "Settings",
   "fullscreen": "Fullscreen",
   "speed": "Speed",

--- a/src/ts/localization/languages/es.json
+++ b/src/ts/localization/languages/es.json
@@ -48,6 +48,7 @@
   "ads.skip": "Saltar",
   "ads.skippableIn": "Saltar anuncio en {remainingTime}",
   "ads.adNumberOfTotal": "Anuncio {activeAdIndex} de {totalAdsCount}",
+  "ads.adLabelIfOne": "Anuncio",
   "settings": "Configuración",
   "fullscreen": "Pantalla Completa",
   "speed": "Velocidad",

--- a/src/ts/localization/languages/fr.json
+++ b/src/ts/localization/languages/fr.json
@@ -48,6 +48,7 @@
   "ads.skip": "Passer",
   "ads.skippableIn": "Passer l'annonce dans {remainingTime}",
   "ads.adNumberOfTotal": "Annonce {activeAdIndex} sur {totalAdsCount}",
+  "ads.adLabelIfOne": "Annonce",
   "settings": "Réglages",
   "fullscreen": "Plein écran",
   "speed": "Vitesse",

--- a/src/ts/localization/languages/nl.json
+++ b/src/ts/localization/languages/nl.json
@@ -48,6 +48,7 @@
   "ads.skip": "Overslaan",
   "ads.skippableIn": "Advertentie overslaan over {remainingTime}",
   "ads.adNumberOfTotal": "Advertentie {activeAdIndex} van {totalAdsCount}",
+  "ads.adLabelIfOne": "Advertentie",
   "settings": "Instellingen",
   "fullscreen": "Volledig scherm",
   "speed": "Snelheid",

--- a/src/ts/localization/languages/pt.json
+++ b/src/ts/localization/languages/pt.json
@@ -48,6 +48,7 @@
   "ads.skip": "Ignorar",
   "ads.skippableIn": "Ignorar anúncio em {remainingTime}",
   "ads.adNumberOfTotal": "Anúncio {activeAdIndex} de {totalAdsCount}",
+  "ads.adLabelIfOne": "Anúncio",
   "settings": "Definições",
   "fullscreen": "Ecrã inteiro",
   "speed": "Velocidade",


### PR DESCRIPTION
## Description
Instead of displaying "Ad 1 of 1" the adcounterlabel should display a seperate, configurable text. Typically just "Ad"

the translations are my best guess

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
