### PR TITLE
Fix subtitle settings being overridden by cue-embedded styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Subtitle settings chosen via the subtitle settings panel are overridden by styling embedded in cues, such as inline styles in WebVTT and TTML
+
 ## [4.20.0] - 2026-08-13
 
 ### Added

--- a/spec/components/settings/subtitlesettings/SubtitleOverlaySettingsStyles.spec.ts
+++ b/spec/components/settings/subtitlesettings/SubtitleOverlaySettingsStyles.spec.ts
@@ -1,11 +1,28 @@
+import childProcess = require('child_process');
 import fs = require('fs');
 import path = require('path');
 
+const stylesPath = path.resolve(
+  process.cwd(),
+  'src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss',
+);
+
+/**
+ * Compiles the subtitle settings stylesheet and returns the generated CSS.
+ *
+ * Sass runs in a child process because its file system access is incompatible with the
+ * globals Jest installs in the test realm.
+ */
+function compileStyles(): string {
+  const sassCli = path.resolve(process.cwd(), 'node_modules/sass/sass.js');
+
+  return childProcess.execFileSync(process.execPath, [sassCli, '--no-source-map', stylesPath], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+
 describe('Subtitle overlay settings styles', () => {
-  const stylesPath = path.resolve(
-    process.cwd(),
-    'src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss',
-  );
   const styles = fs.readFileSync(stylesPath, 'utf8');
   const stylesWithoutWhitespace = styles.replace(/\s/g, '');
 
@@ -16,5 +33,82 @@ describe('Subtitle overlay settings styles', () => {
     expect(styles).toContain('.#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-region-container');
     expect(styles).toContain('.#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-cue-container');
     expect(styles).toContain('.#{$prefix}-ui-label-text');
+  });
+});
+
+describe('Subtitle overlay settings style precedence', () => {
+  const css = compileStyles();
+
+  /**
+   * Returns the declaration block of every rule whose selector contains the token.
+   */
+  function declarationsForSelector(token: string): string[] {
+    const rules = css.match(new RegExp(`[^{}]*${token}[^{}]*\\{[^}]*\\}`, 'g')) ?? [];
+
+    return rules.map(rule =>
+      rule
+        .slice(rule.indexOf('{') + 1, rule.lastIndexOf('}'))
+        .replace(/\s+/g, ' ')
+        .trim(),
+    );
+  }
+
+  it('marks the subtitle background important so it wins over a background set inside the cue', () => {
+    const declarations = declarationsForSelector('bmpui-bgcolor-black75');
+
+    expect(declarations.length).toBeGreaterThan(0);
+    expect(declarations.every(declaration => declaration.includes('!important'))).toBe(true);
+  });
+
+  it('clears a background set on cue descendants so it cannot cover the subtitle background', () => {
+    const cueDescendantRules = css.match(
+      /\.bmpui-bgcolor-black75[^{}]*\*\s*\{\s*background-color:\s*initial\s*!important;?\s*\}/g,
+    );
+
+    expect(cueDescendantRules).not.toBeNull();
+  });
+
+  /**
+   * Returns the declaration block of the rule that targets the label itself, as opposed to
+   * the one targeting its cue descendants.
+   */
+  function declarationsForLabel(settingClass: string): string {
+    const rule = css.match(new RegExp(`\\.${settingClass}[^{}]*\\.bmpui-ui-subtitle-label\\s*\\{([^}]*)\\}`));
+
+    return rule === null ? '' : rule[1].replace(/\s+/g, ' ').trim();
+  }
+
+  it('marks the font color important on the label', () => {
+    const declarations = declarationsForLabel('bmpui-fontcolor-white100');
+
+    expect(declarations).toContain('color: white !important');
+    expect(declarations).toContain('-webkit-text-fill-color: white !important');
+  });
+
+  // Every property a setting applies has to be inherited by nested cue elements, because
+  // the player renders cue-embedded styling as inline styles on those elements.
+  const inheritedProperties = [
+    { name: 'font color', settingClass: 'bmpui-fontcolor-white100', property: 'color' },
+    { name: 'font color fill', settingClass: 'bmpui-fontcolor-white100', property: '-webkit-text-fill-color' },
+    { name: 'italic font style', settingClass: 'bmpui-fontstyle-italic', property: 'font-style' },
+    { name: 'bold font style', settingClass: 'bmpui-fontstyle-bold', property: 'font-weight' },
+    { name: 'font family', settingClass: 'bmpui-fontfamily-monospacedserif', property: 'font-family' },
+    { name: 'small capital font family', settingClass: 'bmpui-fontfamily-smallcapital', property: 'font-variant' },
+    { name: 'character edge', settingClass: 'bmpui-characteredge-uniform-black', property: 'text-shadow' },
+    { name: 'font size', settingClass: 'bmpui-fontsize-150', property: 'font-size' },
+  ];
+
+  it.each(inheritedProperties)('makes cue descendants inherit the $name setting', ({ settingClass, property }) => {
+    const descendantRule = new RegExp(
+      `\\.${settingClass}[^{}]*\\.bmpui-ui-subtitle-label \\*\\s*\\{[^}]*${property}:\\s*inherit\\s*!important`,
+    );
+
+    expect(css).toMatch(descendantRule);
+  });
+
+  it('leaves the font size on the label unimportant so the CEA-608 grid size stays authoritative', () => {
+    const declarations = declarationsForLabel('bmpui-fontsize-150');
+
+    expect(declarations).toBe('font-size: 1.5em;');
   });
 });

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -198,3 +198,25 @@
 
   @return $string;
 }
+
+/// Makes descendants inherit the given properties. Declared `!important`, so it also
+/// overrides values set on them directly, including inline styles.
+/// @param {String...} $properties - The properties to inherit
+@mixin inherit-in-descendants($properties...) {
+  * {
+    @each $property in $properties {
+      #{$property}: inherit !important;
+    }
+  }
+}
+
+/// Resets the given properties on descendants to their initial value. Declared `!important`,
+/// so it also overrides values set on them directly, including inline styles.
+/// @param {String...} $properties - The properties to reset
+@mixin reset-in-descendants($properties...) {
+  * {
+    @each $property in $properties {
+      #{$property}: initial !important;
+    }
+  }
+}

--- a/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
+++ b/src/scss/components/settings/subtitlesettings/_subtitle-overlay-settings.scss
@@ -1,6 +1,16 @@
 @import '../../../variables';
 @import '../../../mixins';
 
+// Every rule below is keyed on a class that the overlay carries only while the corresponding
+// subtitle setting is explicitly set.
+//
+// The declarations are `!important` so an explicit user choice outranks the inline styles the
+// player derives from cue-embedded styling (WebVTT cue classes and `STYLE` blocks, TTML
+// inline styles). The player renders that cue content as elements inside the subtitle label,
+// so the styling sits on descendants and every setting has to reach them as well:
+// - inherited properties are made to inherit from the label
+// - non-inherited ones are cleared, because inheriting would repeat the label's value
+
 .#{$prefix}-ui-subtitle-overlay {
   $colors: (
     'white': #fff,
@@ -44,9 +54,11 @@
     @each $opacity-name, $opacity-value in $opacities {
       &.#{$prefix}-fontcolor-#{$color-name}#{$opacity-name} {
         .#{$prefix}-ui-subtitle-label {
-          color: transparentize($color-value, 1 - $opacity-value);
+          color: transparentize($color-value, 1 - $opacity-value) !important;
           // sass-lint:disable no-vendor-prefixes
-          -webkit-text-fill-color: transparentize($color-value, 1 - $opacity-value);
+          -webkit-text-fill-color: transparentize($color-value, 1 - $opacity-value) !important;
+
+          @include inherit-in-descendants(color, -webkit-text-fill-color);
         }
       }
     }
