### PR TITLE
Fix seek bar shrinking to zero width during live playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `AdCounterLabel` now displays its configured or ad-specific message for single-ad ad breaks and when no valid current ad index is available.
-- The seek bar no longer gets smaller on every time update during live playback until it disappears. This only affected pages that do not set a global `box-sizing: border-box`.
+- The seek bar no longer gets smaller on every time update during live playback. This only affected pages that do not set a global `box-sizing: border-box`.
 
 ## [4.18.0] - 2026-08-06
 
 ### Known Issues
 
-- On live streams the seek bar gets smaller on every time update until it disappears from the control bar. Only affects pages that do not set a global `box-sizing: border-box`. To work around it, add `.bmpui-ui-playbacktimelabel { box-sizing: border-box; }` to your page. Fixed in 4.19.0.
+- On live streams the seek bar gets smaller on every time update until it disappears from the control bar. Only affects pages that do not set a global `box-sizing: border-box`. To work around it, add `.bmpui-ui-playbacktimelabel { box-sizing: border-box; }` to your page. Fixed in `4.19.0`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `AdCounterLabel` now displays its configured or ad-specific message for single-ad ad breaks and when no valid current ad index is available.
+- The seek bar no longer gets smaller on every time update during live playback until it disappears. This only affected pages that do not set a global `box-sizing: border-box`.
 
 ## [4.18.0] - 2026-08-06
+
+### Known Issues
+
+- On live streams the seek bar gets smaller on every time update until it disappears from the control bar. Only affects pages that do not set a global `box-sizing: border-box`. To work around it, add `.bmpui-ui-playbacktimelabel { box-sizing: border-box; }` to your page. Fixed in 4.19.0.
 
 ### Added
 

--- a/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
+++ b/spec/components/labels/PlaybackTimeLabelStyles.spec.ts
@@ -34,4 +34,10 @@ describe('PlaybackTimeLabel styles', () => {
       getCssProperty('.bmpui-ui-button', 'padding'),
     );
   });
+
+  // Without this the label gets wider on every time update and pushes the seek bar out of the
+  // control bar. We set it ourselves so it does not depend on the page having a CSS reset.
+  it('sizes the playback time label as a border box', () => {
+    expect(getCssProperty('.bmpui-ui-playbacktimelabel', 'box-sizing')).toBe('border-box');
+  });
 });

--- a/src/scss/components/labels/_playback-time-label.scss
+++ b/src/scss/components/labels/_playback-time-label.scss
@@ -3,8 +3,7 @@
 .#{$prefix}-ui-playbacktimelabel {
   @extend %ui-label;
 
-  // The label sets its own min-width from its offsetWidth. offsetWidth counts padding and
-  // min-width does not, so without border-box the label gets wider on every time update.
+  // PlaybackTimeLabel writes offsetWidth back as min-width, so both must describe the same box.
   box-sizing: border-box;
   font-weight: $font-weight-medium;
   text-transform: uppercase;

--- a/src/scss/components/labels/_playback-time-label.scss
+++ b/src/scss/components/labels/_playback-time-label.scss
@@ -3,7 +3,8 @@
 .#{$prefix}-ui-playbacktimelabel {
   @extend %ui-label;
 
-  // PlaybackTimeLabel writes offsetWidth back as min-width, so both must describe the same box.
+  // PlaybackTimeLabel writes its border-box offsetWidth back as min-width. Keep min-width
+  // border-box too, or padding is added again and the measurement grows on every update.
   box-sizing: border-box;
   font-weight: $font-weight-medium;
   text-transform: uppercase;

--- a/src/scss/components/labels/_playback-time-label.scss
+++ b/src/scss/components/labels/_playback-time-label.scss
@@ -3,6 +3,9 @@
 .#{$prefix}-ui-playbacktimelabel {
   @extend %ui-label;
 
+  // The label sets its own min-width from its offsetWidth. offsetWidth counts padding and
+  // min-width does not, so without border-box the label gets wider on every time update.
+  box-sizing: border-box;
   font-weight: $font-weight-medium;
   text-transform: uppercase;
 

--- a/src/ts/components/labels/PlaybackTimeLabel.ts
+++ b/src/ts/components/labels/PlaybackTimeLabel.ts
@@ -155,6 +155,10 @@ export class PlaybackTimeLabel extends Label<PlaybackTimeLabelConfig> {
 
       // To avoid 'jumping' in the UI by varying label sizes due to non-monospaced fonts,
       // we gradually increase the min-width with the content to reach a stable size.
+      // This only settles while the box we measure matches the box min-width constrains, which is
+      // why the label is border-box (see _playback-time-label.scss). Under content-box, padding
+      // would be counted by offsetWidth but not by min-width, so the label would grow on every
+      // update instead.
       const width = this.getDomElement().width();
       if (width > minWidth) {
         minWidth = width;


### PR DESCRIPTION
## Description

Fixes a `4.18.0` regression: during live playback the seek bar loses width on every time update.

To stop the time label jumping around with non-monospaced fonts, `PlaybackTimeLabel` remembers the widest it has been and applies that as `min-width`. It measures with `offsetWidth`, which includes padding, but `min-width` under the default `content-box` excludes it.

With no padding the two matched. #921 added padding for the focus target, so each update now stores a value `12px` too large, the label grows, and the `SeekBar` next to it loses the same `12px`.

The issue is not reproducible on our demo page because it loads Bootstrap, which makes the label already `border-box`. Pages without one, including the iOS SDK WebView, are affected.

### Changes

This PR sets `box-sizing: border-box` on the label so both numbers describe the same box, instead of relying on the embedding page's reset.

### How to reproduce

As said, `index.html` cannot show this. It loads Bootstrap, whose `box-sizing: inherit` reset makes the label `border-box` and hides the bug. Use `simple.html`, which has no reset.

Point `src/html/simple.html` at a live source:

```js
var source = {
  hls: 'https://bitcdn-kronehit.bitmovin.com/v2/hls/playlist.m3u8',
};
```

Then `npm start` and open `simple.html`. Any live source works, a timeshift window is not needed. Watch the control bar for `~10` seconds.

- on `develop`: the seek bar shrinks on every time update
- on this branch: seek bar holds its size


## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
