### PR TITLE
Fix componentLayoutOverrides being ignored in minified builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `UIConfig.componentLayoutOverrides` and `UIConfig.componentConfigOverrides` are now applied in applications whose production build minifies the UI, instead of being silently ignored. Components are matched by their public export name instead of their runtime class name, which minifiers mangle by default.
+
 ## [4.20.0] - 2026-08-13
 
 ### Added

--- a/spec/utils/ComponentLayoutOverrideProcessor.spec.ts
+++ b/spec/utils/ComponentLayoutOverrideProcessor.spec.ts
@@ -83,6 +83,28 @@ describe('ComponentLayoutOverrideProcessor', () => {
     expect(playbackSpeedSelectBoxReleaseSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('applies overrides when a minifier mangled the runtime class names', () => {
+    const playbackToggleButton = new PlaybackToggleButton();
+    const fullscreenToggleButton = new FullscreenToggleButton();
+    const uiContainer = new Container<ContainerConfig>({
+      components: [playbackToggleButton, fullscreenToggleButton],
+    });
+    const originalNameDescriptor = Object.getOwnPropertyDescriptor(FullscreenToggleButton, 'name');
+    Object.defineProperty(FullscreenToggleButton, 'name', { value: 'r', configurable: true });
+
+    try {
+      new ComponentLayoutOverrideProcessor({
+        componentLayoutOverrides: {
+          FullscreenToggleButton: UIComponentLayoutOverride.Exclude,
+        },
+      }).process(uiContainer, UIVariantIdentifier.main);
+    } finally {
+      Object.defineProperty(FullscreenToggleButton, 'name', originalNameDescriptor);
+    }
+
+    expect(uiContainer.getComponents()).toEqual([playbackToggleButton]);
+  });
+
   it('recursively releases removed component subtrees', () => {
     const fullscreenToggleButton = new FullscreenToggleButton();
     const nestedContainer = new Container<ContainerConfig>({ components: [fullscreenToggleButton] });

--- a/spec/utils/ComponentLayoutOverrideProcessor.spec.ts
+++ b/spec/utils/ComponentLayoutOverrideProcessor.spec.ts
@@ -83,26 +83,34 @@ describe('ComponentLayoutOverrideProcessor', () => {
     expect(playbackSpeedSelectBoxReleaseSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('applies overrides when a minifier mangled the runtime class names', () => {
-    const playbackToggleButton = new PlaybackToggleButton();
-    const fullscreenToggleButton = new FullscreenToggleButton();
-    const uiContainer = new Container<ContainerConfig>({
-      components: [playbackToggleButton, fullscreenToggleButton],
+  it('applies overrides when a minifier mangled the runtime class names', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const { FullscreenToggleButton } = await import('../../src/ts/components/buttons/FullscreenToggleButton');
+      const { PlaybackToggleButton } = await import('../../src/ts/components/buttons/PlaybackToggleButton');
+      const { Container } = await import('../../src/ts/components/Container');
+      const { UIComponentLayoutOverride } = await import('../../src/ts/UIComponentLayoutOverrides');
+      const { UIVariantIdentifier } = await import('../../src/ts/UIManager');
+      const { ComponentLayoutOverrideProcessor } = await import('../../src/ts/utils/ComponentLayoutOverrideProcessor');
+      const playbackToggleButton = new PlaybackToggleButton();
+      const fullscreenToggleButton = new FullscreenToggleButton();
+      const uiContainer = new Container({
+        components: [playbackToggleButton, fullscreenToggleButton],
+      });
+      const originalNameDescriptor = Object.getOwnPropertyDescriptor(FullscreenToggleButton, 'name');
+      Object.defineProperty(FullscreenToggleButton, 'name', { value: 'r', configurable: true });
+
+      try {
+        new ComponentLayoutOverrideProcessor({
+          componentLayoutOverrides: {
+            FullscreenToggleButton: UIComponentLayoutOverride.Exclude,
+          },
+        }).process(uiContainer, UIVariantIdentifier.main);
+      } finally {
+        Object.defineProperty(FullscreenToggleButton, 'name', originalNameDescriptor);
+      }
+
+      expect(uiContainer.getComponents()).toEqual([playbackToggleButton]);
     });
-    const originalNameDescriptor = Object.getOwnPropertyDescriptor(FullscreenToggleButton, 'name');
-    Object.defineProperty(FullscreenToggleButton, 'name', { value: 'r', configurable: true });
-
-    try {
-      new ComponentLayoutOverrideProcessor({
-        componentLayoutOverrides: {
-          FullscreenToggleButton: UIComponentLayoutOverride.Exclude,
-        },
-      }).process(uiContainer, UIVariantIdentifier.main);
-    } finally {
-      Object.defineProperty(FullscreenToggleButton, 'name', originalNameDescriptor);
-    }
-
-    expect(uiContainer.getComponents()).toEqual([playbackToggleButton]);
   });
 
   it('recursively releases removed component subtrees', () => {

--- a/spec/utils/ConstructorUtils.spec.ts
+++ b/spec/utils/ConstructorUtils.spec.ts
@@ -14,20 +14,25 @@ describe('getConstructorNames', () => {
     expect(watermarkIndex).toBeGreaterThan(clickOverlayIndex);
   });
 
-  it('returns public class names when a minifier mangled the runtime class names', () => {
-    const restoreClassNames = mangleClassNames([Watermark, Component]);
+  it('returns public class names when a minifier mangled the runtime class names', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const { Component } = await import('../../src/ts/components/Component');
+      const { Watermark } = await import('../../src/ts/components/Watermark');
+      const { getConstructorNames } = await import('../../src/ts/utils/ConstructorUtils');
+      const restoreClassNames = mangleClassNames([Watermark, Component]);
 
-    try {
-      const constructorNames = getConstructorNames(Watermark);
+      try {
+        const constructorNames = getConstructorNames(Watermark);
 
-      expect(constructorNames).not.toContain('r');
-      expect(constructorNames).not.toContain('t');
-      expect(constructorNames).toContain('Component');
-      expect(constructorNames).toContain('ClickOverlay');
-      expect(constructorNames).toContain('Watermark');
-    } finally {
-      restoreClassNames();
-    }
+        expect(constructorNames).not.toContain('r');
+        expect(constructorNames).not.toContain('t');
+        expect(constructorNames).toContain('Component');
+        expect(constructorNames).toContain('ClickOverlay');
+        expect(constructorNames).toContain('Watermark');
+      } finally {
+        restoreClassNames();
+      }
+    });
   });
 
   it('falls back to the runtime class name for non-public classes', () => {
@@ -41,7 +46,7 @@ describe('getConstructorNames', () => {
 });
 
 /** Simulates minifier identifier mangling, which renames classes but leaves export names untouched. */
-function mangleClassNames(constructors: Function[]): () => void {
+function mangleClassNames(constructors: object[]): () => void {
   const mangledNames = ['r', 't', 'n', 'e', 'i'];
   const originalDescriptors = constructors.map(constructor => Object.getOwnPropertyDescriptor(constructor, 'name'));
 

--- a/spec/utils/ConstructorUtils.spec.ts
+++ b/spec/utils/ConstructorUtils.spec.ts
@@ -1,0 +1,57 @@
+import { Component } from '../../src/ts/components/Component';
+import { Watermark } from '../../src/ts/components/Watermark';
+import { getConstructorNames } from '../../src/ts/utils/ConstructorUtils';
+
+describe('getConstructorNames', () => {
+  it('returns the names of all classes in the prototype chain, base classes first', () => {
+    const constructorNames = getConstructorNames(Watermark);
+
+    const componentIndex = constructorNames.indexOf('Component');
+    const clickOverlayIndex = constructorNames.indexOf('ClickOverlay');
+    const watermarkIndex = constructorNames.indexOf('Watermark');
+    expect(componentIndex).toBeGreaterThanOrEqual(0);
+    expect(clickOverlayIndex).toBeGreaterThan(componentIndex);
+    expect(watermarkIndex).toBeGreaterThan(clickOverlayIndex);
+  });
+
+  it('returns public class names when a minifier mangled the runtime class names', () => {
+    const restoreClassNames = mangleClassNames([Watermark, Component]);
+
+    try {
+      const constructorNames = getConstructorNames(Watermark);
+
+      expect(constructorNames).not.toContain('r');
+      expect(constructorNames).not.toContain('t');
+      expect(constructorNames).toContain('Component');
+      expect(constructorNames).toContain('ClickOverlay');
+      expect(constructorNames).toContain('Watermark');
+    } finally {
+      restoreClassNames();
+    }
+  });
+
+  it('falls back to the runtime class name for non-public classes', () => {
+    class CustomWatermark extends Watermark {}
+
+    const constructorNames = getConstructorNames(CustomWatermark);
+
+    expect(constructorNames).toContain('Watermark');
+    expect(constructorNames[constructorNames.length - 1]).toEqual('CustomWatermark');
+  });
+});
+
+/** Simulates minifier identifier mangling, which renames classes but leaves export names untouched. */
+function mangleClassNames(constructors: Function[]): () => void {
+  const mangledNames = ['r', 't', 'n', 'e', 'i'];
+  const originalDescriptors = constructors.map(constructor => Object.getOwnPropertyDescriptor(constructor, 'name'));
+
+  constructors.forEach((constructor, index) => {
+    Object.defineProperty(constructor, 'name', { value: mangledNames[index], configurable: true });
+  });
+
+  return () => {
+    constructors.forEach((constructor, index) => {
+      Object.defineProperty(constructor, 'name', originalDescriptors[index]);
+    });
+  };
+}

--- a/src/ts/utils/ConstructorUtils.ts
+++ b/src/ts/utils/ConstructorUtils.ts
@@ -1,9 +1,40 @@
+let publicExportValues: unknown[];
+let publicExportNames: string[];
+
+// Lazy require to avoid circular deps — main.ts can't be statically imported while Component is initializing.
+
+function getPublicExportName(constructor: object): string | undefined {
+  if (publicExportValues == null) {
+    publicExportValues = [];
+    publicExportNames = [];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const publicExports = require('../main') as { [exportName: string]: unknown };
+    for (const exportName of Object.keys(publicExports)) {
+      const exportValue = publicExports[exportName];
+      if (typeof exportValue === 'function' && publicExportValues.indexOf(exportValue) === -1) {
+        publicExportValues.push(exportValue);
+        publicExportNames.push(exportName);
+      }
+    }
+  }
+
+  const exportIndex = publicExportValues.indexOf(constructor);
+  return exportIndex === -1 ? undefined : publicExportNames[exportIndex];
+}
+
+// Uses export names from main.ts instead of constructor.name so overrides work in minified builds.
 export function getConstructorNames(constructor: { prototype: object }): string[] {
   const constructorNames: string[] = [];
   let prototype = constructor.prototype;
 
-  while (prototype && prototype.constructor && prototype.constructor.name) {
-    constructorNames.unshift(prototype.constructor.name);
+  while (prototype && prototype.constructor) {
+    const constructorName = getPublicExportName(prototype.constructor) ?? prototype.constructor.name;
+
+    if (!constructorName) {
+      break;
+    }
+
+    constructorNames.unshift(constructorName);
     prototype = Object.getPrototypeOf(prototype);
   }
 

--- a/src/ts/utils/ConstructorUtils.ts
+++ b/src/ts/utils/ConstructorUtils.ts
@@ -1,25 +1,21 @@
-let publicExportValues: unknown[];
-let publicExportNames: string[];
+let publicExportNames: Map<object, string>;
 
 // Lazy require to avoid circular deps — main.ts can't be statically imported while Component is initializing.
 
 function getPublicExportName(constructor: object): string | undefined {
-  if (publicExportValues == null) {
-    publicExportValues = [];
-    publicExportNames = [];
+  if (publicExportNames == null) {
+    publicExportNames = new Map();
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const publicExports = require('../main') as { [exportName: string]: unknown };
     for (const exportName of Object.keys(publicExports)) {
       const exportValue = publicExports[exportName];
-      if (typeof exportValue === 'function' && publicExportValues.indexOf(exportValue) === -1) {
-        publicExportValues.push(exportValue);
-        publicExportNames.push(exportName);
+      if (typeof exportValue === 'function' && !publicExportNames.has(exportValue)) {
+        publicExportNames.set(exportValue, exportName);
       }
     }
   }
 
-  const exportIndex = publicExportValues.indexOf(constructor);
-  return exportIndex === -1 ? undefined : publicExportNames[exportIndex];
+  return publicExportNames.get(constructor);
 }
 
 // Uses export names from main.ts instead of constructor.name so overrides work in minified builds.


### PR DESCRIPTION
## Description
<!-- Add a short description about the changes -->

Fixes `UIConfig.componentLayoutOverrides` and `UIConfig.componentConfigOverrides` being ignored when UI constructor names are mangled by a downstream production build.

### When this happens

The published package exposes two relevant distribution paths:

- Applications that load the prebuilt `dist/js/bitmovinplayer-ui.js` UMD bundle directly are not affected. That bundle is minified by this repository with `keep_classnames: true`.
- Applications that install the UI through NPM normally consume `dist/js/framework/main.js`. These framework modules are compiled but not minified. A customer bundler such as Webpack can include them in the application production bundle and minify them again using customer-controlled settings. Those settings do not inherit this repository setting and can rename classes such as `FullscreenToggleButton` to `r`.

Both override APIs use `getConstructorNames()` to match public override keys against component constructors, so both are affected by this NPM consumer-build path.

For example, the following layout override is silently ignored when `Watermark.name` has been mangled:

```ts
componentLayoutOverrides: {
  Watermark: UIComponentLayoutOverride.Exclude,
}
```

### Root cause

`getConstructorNames()` previously used `constructor.name`. Runtime class names are implementation details that production minifiers can rename, while override keys such as `Watermark` and `FullscreenToggleButton` are stable public API names.

### Fix

Resolve public component names from the stable export names exposed by `main.ts`, using constructor identity to map each exported class to its public name. Runtime constructor names remain the fallback for non-public classes.

The regression tests mangle runtime class names and initialize the public-export lookup inside fresh Jest module registries, covering the same cold-cache order as a minified consumer bundle.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry