### PR TITLE
Display ad message instead of `Ad 1 of 1` for single-ad ad breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `AdCounterLabel` now extends `AdMessageLabel` and inherits its ad-message behavior.
 - `AdCounterLabel` now displays its configured `text` for single-ad ad breaks instead of the `Ad 1 of 1` count.
-- `AdCounterLabel` is now also used in the small-screen ads UI to show the ad counter instead of the `PlaybackLabel`.
+- `AdCounterLabel` is now also used in the small-screen ads UI instead of the current-time `PlaybackTimeLabel`.
+
+### Fixed
+
+- `AdCounterLabel` now displays its configured or ad-specific message for single-ad ad breaks and when no valid current ad index is available.
 
 ## [4.18.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `AdCounterLabel` now extends `AdMessageLabel` and inherits its ad-message behavior.
 - `AdCounterLabel` now displays its configured `text` for single-ad ad breaks instead of the `Ad 1 of 1` count.
+- `AdCounterLabel` is now also used in the small-screen ads UI to show the ad counter instead of the `PlaybackLabel`.
 
 ## [4.18.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- `AdCounterLabel` now extends `AdMessageLabel` and inherits its ad-message behavior.
+- `AdCounterLabel` now displays its configured `text` for single-ad ad breaks instead of the `Ad 1 of 1` count.
+
 ## [4.18.0] - 2026-08-06
 
 ### Added

--- a/spec/components/ads/AdCounterLabel.spec.ts
+++ b/spec/components/ads/AdCounterLabel.spec.ts
@@ -1,6 +1,6 @@
 import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
 import { UIInstanceManager } from '../../../src/ts/UIManager';
-import { AdCounterLabel } from '../../../src/ts/components/ads/AdCounterLabel';
+import { AdCounterLabel, AdCounterLabelConfig } from '../../../src/ts/components/ads/AdCounterLabel';
 import { AdBreakTrackerAdCountChangedArgs } from '../../../src/ts/utils/AdBreakTracker';
 import { EventDispatcher } from '../../../src/ts/EventDispatcher';
 
@@ -25,17 +25,18 @@ describe('AdCounterLabel', () => {
 
     const config = uiInstanceManagerMock.getConfig();
     (config as any).adBreakTracker = adBreakTrackerMock;
-
-    adCounterLabel = new AdCounterLabel({ adCountOutOfTotal: 'Ad {activeAdIndex} of {totalAdsCount}' });
-    adCounterLabel.configure(playerMock, uiInstanceManagerMock);
   });
 
   it('shows the ad counter text when onAdCountChanged fires', () => {
+    configureAdCounterLabel();
+
     adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 3 });
     expect(adCounterLabel.getText()).toBe('Ad 1 of 3');
   });
 
   it('updates text when onAdCountChanged fires again with new values', () => {
+    configureAdCounterLabel();
+
     adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 3 });
     expect(adCounterLabel.getText()).toBe('Ad 1 of 3');
 
@@ -44,7 +45,51 @@ describe('AdCounterLabel', () => {
   });
 
   it('shows empty text when tracker reports reset values', () => {
+    configureAdCounterLabel();
+
     adCountChangedDispatcher.dispatch(null, { currentAdIndex: 0, totalNumberOfAds: 0 });
     expect(adCounterLabel.getText()).toBe('');
   });
+
+  it('shows the configured text when the ad break contains only one ad', () => {
+    configureAdCounterLabel({ text: 'Advertisement' });
+
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 1 });
+    expect(adCounterLabel.getText()).toBe('Advertisement');
+  });
+
+  it('falls back to the default localized text for a single-ad ad break', () => {
+    configureAdCounterLabel();
+
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 1, totalNumberOfAds: 1 });
+    expect(adCounterLabel.getText()).toBe('Ad');
+  });
+
+  it('uses the ad-specific message for a single-ad ad break', () => {
+    configureAdCounterLabel({ text: 'Advertisement' });
+    const adBreakTracker = uiInstanceManagerMock.getConfig().adBreakTracker;
+    Object.assign(adBreakTracker, { currentAdIndex: 1, totalNumberOfAds: 1 });
+
+    playerMock.eventEmitter.fireAdStartedEvent({ uiConfig: { message: 'Sponsor message' } });
+
+    expect(adCounterLabel.getText()).toBe('Sponsor message');
+  });
+
+  it('keeps showing the counter instead of the ad-specific message when multiple ads remain', () => {
+    configureAdCounterLabel();
+    const adBreakTracker = uiInstanceManagerMock.getConfig().adBreakTracker;
+    Object.assign(adBreakTracker, { currentAdIndex: 1, totalNumberOfAds: 3 });
+
+    playerMock.eventEmitter.fireAdStartedEvent({ uiConfig: { message: 'Sponsor message' } });
+
+    expect(adCounterLabel.getText()).toBe('Ad 1 of 3');
+  });
 });