@@ -60,7 +72,9 @@
             .#{$prefix}-subtitle-vtt-cue-container
           ) {
           .#{$prefix}-ui-subtitle-label {
-            background-color: transparentize($color-value, 1 - $opacity-value);
+            background-color: transparentize($color-value, 1 - $opacity-value) !important;
+
+            @include reset-in-descendants(background-color);
           }
         }
 
@@ -68,7 +82,9 @@
         .#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-cue-container {
           .#{$prefix}-ui-subtitle-label {
             .#{$prefix}-ui-label-text {
-              background-color: transparentize($color-value, 1 - $opacity-value);
+              background-color: transparentize($color-value, 1 - $opacity-value) !important;
+
+              @include reset-in-descendants(background-color);
             }
           }
         }
@@ -80,24 +96,30 @@
   @each $color-name, $color-value in $colors {
     @each $opacity-name, $opacity-value in $opacities {
       &.#{$prefix}-windowcolor-#{$color-name}#{$opacity-name} {
+        // The window sits behind the subtitle, so a background set on the cue itself
+        // is left in place and keeps painting on top.
         .#{$prefix}-subtitle-region-container:not(.#{$prefix}-subtitle-vtt-cue-container) {
-          background-color: transparentize($color-value, 1 - $opacity-value);
+          background-color: transparentize($color-value, 1 - $opacity-value) !important;
         }
 
         .#{$prefix}-subtitle-region-container.#{$prefix}-subtitle-vtt-cue-container {
           .#{$prefix}-ui-subtitle-label.#{$prefix}-subtitle-vtt-cue {
-            background-color: transparentize($color-value, 1 - $opacity-value);
+            background-color: transparentize($color-value, 1 - $opacity-value) !important;
           }
         }
       }
     }
   }
 
