### PR TITLE
Fix seek bar and play button locking up after source unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `UIConfig.componentLayoutOverrides` and `UIConfig.componentConfigOverrides` are now applied in applications whose production build minifies the UI, instead of being silently ignored. Components are matched by their public export name instead of their runtime class name, which minifiers mangle by default.
 - `SeekBar` showing a stale playback position when a new source is loaded while a seek was still pending.
+- `PlaybackToggleButton` no longer responding to clicks when a new source is loaded after a play attempt that never reached playback, for example because the previous source stalled.
 
 ## [4.20.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `UIConfig.componentLayoutOverrides` and `UIConfig.componentConfigOverrides` are now applied in applications whose production build minifies the UI, instead of being silently ignored. Components are matched by their public export name instead of their runtime class name, which minifiers mangle by default.
+- `SeekBar` showing a stale playback position when a new source is loaded while a seek was still pending.
 
 ## [4.20.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `SeekBar` showing a stale playback position when a new source is loaded while a seek was still pending.
+- `PlaybackToggleButton` no longer responding to clicks when a new source is loaded after a play attempt that never reached playback, for example because the previous source stalled.
+
 ## [4.20.1] - 2026-08-27
 
 ### Fixed
 
 - `UIConfig.componentLayoutOverrides` and `UIConfig.componentConfigOverrides` are now applied in applications whose production build minifies the UI, instead of being silently ignored. Components are matched by their public export name instead of their runtime class name, which minifiers mangle by default.
-- `SeekBar` showing a stale playback position when a new source is loaded while a seek was still pending.
-- `PlaybackToggleButton` no longer responding to clicks when a new source is loaded after a play attempt that never reached playback, for example because the previous source stalled.
 
 ## [4.20.0] - 2026-08-13
 

