### PR TITLE
Fix duplicate ad break tracking across deserialized objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Ad counts no longer increase incorrectly when player adapters provide freshly deserialized instances of the same ad break.
+
 ## [4.20.2] - 2026-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Ad counts no longer increase incorrectly when player adapters provide freshly deserialized instances of the same ad break.
+- Ad count in `AdCounterLabel` no longer increases incorrectly when used on mobile SDKs.
 
 ## [4.20.2] - 2026-09-03
 

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -330,6 +330,24 @@ describe('AdBreakTracker', () => {
       expect(tracker.totalNumberOfAds).toBe(4);
     });
 
+    it('deduplicates freshly deserialized instances of the same ad break by ID', () => {
+      const break2 = makeBreak('break-2', 5, [{ id: 'a3' }]);
+
+      adsState.activeAdBreak = makeBreak('break-1', 5, [{ id: 'a1' }, { id: 'a2' }]);
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      // A player adapter may deserialize the same ad break again for the next AdStarted event.
+      adsState.activeAdBreak = makeBreak('break-1', 5, [{ id: 'a1' }, { id: 'a2' }]);
+      adsState.activeAd = { id: 'a2' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(2);
+      expect(tracker.totalNumberOfAds).toBe(3);
+    });
+
     it('dispatches onAdCountChanged with currentAdIndex and totalNumberOfAds after AdStarted', () => {
       const break1 = makeBreak('break-1', 5, [{ id: 'a1' }]);
       const break2 = makeBreak('break-2', 5, [{ id: 'a2' }]);

--- a/spec/utils/AdBreakTracker.spec.ts
+++ b/spec/utils/AdBreakTracker.spec.ts
@@ -2,7 +2,7 @@ import { AdBreak, PlayerEvent } from 'bitmovin-player';
 import { PlayerEventEmitter } from '../helper/PlayerEventEmitter';
 import { AdBreakTracker } from '../../src/ts/utils/AdBreakTracker';
 
-const makeBreak = (id: string, scheduleTime: number, ads: { id: string }[] = []): AdBreak =>
+const makeBreak = (id: string | undefined, scheduleTime: number, ads: { id: string }[] = []): AdBreak =>
   ({ id, scheduleTime, ads }) as unknown as AdBreak;
 
 // Mutable ad state the player mock delegates to.
@@ -346,6 +346,24 @@ describe('AdBreakTracker', () => {
 
       expect(tracker.currentAdIndex).toBe(2);
       expect(tracker.totalNumberOfAds).toBe(3);
+    });
+
+    it('keeps distinct ad breaks when their IDs are missing', () => {
+      const break1 = makeBreak(undefined, 5, [{ id: 'a1' }]);
+      const break2 = makeBreak(undefined, 5, [{ id: 'a2' }]);
+
+      adsState.activeAdBreak = break1;
+      adsState.activeAd = { id: 'a1' };
+      adsState.list = [break2];
+      eventEmitter.fireAdStartedEvent();
+
+      adsState.activeAdBreak = break2;
+      adsState.activeAd = { id: 'a2' };
+      adsState.list = [];
+      eventEmitter.fireAdStartedEvent();
+
+      expect(tracker.currentAdIndex).toBe(2);
+      expect(tracker.totalNumberOfAds).toBe(2);
     });
 
     it('dispatches onAdCountChanged with currentAdIndex and totalNumberOfAds after AdStarted', () => {

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -129,8 +129,9 @@ export class AdBreakTracker {
 
       this.groupScheduleTime = activeBreak.scheduleTime;
 
-      // Add the active break if it's not already retained (new break in the group)
-      if (!this.groupBreaks.includes(activeBreak)) {
+      // Player adapters may deserialize a new object for the same break on every event,
+      // so use the stable break ID instead of object identity for deduplication.
+      if (!this.groupBreaks.some(adBreak => adBreak.id === activeBreak.id)) {
         this.groupBreaks.push(activeBreak);
       }
     } else {

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -129,7 +129,7 @@ export class AdBreakTracker {
 
       this.groupScheduleTime = activeBreak.scheduleTime;
 
-      // Player adapters may deserialize a new object for the same break on every event,
+      // On mobile, the Player may deserialize a new object for the same break on every event,
       // so use the stable break ID instead of object identity for deduplication.
       const activeBreakAlreadyRetained = this.groupBreaks.some(adBreak =>
         activeBreak.id != null && adBreak.id != null ? adBreak.id === activeBreak.id : adBreak === activeBreak,

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -131,10 +131,10 @@ export class AdBreakTracker {
 
       // On mobile, the Player may deserialize a new object for the same break on every event,
       // so use the stable break ID instead of object identity for deduplication.
-      const activeBreakAlreadyRetained = this.groupBreaks.some(adBreak =>
+      const containsAdBreak = this.groupBreaks.some(adBreak =>
         activeBreak.id != null && adBreak.id != null ? adBreak.id === activeBreak.id : adBreak === activeBreak,
       );
-      if (!activeBreakAlreadyRetained) {
+      if (!containsAdBreak) {
         this.groupBreaks.push(activeBreak);
       }
     } else {

--- a/src/ts/utils/AdBreakTracker.ts
+++ b/src/ts/utils/AdBreakTracker.ts
@@ -131,7 +131,10 @@ export class AdBreakTracker {
 
       // Player adapters may deserialize a new object for the same break on every event,
       // so use the stable break ID instead of object identity for deduplication.
-      if (!this.groupBreaks.some(adBreak => adBreak.id === activeBreak.id)) {
+      const activeBreakAlreadyRetained = this.groupBreaks.some(adBreak =>
+        activeBreak.id != null && adBreak.id != null ? adBreak.id === activeBreak.id : adBreak === activeBreak,
+      );
+      if (!activeBreakAlreadyRetained) {
         this.groupBreaks.push(activeBreak);
       }
     } else {


### PR DESCRIPTION
## Description

Deduplicate retained ad breaks by their stable ID so adapters that provide freshly deserialized objects do not inflate the displayed ad count. Includes regression coverage for repeated `AdStarted` events with distinct objects representing the same break.

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
