### PR TITLE
Fix settings panel overflow with long option names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Long option names causing settings panels to overflow or setting labels to become unreadable.
 - Ad count in `AdCounterLabel` no longer increases incorrectly when used on mobile SDKs.
 
 ## [4.20.2] - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The selected subtitle track label no longer includes the number of available tracks.
+
 ### Fixed
 
 - Long option names causing settings panels to overflow or setting labels to become unreadable.

--- a/src/scss/components/settings/_settings-panel-item.scss
+++ b/src/scss/components/settings/_settings-panel-item.scss
@@ -36,14 +36,34 @@
   }
 
   .#{$prefix}-ui-label {
+    flex-shrink: 0;
     line-height: $icon-size;
+    max-width: 100%;
     min-height: $icon-size;
+    min-width: 0;
+
+    .#{$prefix}-ui-icon {
+      flex: 0 0 auto;
+      width: $icon-size;
+    }
+
+    .#{$prefix}-ui-label-text {
+      overflow-wrap: anywhere;
+      white-space: normal;
+    }
   }
 
   .#{$prefix}-ui-label-setting-selected-option {
     align-self: center;
+    flex-shrink: 1;
     margin-left: auto;
     width: fit-content;
+
+    .#{$prefix}-ui-label-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 
     .#{$prefix}-ui-icon {
       background-image: svg-load('../../assets/images/angle-right.svg', stroke=$color-icon);

--- a/src/scss/components/settings/_settings-panel.scss
+++ b/src/scss/components/settings/_settings-panel.scss
@@ -27,13 +27,14 @@
   box-shadow: 0 0 3px 0 transparentize($color: #000, $amount: 0.75);
   height: fit-content;
   max-height: 60%;
-  min-width: fit-content;
+  max-width: calc(100% - 1em - max(1em, env(safe-area-inset-right, 0)));
+  min-width: 40%;
   overflow: hidden;
   overflow-y: auto;
   padding: 0;
   position: absolute;
   right: max(1em, env(safe-area-inset-right, 0));
-  width: 40%;
+  width: fit-content;
 
   > .#{$prefix}-container-wrapper {
     overflow-y: auto;

--- a/src/ts/components/settings/DynamicSettingsPanelItem.ts
+++ b/src/ts/components/settings/DynamicSettingsPanelItem.ts
@@ -1,9 +1,8 @@
 import { Label, LabelConfig, LabelStyle } from '../labels/Label';
 import { UIInstanceManager } from '../../UIManager';
 import { PlayerAPI } from 'bitmovin-player';
-import { i18n, LocalizableText } from '../../localization/i18n';
+import { LocalizableText } from '../../localization/i18n';
 import { ListSelector, ListSelectorConfig } from '../lists/ListSelector';
-import { SubtitleSelectBox } from './SubtitleSelectBox';
 import { SettingsPanelItem, SettingsPanelItemConfig } from './SettingsPanelItem';
 import { SettingsPanelSelectOption } from './SettingsPanelSelectOption';
 import { SettingsPanelPage } from './SettingsPanelPage';
@@ -110,13 +109,7 @@ export class DynamicSettingsPanelItem extends InteractiveSettingsPanelItem<Dynam
       return;
     }
 
-    let selectedOptionLabelText = selectedItem.label;
-    if (this.settingComponent instanceof SubtitleSelectBox) {
-      const availableSettings = this.settingComponent.getItems().length;
-      selectedOptionLabelText =
-        i18n.performLocalization(selectedOptionLabelText) + ' (' + (availableSettings - 1) + ')';
-    }
-    this.selectedOptionLabel.setText(selectedOptionLabelText);
+    this.selectedOptionLabel.setText(selectedItem.label);
   };
 
   private buildSubPanelPage(): SettingsPanelPage {


### PR DESCRIPTION
## Description
Fix settings panels overflowing the player or making setting labels unreadable when option names are long. Keep setting labels visible, truncate selected values, and wrap full names in the options list. 

Also remove the available subtitle count from the selected track label.

## Validation
TypeScript and Sass lint, TypeScript checks, and development build passed. 
Manual testing of the layout fix worked well

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/88a53d85-6e56-4944-89e3-61b7cbc39b3b) | ![After](https://github.com/user-attachments/assets/80301132-3b65-45b3-89bf-7433014d4e9f) |

## Checklist (for PR submitter and reviewers)
<!-- A PR with CHANGELOG entry will be released automatically -->
<!-- This is required and should be added in every case -->
- [x] `CHANGELOG` entry
