### PR TITLE
Make live indicator keyboard accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- The LIVE indicator can now be focused and activated with Enter or Space to return to the live edge.
+
 ## [4.17.0] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `live.jumpToLiveEdge` localization key for the LIVE indicator's accessible name; interpolates the `live` label via `{liveLabel}`.
+
 ### Fixed
 
 - The LIVE indicator can now be focused and activated with Enter or Space to return to the live edge.

--- a/spec/components/labels/PlaybackTimeLabel.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabel.spec.ts
@@ -24,6 +24,79 @@ describe('PlaybackTimeLabel', () => {
       playbackTimeLabel = new PlaybackTimeLabel();
     });
 
+    describe('keyboard accessibility', () => {
+      let mockDomElement: ReturnType<typeof MockHelper.generateDOMMock>;
+
+      beforeEach(() => {
+        mockDomElement = MockHelper.generateDOMMock();
+        jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
+
+        playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+      });
+
+      it('exposes the live indicator as an accessible button', () => {
+        expect(mockDomElement.attr).toHaveBeenCalledWith('tabindex', '0');
+        expect(mockDomElement.attr).toHaveBeenCalledWith('role', 'button');
+        expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'Jump to live edge');
+      });
+
+      it.each(['Enter', ' '])('jumps to the live edge when pressing %p', key => {
+        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
+          event: KeyboardEvent,
+        ) => void;
+        const keyboardEvent = {
+          key,
+          preventDefault: jest.fn(),
+        } as unknown as KeyboardEvent;
+
+        expect(keydownHandler).toEqual(expect.any(Function));
+        keydownHandler(keyboardEvent);
+
+        expect(keyboardEvent.preventDefault).toHaveBeenCalled();
+        expect(playerMock.timeShift).toHaveBeenCalledWith(0);
+      });
+
+      it('ignores unrelated keys', () => {
+        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
+          event: KeyboardEvent,
+        ) => void;
+        const keyboardEvent = {
+          key: 'ArrowRight',
+          preventDefault: jest.fn(),
+        } as unknown as KeyboardEvent;
+
+        keydownHandler(keyboardEvent);
+
+        expect(keyboardEvent.preventDefault).not.toHaveBeenCalled();
+        expect(playerMock.timeShift).not.toHaveBeenCalled();
+      });
+
+      it('restores non-interactive semantics when switching to VOD', () => {
+        jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
+
+        playerMock.eventEmitter.fireDurationChangedEvent();
+
+        expect(mockDomElement.attr).toHaveBeenCalledWith('tabindex', '-1');
+        expect(mockDomElement.removeAttr).toHaveBeenCalledWith('role');
+        expect(mockDomElement.removeAttr).toHaveBeenCalledWith('aria-label');
+        expect(mockDomElement.off).toHaveBeenCalledWith('keydown', expect.any(Function));
+      });
+    });
+
+    it('restores the configured tab index when switching to VOD', () => {
+      const mockDomElement = MockHelper.generateDOMMock();
+      playbackTimeLabel = new PlaybackTimeLabel({
+        tabIndex: 2,
+      });
+      jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
+      playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+      jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
+
+      playerMock.eventEmitter.fireDurationChangedEvent();
+
+      expect(mockDomElement.attr).toHaveBeenCalledWith('tabindex', '2');
+    });
+
     describe('switch to inactive', () => {
       let removeClassSpy: any;
       beforeEach(() => {

--- a/spec/components/labels/PlaybackTimeLabel.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabel.spec.ts
@@ -72,6 +72,7 @@ describe('PlaybackTimeLabel', () => {
       });
 
       it('restores non-interactive semantics when switching to VOD', () => {
+        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1];
         jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
 
         playerMock.eventEmitter.fireDurationChangedEvent();
@@ -79,7 +80,7 @@ describe('PlaybackTimeLabel', () => {
         expect(mockDomElement.attr).toHaveBeenCalledWith('tabindex', '-1');
         expect(mockDomElement.removeAttr).toHaveBeenCalledWith('role');
         expect(mockDomElement.removeAttr).toHaveBeenCalledWith('aria-label');
-        expect(mockDomElement.off).toHaveBeenCalledWith('keydown', expect.any(Function));
+        expect(mockDomElement.off).toHaveBeenCalledWith('keydown', keydownHandler);
       });
     });
 

--- a/spec/components/labels/PlaybackTimeLabel.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabel.spec.ts
@@ -27,6 +27,12 @@ describe('PlaybackTimeLabel', () => {
     describe('keyboard accessibility', () => {
       let mockDomElement: ReturnType<typeof MockHelper.generateDOMMock>;
 
+      const getKeydownHandler = (): ((event: KeyboardEvent) => void) => {
+        const handler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1];
+        expect(handler).toEqual(expect.any(Function));
+        return handler as (event: KeyboardEvent) => void;
+      };
+
       beforeEach(() => {
         mockDomElement = MockHelper.generateDOMMock();
         jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
@@ -37,19 +43,16 @@ describe('PlaybackTimeLabel', () => {
       it('exposes the live indicator as an accessible button', () => {
         expect(mockDomElement.attr).toHaveBeenCalledWith('tabindex', '0');
         expect(mockDomElement.attr).toHaveBeenCalledWith('role', 'button');
-        expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'Jump to live edge');
+        expect(mockDomElement.attr).toHaveBeenCalledWith('aria-label', 'Live, jump to live edge');
       });
 
       it.each(['Enter', ' '])('jumps to the live edge when pressing %p', key => {
-        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
-          event: KeyboardEvent,
-        ) => void;
+        const keydownHandler = getKeydownHandler();
         const keyboardEvent = {
           key,
           preventDefault: jest.fn(),
         } as unknown as KeyboardEvent;
 
-        expect(keydownHandler).toEqual(expect.any(Function));
         keydownHandler(keyboardEvent);
 
         expect(keyboardEvent.preventDefault).toHaveBeenCalled();
@@ -57,9 +60,7 @@ describe('PlaybackTimeLabel', () => {
       });
 
       it('jumps to the live edge when Space is reported through the event code', () => {
-        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
-          event: KeyboardEvent,
-        ) => void;
+        const keydownHandler = getKeydownHandler();
         const keyboardEvent = {
           key: 'Unidentified',
           code: 'Space',
@@ -73,9 +74,7 @@ describe('PlaybackTimeLabel', () => {
       });
 
       it('prevents repeated activation keys without jumping to the live edge again', () => {
-        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
-          event: KeyboardEvent,
-        ) => void;
+        const keydownHandler = getKeydownHandler();
         const keyboardEvent = {
           key: ' ',
           code: 'Space',
@@ -90,9 +89,7 @@ describe('PlaybackTimeLabel', () => {
       });
 
       it('ignores unrelated keys', () => {
-        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
-          event: KeyboardEvent,
-        ) => void;
+        const keydownHandler = getKeydownHandler();
         const keyboardEvent = {
           key: 'ArrowRight',
           preventDefault: jest.fn(),
@@ -105,7 +102,7 @@ describe('PlaybackTimeLabel', () => {
       });
 
       it('restores non-interactive semantics when switching to VOD', () => {
-        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1];
+        const keydownHandler = getKeydownHandler();
         jest.spyOn(playerMock, 'isLive').mockReturnValue(false);
 
         playerMock.eventEmitter.fireDurationChangedEvent();
@@ -115,6 +112,20 @@ describe('PlaybackTimeLabel', () => {
         expect(mockDomElement.removeAttr).toHaveBeenCalledWith('aria-label');
         expect(mockDomElement.off).toHaveBeenCalledWith('keydown', keydownHandler);
       });
+    });
+
+    it('does not enable live interaction when configured to hide during live playback', () => {
+      const mockDomElement = MockHelper.generateDOMMock();
+      playbackTimeLabel = new PlaybackTimeLabel({ hideInLivePlayback: true });
+      const subscribeSpy = jest.spyOn(playbackTimeLabel.onClick, 'subscribe');
+      jest.spyOn(playbackTimeLabel, 'getDomElement').mockReturnValue(mockDomElement);
+
+      playbackTimeLabel.configure(playerMock, uiInstanceManagerMock);
+
+      expect(subscribeSpy).not.toHaveBeenCalled();
+      expect(mockDomElement.attr).not.toHaveBeenCalledWith('tabindex', '0');
+      expect(mockDomElement.attr).not.toHaveBeenCalledWith('role', 'button');
+      expect(mockDomElement.on).not.toHaveBeenCalledWith('keydown', expect.any(Function));
     });
 
     it('restores the configured tab index when switching to VOD', () => {

--- a/spec/components/labels/PlaybackTimeLabel.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabel.spec.ts
@@ -56,6 +56,39 @@ describe('PlaybackTimeLabel', () => {
         expect(playerMock.timeShift).toHaveBeenCalledWith(0);
       });
 
+      it('jumps to the live edge when Space is reported through the event code', () => {
+        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
+          event: KeyboardEvent,
+        ) => void;
+        const keyboardEvent = {
+          key: 'Unidentified',
+          code: 'Space',
+          preventDefault: jest.fn(),
+        } as unknown as KeyboardEvent;
+
+        keydownHandler(keyboardEvent);
+
+        expect(keyboardEvent.preventDefault).toHaveBeenCalled();
+        expect(playerMock.timeShift).toHaveBeenCalledWith(0);
+      });
+
+      it('prevents repeated activation keys without jumping to the live edge again', () => {
+        const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
+          event: KeyboardEvent,
+        ) => void;
+        const keyboardEvent = {
+          key: ' ',
+          code: 'Space',
+          repeat: true,
+          preventDefault: jest.fn(),
+        } as unknown as KeyboardEvent;
+
+        keydownHandler(keyboardEvent);
+
+        expect(keyboardEvent.preventDefault).toHaveBeenCalled();
+        expect(playerMock.timeShift).not.toHaveBeenCalled();
+      });
+
       it('ignores unrelated keys', () => {
         const keydownHandler = mockDomElement.on.mock.calls.find(([eventName]) => eventName === 'keydown')?.[1] as (
           event: KeyboardEvent,

--- a/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
@@ -2,17 +2,32 @@ import childProcess = require('child_process');
 import path = require('path');
 
 describe('PlaybackTimeLabel styles', () => {
+  const sassExecutable = path.resolve(path.dirname(require.resolve('sass')), 'sass.js');
   const css = childProcess.execFileSync(
-    path.resolve(process.cwd(), 'node_modules/.bin/sass'),
-    ['--no-source-map', path.resolve(process.cwd(), 'src/scss/bitmovinplayer-ui.scss')],
+    process.execPath,
+    [sassExecutable, '--no-source-map', path.resolve(process.cwd(), 'src/scss/bitmovinplayer-ui.scss')],
     { encoding: 'utf8' },
   );
+
+  const getCssProperty = (selector: string, property: string): string => {
+    const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const declarations = css.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`))?.[1];
+    const value = declarations?.match(new RegExp(`${property}:\\s*([^;]+);`))?.[1];
+
+    if (value == null) {
+      throw new Error(`Could not find ${property} for ${selector} in compiled CSS`);
+    }
+
+    return value;
+  };
 
   it('renders a visible keyboard focus state for the live indicator', () => {
     expect(css).toMatch(/\.bmpui-ui-playbacktimelabel\.bmpui-ui-playbacktimelabel-live\.bmpui-focus-visible\s*\{/);
   });
 
   it('adds button-sized spacing around the live indicator', () => {
-    expect(css).toMatch(/\.bmpui-ui-playbacktimelabel\.bmpui-ui-playbacktimelabel-live\s*\{[^}]*padding:\s*0\.375rem;/);
+    expect(getCssProperty('.bmpui-ui-playbacktimelabel.bmpui-ui-playbacktimelabel-live', 'padding')).toBe(
+      getCssProperty('.bmpui-ui-button', 'padding'),
+    );
   });
 });

--- a/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
@@ -1,11 +1,15 @@
-import childProcess = require('child_process');
-import path = require('path');
+import * as childProcess from 'child_process';
+import * as path from 'path';
 
 describe('PlaybackTimeLabel styles', () => {
-  const sassExecutable = path.resolve(path.dirname(require.resolve('sass')), 'sass.js');
+  // Sass's filesystem access is incompatible with this repository's Jest runtime, so compile in a clean Node process.
   const css = childProcess.execFileSync(
     process.execPath,
-    [sassExecutable, '--no-source-map', path.resolve(process.cwd(), 'src/scss/bitmovinplayer-ui.scss')],
+    [
+      '-e',
+      "process.stdout.write(require('sass').compile(process.argv[1]).css)",
+      path.resolve(process.cwd(), 'src/scss/bitmovinplayer-ui.scss'),
+    ],
     { encoding: 'utf8' },
   );
 

--- a/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
@@ -2,13 +2,17 @@ import childProcess = require('child_process');
 import path = require('path');
 
 describe('PlaybackTimeLabel styles', () => {
-  it('renders a visible keyboard focus state for the live indicator', () => {
-    const css = childProcess.execFileSync(
-      path.resolve(process.cwd(), 'node_modules/.bin/sass'),
-      ['--no-source-map', path.resolve(process.cwd(), 'src/scss/bitmovinplayer-ui.scss')],
-      { encoding: 'utf8' },
-    );
+  const css = childProcess.execFileSync(
+    path.resolve(process.cwd(), 'node_modules/.bin/sass'),
+    ['--no-source-map', path.resolve(process.cwd(), 'src/scss/bitmovinplayer-ui.scss')],
+    { encoding: 'utf8' },
+  );
 
+  it('renders a visible keyboard focus state for the live indicator', () => {
     expect(css).toMatch(/\.bmpui-ui-playbacktimelabel\.bmpui-ui-playbacktimelabel-live\.bmpui-focus-visible\s*\{/);
+  });
+
+  it('adds button-sized spacing around the live indicator', () => {
+    expect(css).toMatch(/\.bmpui-ui-playbacktimelabel\.bmpui-ui-playbacktimelabel-live\s*\{[^}]*padding:\s*0\.375rem;/);
   });
 });

--- a/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
@@ -1,0 +1,14 @@
+import childProcess = require('child_process');
+import path = require('path');
+
+describe('PlaybackTimeLabel styles', () => {
+  it('renders a visible keyboard focus state for the live indicator', () => {
+    const css = childProcess.execFileSync(
+      path.resolve(process.cwd(), 'node_modules/.bin/sass'),
+      ['--no-source-map', path.resolve(process.cwd(), 'src/scss/bitmovinplayer-ui.scss')],
+      { encoding: 'utf8' },
+    );
+
+    expect(css).toMatch(/\.bmpui-ui-playbacktimelabel\.bmpui-ui-playbacktimelabel-live\.bmpui-focus-visible\s*\{/);
+  });
+});

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -87,6 +87,7 @@ export namespace MockHelper {
       empty: jest.fn(),
       append: jest.fn(),
       attr: jest.fn(),
+      removeAttr: jest.fn(),
       get: jest.fn(),
     };
 
@@ -145,6 +146,7 @@ export namespace MockHelper {
         isCasting: jest.fn(),
         isViewModeAvailable: jest.fn(),
         seek: jest.fn(),
+        timeShift: jest.fn(),
         isMuted: jest.fn(),
         mute: jest.fn(),
         unmute: jest.fn(),

--- a/spec/localization/Localization.spec.ts
+++ b/spec/localization/Localization.spec.ts
@@ -85,6 +85,16 @@ describe('Localization', () => {
     it('injects the value to string passed by config', () => {
       expect(i18n.performLocalization(i18n.getLocalizer('variableTest', { value: 1 }))).toEqual('1');
     });
+
+    Object.entries(defaultVocabularies).forEach(([language, vocabulary]) => {
+      it(`includes the visible live label in the ${language} live action label`, () => {
+        i18n.setConfig({ language, vocabularies: defaultVocabularies });
+        const liveLabel = i18n.performLocalization(i18n.getLocalizer('live'));
+        const liveActionLabel = i18n.performLocalization(i18n.getLocalizer('live.jumpToLiveEdge', { liveLabel }));
+
+        expect(liveActionLabel).toContain(liveLabel);
+      });
+    });
   });
 
   describe('setLanguage', () => {

--- a/src/scss/components/labels/_playback-time-label.scss
+++ b/src/scss/components/labels/_playback-time-label.scss
@@ -7,6 +7,8 @@
   text-transform: uppercase;
 
   &.#{$prefix}-ui-playbacktimelabel-live {
+    @include focusable;
+
     cursor: pointer;
 
     &::before {

--- a/src/scss/components/labels/_playback-time-label.scss
+++ b/src/scss/components/labels/_playback-time-label.scss
@@ -10,6 +10,7 @@
     @include focusable;
 
     cursor: pointer;
+    padding: calc($icon-size * 0.25);
 
     &::before {
       color: $color-secondary;

--- a/src/ts/components/labels/PlaybackTimeLabel.ts
+++ b/src/ts/components/labels/PlaybackTimeLabel.ts
@@ -77,6 +77,29 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       player.timeShift(0);
     };
 
+    const liveKeyDownHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        liveClickHandler();
+      }
+    };
+
+    const enableLiveInteraction = () => {
+      const domElement = this.getDomElement();
+      domElement.attr('tabindex', '0');
+      domElement.attr('role', 'button');
+      this.setAriaLabel(i18n.getLocalizer('live.jumpToLiveEdge'));
+      domElement.on('keydown', liveKeyDownHandler);
+    };
+
+    const disableLiveInteraction = () => {
+      const domElement = this.getDomElement();
+      domElement.attr('tabindex', config.tabIndex.toString());
+      domElement.removeAttr('role');
+      domElement.removeAttr('aria-label');
+      domElement.off('keydown', liveKeyDownHandler);
+    };
+
     const updateLiveState = () => {
       // Player is playing a live stream when the duration is infinite
       live = player.isLive();
@@ -89,12 +112,14 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
           this.hide();
         }
         this.onClick.subscribe(liveClickHandler);
+        enableLiveInteraction();
         updateLiveTimeshiftState();
       } else {
         this.getDomElement().removeClass(liveCssClass);
         this.getDomElement().removeClass(liveEdgeCssClass);
         this.show();
         this.onClick.unsubscribe(liveClickHandler);
+        disableLiveInteraction();
       }
     };
 

--- a/src/ts/components/labels/PlaybackTimeLabel.ts
+++ b/src/ts/components/labels/PlaybackTimeLabel.ts
@@ -78,9 +78,12 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
     };
 
     const liveKeyDownHandler = (event: KeyboardEvent) => {
-      if (event.key === 'Enter' || event.key === ' ') {
+      const isActivationKey = event.key === 'Enter' || event.key === ' ' || event.code === 'Space';
+      if (isActivationKey) {
         event.preventDefault();
-        liveClickHandler();
+        if (!event.repeat) {
+          liveClickHandler();
+        }
       }
     };
 

--- a/src/ts/components/labels/PlaybackTimeLabel.ts
+++ b/src/ts/components/labels/PlaybackTimeLabel.ts
@@ -88,6 +88,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       const domElement = this.getDomElement();
       domElement.attr('tabindex', '0');
       domElement.attr('role', 'button');
+      // Describe the action rather than the displayed live state for assistive technologies.
       this.setAriaLabel(i18n.getLocalizer('live.jumpToLiveEdge'));
       domElement.on('keydown', liveKeyDownHandler);
     };

--- a/src/ts/components/labels/PlaybackTimeLabel.ts
+++ b/src/ts/components/labels/PlaybackTimeLabel.ts
@@ -91,8 +91,10 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       const domElement = this.getDomElement();
       domElement.attr('tabindex', '0');
       domElement.attr('role', 'button');
-      // Describe the action rather than the displayed live state for assistive technologies.
-      this.setAriaLabel(i18n.getLocalizer('live.jumpToLiveEdge'));
+      // Keep the visible label in the accessible name so speech input can target the control.
+      const liveLabel = i18n.performLocalization(i18n.getLocalizer('live'));
+      this.setAriaLabel(i18n.getLocalizer('live.jumpToLiveEdge', { liveLabel }));
+      this.onClick.subscribe(liveClickHandler);
       domElement.on('keydown', liveKeyDownHandler);
     };
 
@@ -101,6 +103,7 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
       domElement.attr('tabindex', config.tabIndex.toString());
       domElement.removeAttr('role');
       domElement.removeAttr('aria-label');
+      this.onClick.unsubscribe(liveClickHandler);
       domElement.off('keydown', liveKeyDownHandler);
     };
 
@@ -114,15 +117,14 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
         this.setText(i18n.getLocalizer('live'));
         if (config.hideInLivePlayback) {
           this.hide();
+        } else {
+          enableLiveInteraction();
         }
-        this.onClick.subscribe(liveClickHandler);
-        enableLiveInteraction();
         updateLiveTimeshiftState();
       } else {
         this.getDomElement().removeClass(liveCssClass);
         this.getDomElement().removeClass(liveEdgeCssClass);
         this.show();
-        this.onClick.unsubscribe(liveClickHandler);
         disableLiveInteraction();
       }
     };

--- a/src/ts/localization/i18n.ts
+++ b/src/ts/localization/i18n.ts
@@ -112,6 +112,7 @@ export interface Vocabulary {
   speed: string;
   playPause: string;
   live: string;
+  'live.jumpToLiveEdge': string;
   'subtitle.example': string;
   'subtitle.select': string;
   playingOn: string;

--- a/src/ts/localization/languages/de.json
+++ b/src/ts/localization/languages/de.json
@@ -71,6 +71,7 @@
   "normal": "normal",
   "default": "standard",
   "live": "Live",
+  "live.jumpToLiveEdge": "Zum Live-Punkt springen",
   "subtitle.example": "Beispiel Untertitel",
   "subtitle.select": "Untertitel auswählen",
   "playingOn": "Spielt auf <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/de.json
+++ b/src/ts/localization/languages/de.json
@@ -71,7 +71,7 @@
   "normal": "normal",
   "default": "standard",
   "live": "Live",
-  "live.jumpToLiveEdge": "Zum Live-Punkt springen",
+  "live.jumpToLiveEdge": "{liveLabel}, zum Live-Punkt springen",
   "subtitle.example": "Beispiel Untertitel",
   "subtitle.select": "Untertitel auswählen",
   "playingOn": "Spielt auf <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/en.json
+++ b/src/ts/localization/languages/en.json
@@ -71,6 +71,7 @@
   "normal": "normal",
   "default": "default",
   "live": "Live",
+  "live.jumpToLiveEdge": "Jump to live edge",
   "subtitle.example": "example subtitle",
   "subtitle.select": "Select subtitle",
   "playingOn": "Playing on <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/en.json
+++ b/src/ts/localization/languages/en.json
@@ -71,7 +71,7 @@
   "normal": "normal",
   "default": "default",
   "live": "Live",
-  "live.jumpToLiveEdge": "Jump to live edge",
+  "live.jumpToLiveEdge": "{liveLabel}, jump to live edge",
   "subtitle.example": "example subtitle",
   "subtitle.select": "Select subtitle",
   "playingOn": "Playing on <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/es.json
+++ b/src/ts/localization/languages/es.json
@@ -71,7 +71,7 @@
   "normal": "normal",
   "default": "predeterminado",
   "live": "Directo",
-  "live.jumpToLiveEdge": "Saltar al punto en directo",
+  "live.jumpToLiveEdge": "{liveLabel}, saltar al punto en directo",
   "subtitle.example": "Ejemplo de Subtítulo",
   "subtitle.select": "Seleccionar subtítulo",
   "playingOn": "Reproduciendo en <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/es.json
+++ b/src/ts/localization/languages/es.json
@@ -71,6 +71,7 @@
   "normal": "normal",
   "default": "predeterminado",
   "live": "Directo",
+  "live.jumpToLiveEdge": "Saltar al punto en directo",
   "subtitle.example": "Ejemplo de Subtítulo",
   "subtitle.select": "Seleccionar subtítulo",
   "playingOn": "Reproduciendo en <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/fr.json
+++ b/src/ts/localization/languages/fr.json
@@ -71,6 +71,7 @@
   "normal": "normale",
   "default": "défaut",
   "live": "En direct",
+  "live.jumpToLiveEdge": "Aller au direct",
   "subtitle.example": "exemple de sous-titre",
   "subtitle.select": "Sélectionner un sous-titre",
   "playingOn": "Lecture sur <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/fr.json
+++ b/src/ts/localization/languages/fr.json
@@ -71,7 +71,7 @@
   "normal": "normale",
   "default": "défaut",
   "live": "En direct",
-  "live.jumpToLiveEdge": "Aller au direct",
+  "live.jumpToLiveEdge": "{liveLabel}, aller au direct",
   "subtitle.example": "exemple de sous-titre",
   "subtitle.select": "Sélectionner un sous-titre",
   "playingOn": "Lecture sur <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/nl.json
+++ b/src/ts/localization/languages/nl.json
@@ -71,6 +71,7 @@
   "normal": "normaal",
   "default": "standaard",
   "live": "Live",
+  "live.jumpToLiveEdge": "Naar live springen",
   "subtitle.example": "voorbeeld ondertiteling",
   "subtitle.select": "Selecteer ondertiteling",
   "playingOn": "Speelt af op <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/nl.json
+++ b/src/ts/localization/languages/nl.json
@@ -71,7 +71,7 @@
   "normal": "normaal",
   "default": "standaard",
   "live": "Live",
-  "live.jumpToLiveEdge": "Naar live springen",
+  "live.jumpToLiveEdge": "{liveLabel}, naar live springen",
   "subtitle.example": "voorbeeld ondertiteling",
   "subtitle.select": "Selecteer ondertiteling",
   "playingOn": "Speelt af op <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/pt.json
+++ b/src/ts/localization/languages/pt.json
@@ -71,6 +71,7 @@
   "normal": "normal",
   "default": "predefinição",
   "live": "Ao Vivo",
+  "live.jumpToLiveEdge": "Ir para a transmissão ao vivo",
   "subtitle.example": "exemplo de legenda",
   "subtitle.select": "Selecionar legenda",
   "playingOn": "A reproduzir em <strong>{castDeviceName}</strong>",

--- a/src/ts/localization/languages/pt.json
+++ b/src/ts/localization/languages/pt.json
@@ -71,7 +71,7 @@
   "normal": "normal",
   "default": "predefinição",
   "live": "Ao Vivo",
-  "live.jumpToLiveEdge": "Ir para a transmissão ao vivo",
+  "live.jumpToLiveEdge": "{liveLabel}, ir para a transmissão ao vivo",
   "subtitle.example": "exemplo de legenda",
   "subtitle.select": "Selecionar legenda",
   "playingOn": "A reproduzir em <strong>{castDeviceName}</strong>",


### PR DESCRIPTION
## Description

The LIVE button is not accessible via keyboard.

### Changes

- Make the LIVE indicator keyboard focusable and expose button semantics
  - Return to the live edge when Enter or Space is pressed
  - Add a visible, button-sized focus highlight
  - Restore non-interactive semantics when switching to VOD
- Add regression coverage for keyboard behavior, cleanup, and compiled styles

 ### Manual Testing Instructions

  1. In the Demo page, select a live video source
  1. Seek back behind the live edge
  1. Press Tab until the LIVE indicator is focused
  1. Confirm it has a clearly visible rounded focus highlight
  1. Press Enter and confirm playback returns to the live edge
  1. Move behind the live edge again, focus LIVE, and press Space
  1. Confirm playback returns to the live edge and the page does not scroll
  1. Switch to a VOD source and confirm the time label is no longer exposed as a focusable button


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