+
+function configureAdCounterLabel(config: AdCounterLabelConfig = {}) {
+  adCounterLabel = new AdCounterLabel({
+    adCountOutOfTotal: 'Ad {activeAdIndex} of {totalAdsCount}',
+    ...config,
+  });
+  adCounterLabel.configure(playerMock, uiInstanceManagerMock);
+}

--- a/spec/components/ads/AdCounterLabel.spec.ts
+++ b/spec/components/ads/AdCounterLabel.spec.ts
@@ -84,6 +84,18 @@ describe('AdCounterLabel', () => {
 
     expect(adCounterLabel.getText()).toBe('Ad 1 of 3');
   });
+
+  it('falls back to the ad message when the current ad index is unavailable', () => {
+    configureAdCounterLabel({ text: 'Advertisement' });
+    const adBreakTracker = uiInstanceManagerMock.getConfig().adBreakTracker;
+    Object.assign(adBreakTracker, { currentAdIndex: 0, totalNumberOfAds: 3 });
+
+    adCountChangedDispatcher.dispatch(null, { currentAdIndex: 0, totalNumberOfAds: 3 });
+    expect(adCounterLabel.getText()).toBe('Advertisement');
+
+    playerMock.eventEmitter.fireAdStartedEvent({ uiConfig: { message: 'Sponsor message' } });
+    expect(adCounterLabel.getText()).toBe('Sponsor message');
+  });
 });
 
 function configureAdCounterLabel(config: AdCounterLabelConfig = {}) {

--- a/src/ts/UIFactory.ts
+++ b/src/ts/UIFactory.ts
@@ -485,10 +485,10 @@ export namespace UIFactory {
         components: [
           new Container({
             components: [
-              new PlaybackTimeLabel({ timeLabelMode: PlaybackTimeLabelMode.CurrentTime }),
+              new AdCounterLabel(),
               new SeekBar({ label: new SeekBarLabel() }),
               new PlaybackTimeLabel({
-                timeLabelMode: PlaybackTimeLabelMode.TotalTime,
+                timeLabelMode: PlaybackTimeLabelMode.RemainingTime,
                 cssClasses: ['text-right'],
               }),
             ],

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -1,9 +1,10 @@
 import { i18n, LocalizableText } from '../../localization/i18n';
 import { UIInstanceManager } from '../../UIManager';
-import { LabelConfig, Label } from '../labels/Label';
-import { PlayerAPI } from 'bitmovin-player';
+import { LabelConfig } from '../labels/Label';
+import { LinearAd, PlayerAPI } from 'bitmovin-player';
 import { StringUtils } from '../../utils/StringUtils';
 import { AdBreakTracker, AdBreakTrackerAdCountChangedArgs } from '../../utils/AdBreakTracker';
+import { AdMessageLabel } from './AdMessageLabel';
 
 export interface AdCounterLabelConfig extends LabelConfig {
   /**
@@ -15,11 +16,12 @@ export interface AdCounterLabelConfig extends LabelConfig {
 }
 
 /**
- * A label that displays the index of the currently playing ad out of the total number of ads.
+ * A label that displays an ad message for a single ad, or the index of the currently playing ad when multiple ads
+ * are scheduled.
  *
  * @category Labels
  */
-export class AdCounterLabel extends Label<AdCounterLabelConfig> {
+export class AdCounterLabel extends AdMessageLabel<AdCounterLabelConfig> {
   private player?: PlayerAPI;
   private adBreakTracker?: AdBreakTracker;
 
@@ -30,6 +32,7 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
       config,
       {
         cssClass: 'ui-label-ad-counter',
+        text: i18n.getLocalizer('ad'),
         adCountOutOfTotal: i18n.getLocalizer('ads.adNumberOfTotal'),
       },
       this.config,
@@ -65,6 +68,17 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
     }
   }
 
+  protected getAdMessage(player: PlayerAPI, ad?: LinearAd): string {
+    const currentAdIndex = this.adBreakTracker?.currentAdIndex;
+    const totalNumberOfAds = this.adBreakTracker?.totalNumberOfAds;
+
+    if (totalNumberOfAds > 1) {
+      return this.getAdCounterMessage(player, currentAdIndex, totalNumberOfAds);
+    }
+
+    return super.getAdMessage(player, ad);
+  }
+
   private readonly adBreakTrackerAdCountChangedHandler = (
     _: AdBreakTracker,
     adBreakTrackerEvent: AdBreakTrackerAdCountChangedArgs,
@@ -79,14 +93,21 @@ export class AdCounterLabel extends Label<AdCounterLabelConfig> {
       return;
     }
 
-    this.setText(
-      StringUtils.replaceAdMessagePlaceholders(
-        i18n.performLocalization(this.config.adCountOutOfTotal),
-        this.player,
-        undefined,
-        currentAdIndex,
-        totalNumberOfAds,
-      ),
+    if (totalNumberOfAds > 1) {
+      this.setText(this.getAdCounterMessage(this.player, currentAdIndex, totalNumberOfAds));
+      return;
+    }
+
+    this.setText(super.getAdMessage(this.player, this.player.ads?.getActiveAd?.() as LinearAd));
+  }
+
+  private getAdCounterMessage(player: PlayerAPI, currentAdIndex?: number, totalNumberOfAds?: number): string {
+    return StringUtils.replaceAdMessagePlaceholders(
+      i18n.performLocalization(this.config.adCountOutOfTotal),
+      player,
+      undefined,
+      currentAdIndex,
+      totalNumberOfAds,
     );
   }
 }

--- a/src/ts/components/ads/AdCounterLabel.ts
+++ b/src/ts/components/ads/AdCounterLabel.ts
@@ -68,12 +68,12 @@ export class AdCounterLabel extends AdMessageLabel<AdCounterLabelConfig> {
     }
   }
 
-  protected getAdMessage(player: PlayerAPI, ad?: LinearAd): string {
-    const currentAdIndex = this.adBreakTracker?.currentAdIndex;
-    const totalNumberOfAds = this.adBreakTracker?.totalNumberOfAds;
+  protected getAdMessage(player: PlayerAPI, ad?: LinearAd, currentAdIndex?: number, totalNumberOfAds?: number): string {
+    const resolvedCurrentAdIndex = currentAdIndex ?? this.adBreakTracker?.currentAdIndex;
+    const resolvedTotalNumberOfAds = totalNumberOfAds ?? this.adBreakTracker?.totalNumberOfAds;
 
-    if (totalNumberOfAds > 1) {
-      return this.getAdCounterMessage(player, currentAdIndex, totalNumberOfAds);
+    if (resolvedCurrentAdIndex > 0 && resolvedTotalNumberOfAds > 1) {
+      return this.getAdCounterMessage(player, resolvedCurrentAdIndex, resolvedTotalNumberOfAds);
     }
 
     return super.getAdMessage(player, ad);
@@ -93,12 +93,9 @@ export class AdCounterLabel extends AdMessageLabel<AdCounterLabelConfig> {
       return;
     }
 
-    if (totalNumberOfAds > 1) {
-      this.setText(this.getAdCounterMessage(this.player, currentAdIndex, totalNumberOfAds));
-      return;
-    }
-
-    this.setText(super.getAdMessage(this.player, this.player.ads?.getActiveAd?.() as LinearAd));
+    this.setText(
+      this.getAdMessage(this.player, this.player.ads?.getActiveAd?.() as LinearAd, currentAdIndex, totalNumberOfAds),
+    );
   }
 
   private getAdCounterMessage(player: PlayerAPI, currentAdIndex?: number, totalNumberOfAds?: number): string {

--- a/src/ts/components/ads/AdMessageLabel.ts
+++ b/src/ts/components/ads/AdMessageLabel.ts
@@ -28,15 +28,15 @@ import { StringUtils } from '../../utils/StringUtils';
  *
  * @category Labels
  */
-export class AdMessageLabel extends Label<LabelConfig> {
-  constructor(config: LabelConfig = {}) {
+export class AdMessageLabel<Config extends LabelConfig = LabelConfig> extends Label<Config> {
+  constructor(config: Config = {} as Config) {
     super(config);
 
     this.config = this.mergeConfig(
       config,
       {
         cssClass: 'ui-ad-message-label',
-      },
+      } as Config,
       this.config,
     );
   }
@@ -44,16 +44,14 @@ export class AdMessageLabel extends Label<LabelConfig> {
   configure(player: PlayerAPI, uimanager: UIInstanceManager): void {
     super.configure(player, uimanager);
 
-    const config = this.getConfig();
-    let text = config.text || '';
+    let ad: LinearAd;
 
     const updateMessageHandler = () => {
-      this.setText(StringUtils.replaceAdMessagePlaceholders(i18n.performLocalization(text), player));
+      this.setText(this.getAdMessage(player, ad));
     };
 
     const adStartHandler = (event: AdEvent) => {
-      const uiConfig = (event.ad as LinearAd).uiConfig;
-      text = uiConfig?.message || config.text || '';
+      ad = event.ad as LinearAd;
 
       updateMessageHandler();
 
@@ -69,5 +67,10 @@ export class AdMessageLabel extends Label<LabelConfig> {
     player.on(player.exports.PlayerEvent.AdError, adEndHandler);
     player.on(player.exports.PlayerEvent.AdFinished, adEndHandler);
     player.on(player.exports.PlayerEvent.SourceUnloaded, adEndHandler);
+  }
+
+  protected getAdMessage(player: PlayerAPI, ad?: LinearAd): string {
+    const text = ad?.uiConfig?.message || this.config.text || '';
+    return StringUtils.replaceAdMessagePlaceholders(i18n.performLocalization(text), player);
   }
 }

--- a/src/ts/localization/i18n.ts
+++ b/src/ts/localization/i18n.ts
@@ -95,6 +95,7 @@ export interface Vocabulary {
   'ads.skip': string;
   'ads.skippableIn': string;
   'ads.adNumberOfTotal': string;
+  ad: string;
   pictureInPicture: string;
   appleAirplay: string;
   googleCast: string;

--- a/src/ts/localization/languages/de.json
+++ b/src/ts/localization/languages/de.json
@@ -48,6 +48,7 @@
   "ads.skip": "Überspringen",
   "ads.skippableIn": "Überspringen in {remainingTime}",
   "ads.adNumberOfTotal": "Anzeige {activeAdIndex} von {totalAdsCount}",
+  "ad": "Anzeige",
   "settings": "Einstellungen",
   "fullscreen": "Vollbild",
   "speed": "Geschwindigkeit",

--- a/src/ts/localization/languages/en.json
+++ b/src/ts/localization/languages/en.json
@@ -48,6 +48,7 @@
   "ads.skip": "Skip",
   "ads.skippableIn": "Skip ad in {remainingTime}",
   "ads.adNumberOfTotal": "Ad {activeAdIndex} of {totalAdsCount}",
+  "ad": "Ad",
   "settings": "Settings",
   "fullscreen": "Fullscreen",
   "speed": "Speed",

--- a/src/ts/localization/languages/es.json
+++ b/src/ts/localization/languages/es.json
@@ -48,6 +48,7 @@
   "ads.skip": "Saltar",
   "ads.skippableIn": "Saltar anuncio en {remainingTime}",
   "ads.adNumberOfTotal": "Anuncio {activeAdIndex} de {totalAdsCount}",
+  "ad": "Anuncio",
   "settings": "Configuración",
   "fullscreen": "Pantalla Completa",
   "speed": "Velocidad",

--- a/src/ts/localization/languages/fr.json
+++ b/src/ts/localization/languages/fr.json
@@ -48,6 +48,7 @@
   "ads.skip": "Passer",
   "ads.skippableIn": "Passer l'annonce dans {remainingTime}",
   "ads.adNumberOfTotal": "Annonce {activeAdIndex} sur {totalAdsCount}",
+  "ad": "Annonce",
   "settings": "Réglages",
   "fullscreen": "Plein écran",
   "speed": "Vitesse",

--- a/src/ts/localization/languages/nl.json
+++ b/src/ts/localization/languages/nl.json
@@ -48,6 +48,7 @@
   "ads.skip": "Overslaan",
   "ads.skippableIn": "Advertentie overslaan over {remainingTime}",
   "ads.adNumberOfTotal": "Advertentie {activeAdIndex} van {totalAdsCount}",
+  "ad": "Advertentie",
   "settings": "Instellingen",
   "fullscreen": "Volledig scherm",
   "speed": "Snelheid",

--- a/src/ts/localization/languages/pt.json
+++ b/src/ts/localization/languages/pt.json
@@ -48,6 +48,7 @@
   "ads.skip": "Ignorar",
   "ads.skippableIn": "Ignorar anúncio em {remainingTime}",
   "ads.adNumberOfTotal": "Anúncio {activeAdIndex} de {totalAdsCount}",
+  "ad": "Anúncio",
   "settings": "Definições",
   "fullscreen": "Ecrã inteiro",
   "speed": "Velocidade",


### PR DESCRIPTION
## Description

For AdBreaks with just 1 Ad the UI displays `Ad 1 of 1` which is unnecessary.

## Changes

`AdCounterLabel` now inherits the existing `AdMessageLabel` behavior. It displays the configured or ad-specific message for a single ad and falls back to that message when no valid current ad index is available. For ad pods with a valid index and total, it continues to display the localized `Ad x of y` counter.

### +1 Change

Use `AdCounterLabel` also in the small-screen ads UI when there are valid values so it can display the ad position once the required player APIs are available.

This keeps the current small-screen behavior usable on mobile SDK bridges that do not yet provide active-ad details while allowing counter support to activate automatically once those APIs are implemented.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