--- a/spec/components/buttons/PlaybackToggleButton.spec.ts
+++ b/spec/components/buttons/PlaybackToggleButton.spec.ts
@@ -1,0 +1,42 @@
+import { MockHelper, TestingPlayerAPI } from '../../helper/MockHelper';
+import { UIInstanceManager } from '../../../src/ts/UIManager';
+import { PlaybackToggleButton } from '../../../src/ts/components/buttons/PlaybackToggleButton';
+
+let playerMock: TestingPlayerAPI;
+let uiInstanceManagerMock: UIInstanceManager;
+
+let playbackToggleButton: PlaybackToggleButton;
+
+describe('PlaybackToggleButton', () => {
+  beforeEach(() => {
+    playerMock = MockHelper.getPlayerMock();
+    uiInstanceManagerMock = MockHelper.getUiInstanceManagerMock();
+
+    playbackToggleButton = new PlaybackToggleButton();
+    playbackToggleButton.initialize();
+
+    // Setup DOM Mock
+    const mockDomElement = MockHelper.generateDOMMock();
+    jest.spyOn(playbackToggleButton, 'getDomElement').mockReturnValue(mockDomElement);
+
+    playbackToggleButton.configure(playerMock, uiInstanceManagerMock);
+  });
+
+  describe('playback that never started', () => {
+    it('starts playback of the next source instead of pausing it', () => {
+      // Playback is initiated but never reaches the Playing state, e.g. because the source stalls.
+      playerMock.eventEmitter.firePlayEvent();
+
+      playerMock.eventEmitter.fireSourceUnloadedEvent();
+      playerMock.eventEmitter.fireSourceLoadedEvent();
+
+      const playSpy = jest.spyOn(playerMock, 'play');
+      const pauseSpy = jest.spyOn(playerMock, 'pause');
+
+      playbackToggleButton['onClickEvent']();
+
+      expect(playSpy).toHaveBeenCalled();
+      expect(pauseSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/spec/components/seekbar/SeekBar.spec.ts
+++ b/spec/components/seekbar/SeekBar.spec.ts
@@ -141,6 +141,37 @@ describe('SeekBar', () => {
     });
   });
 
+  describe('pending seek when the source is unloaded', () => {
+    // The DOM is mocked, so the seeking state cannot be read back from the CSS class and is tracked here instead.
+    let isSeekingState: boolean;
+
+    beforeEach(() => {
+      isSeekingState = false;
+      jest.spyOn(seekbar, 'setSeeking').mockImplementation(seeking => {
+        isSeekingState = seeking;
+      });
+      jest.spyOn(seekbar, 'isSeeking').mockImplementation(() => isSeekingState);
+
+      jest.spyOn(playerMock, 'getDuration').mockReturnValue(20);
+      seekbar.configure(playerMock, uiInstanceManagerMock);
+    });
+
+    it('leaves the seeking state so playback positions of the next source are applied again', () => {
+      playerMock.eventEmitter.fireSeekEvent();
+      expect(isSeekingState).toBe(true);
+
+      // The seek never finishes, so no Seeked event is fired before the source goes away.
+      playerMock.eventEmitter.fireSourceUnloadedEvent();
+      expect(isSeekingState).toBe(false);
+
+      const setPlaybackPositionSpy = jest.spyOn(seekbar, 'setPlaybackPosition');
+      playerMock.eventEmitter.fireSourceLoadedEvent();
+      playerMock.eventEmitter.fireStallEndedEvent();
+
+      expect(setPlaybackPositionSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('group playback', () => {
     beforeEach(() => {
       jest.spyOn(playerMock, 'getDuration').mockReturnValue(0);

--- a/spec/helper/MockHelper.ts
+++ b/spec/helper/MockHelper.ts
@@ -152,6 +152,8 @@ export namespace MockHelper {
         unmute: jest.fn(),
         setVolume: jest.fn(),
         setAudio: jest.fn(),
+        play: jest.fn(),
+        pause: jest.fn(),
 
         // Event faker
         eventEmitter: eventHelper,

--- a/src/ts/components/buttons/PlaybackToggleButton.ts
+++ b/src/ts/components/buttons/PlaybackToggleButton.ts
@@ -87,7 +87,10 @@ export class PlaybackToggleButton extends ToggleButton<PlaybackToggleButtonConfi
     // after unloading + loading a new source, the player might be in a different playing state (from playing into stopped)
     player.on(player.exports.PlayerEvent.SourceLoaded, playbackStateHandler);
     uimanager.getConfig().events.onUpdated.subscribe(playbackStateHandler);
-    player.on(player.exports.PlayerEvent.SourceUnloaded, playbackStateHandler);
+    player.on(player.exports.PlayerEvent.SourceUnloaded, () => {
+      this.isPlayInitiated = false;
+      playbackStateHandler();
+    });
     // when playback finishes, player turns to paused mode
     player.on(player.exports.PlayerEvent.PlaybackFinished, playbackStateHandler);
     player.on(player.exports.PlayerEvent.CastStarted, playbackStateHandler);

--- a/src/ts/components/seekbar/SeekBar.ts
+++ b/src/ts/components/seekbar/SeekBar.ts
@@ -411,6 +411,8 @@ export class SeekBar extends Component<SeekBarConfig> {
     player.on(player.exports.PlayerEvent.Seeked, onPlayerSeeked);
     player.on(player.exports.PlayerEvent.TimeShift, onPlayerSeek);
     player.on(player.exports.PlayerEvent.TimeShifted, onPlayerSeeked);
+    // Clean up in-flight seek during unload
+    player.on(player.exports.PlayerEvent.SourceUnloaded, onPlayerSeeked);
 
     const isGroupPlaybackAPIAvailable = (player: PlayerAPI): player is ExtendedPlayerAPI => {
       return !!(player as ExtendedPlayerAPI).groupPlayback;


### PR DESCRIPTION
## Description
Two UI states that never get released when a source is unloaded, both reachable by loading a new source while the previous one was stalled.

- `SeekBar`: a seek that is still in flight when the source is unloaded never emits a `Seeked` event, so the seek bar stayed in its seeking state and skipped every playback position update of the following source — it stayed frozen at the old source's position. The seek state now ends on `SourceUnloaded`.
- `PlaybackToggleButton`: a play attempt that never reaches playback is followed by neither a `Playing` nor a `Paused` event, so `isPlayInitiated` stayed set. The button then showed the playing state for the next source and every click issued a pause call on an already paused player, which looked like a dead button. The flag is now reset on `SourceUnloaded`.

Both were verified in the browser against a local reproduction page: without the changes the seek bar freezes while playback continues and the play button stops responding; with them the seek bar tracks playback again and the button starts, pauses and resumes the new source. Normal seeking and play/pause behaviour is unchanged. No new player or platform APIs are used, so no mobile SDK-specific verification was needed.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)