-  // Font size
+  // Font size. Not `!important` on the label: CEA-608 rendering depends on the calculated px
+  // size it applies inline, which this must not override. Not needed for WebVTT and TTML
+  // either, whose cue styling sits on descendants and is overridden by the inherit below.
   @each $name, $value in $font-sizes {
     &.#{$prefix}-fontsize-#{$name} {
       .#{$prefix}-ui-subtitle-label {
         font-size: $value + em;
+
+        @include inherit-in-descendants(font-size);
       }
     }
   }
@@ -107,7 +129,9 @@
     @each $name, $value in $character-edges {
       &.#{$prefix}-characteredge-#{$name}-#{$color-name} {
         .#{$prefix}-ui-subtitle-label {
-          text-shadow: unquote(str-replace($value, '$COLOR$', $color-value));
+          text-shadow: unquote(str-replace($value, '$COLOR$', $color-value)) !important;
+
+          @include inherit-in-descendants(text-shadow);
         }
       }
     }
@@ -116,57 +140,75 @@
   // Font family
   &.#{$prefix}-fontfamily-monospacedserif {
     .#{$prefix}-ui-subtitle-label {
-      font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace;
+      font-family: 'Courier New', Courier, 'Nimbus Mono L', 'Cutive Mono', monospace !important;
+
+      @include inherit-in-descendants(font-family);
     }
   }
 
   &.#{$prefix}-fontfamily-proportionalserif {
     .#{$prefix}-ui-subtitle-label {
-      font-family: 'Times New Roman', Times, Georgia, Cambria, 'PT Serif Caption', serif;
+      font-family: 'Times New Roman', Times, Georgia, Cambria, 'PT Serif Caption', serif !important;
+
+      @include inherit-in-descendants(font-family);
     }
   }
 
   &.#{$prefix}-fontfamily-monospacedsansserif {
     .#{$prefix}-ui-subtitle-label {
-      font-family: 'Deja Vu Sans Mono', 'Lucida Console', Monaco, Consolas, 'PT Mono', monospace;
+      font-family: 'Deja Vu Sans Mono', 'Lucida Console', Monaco, Consolas, 'PT Mono', monospace !important;
+
+      @include inherit-in-descendants(font-family);
     }
   }
 
   &.#{$prefix}-fontfamily-proportionalsansserif {
     .#{$prefix}-ui-subtitle-label {
-      font-family: Roboto, 'Arial Unicode Ms', Arial, Helvetica, Verdana, 'PT Sans Caption', sans-serif;
+      font-family: Roboto, 'Arial Unicode Ms', Arial, Helvetica, Verdana, 'PT Sans Caption', sans-serif !important;
+
+      @include inherit-in-descendants(font-family);
     }
   }
 
   &.#{$prefix}-fontfamily-casual {
     .#{$prefix}-ui-subtitle-label {
-      font-family: 'Comic Sans MS', Impact, Handlee, fantasy;
+      font-family: 'Comic Sans MS', Impact, Handlee, fantasy !important;
+
+      @include inherit-in-descendants(font-family);
     }
   }
 
   &.#{$prefix}-fontfamily-cursive {
     .#{$prefix}-ui-subtitle-label {
-      font-family: 'Monotype Corsiva', 'URW Chancery L', 'Apple Chancery', 'Dancing Script', cursive;
-      font-style: italic;
+      font-family: 'Monotype Corsiva', 'URW Chancery L', 'Apple Chancery', 'Dancing Script', cursive !important;
+      font-style: italic !important;
+
+      @include inherit-in-descendants(font-family, font-style);
     }
   }
 
   &.#{$prefix}-fontfamily-smallcapital {
     .#{$prefix}-ui-subtitle-label {
-      font-variant: small-caps;
+      font-variant: small-caps !important;
+
+      @include inherit-in-descendants(font-variant);
     }
   }
 
   // Font Style
   &.#{$prefix}-fontstyle-italic {
     .#{$prefix}-ui-subtitle-label {
-      font-style: italic;
+      font-style: italic !important;
+
+      @include inherit-in-descendants(font-style);
     }
   }
 
   &.#{$prefix}-fontstyle-bold {
     .#{$prefix}-ui-subtitle-label {
-      font-weight: bold;
+      font-weight: bold !important;
+
+      @include inherit-in-descendants(font-weight);
     }
   }
 }


### PR DESCRIPTION
## Description

Subtitle styling settings chosen in the settings panel lost to styling embedded in the caption cues.

The player renders cue content as **elements inside** the subtitle label, and it resolves cue styling onto those elements as inline `style` attributes. For example, for the WebVTT

```
STYLE
::cue(.bg_black) { background-color: #000000; }
::cue(.white)    { color: #aaaaaa; }

25:24:50.208 --> 25:24:50.475 line:83% align:start position:22% size:100%
<c.white><c.bg_black>- The most memorable,</c></c>
```

`bitmovinplayer-subtitles-vtt` maps `<c…>` to `span`, turns the class list into `className`, and writes the resolved declarations via `setAttribute('style', …)`. Combined with `Label`'s own markup, the rendered label is:

```html
<span class="bmpui-ui-subtitle-label">          <!-- what the settings rules target -->
  <span class="bmpui-ui-label-text">
    <span class="white" style="color:#aaaaaa;">
      <span class="bg_black" style="background-color:#000000;">- The most memorable,</span>
    </span>
  </span>
</span>
```

Those inline styles sit on **different elements** from the one the settings rules target, so no amount of `!important` or specificity on `.bmpui-ui-subtitle-label` reaches them — the cascade resolves per element, and inheritance only fills in where a descendant has no declaration of its own.

## Changes

The settings rules are now `!important`, and each one also reaches those descendants:

- inherited properties (`color`, `font-family`, `font-style`, `font-weight`, `font-variant`, `text-shadow`) are made to inherit from the label
- `background-color`, which is not inherited, is cleared instead — inheriting it would have every nested element repaint the box, stacking alpha

## Checklist (for PR submitter and reviewers)

- [x] `CHANGELOG` entry
